### PR TITLE
feat: remove dev-tools drawer from test page

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -14,7 +14,6 @@
       },
       "devDependencies": {
         "@blockly/dev-scripts": "^4.0.1",
-        "@blockly/dev-tools": "^8.0.2",
         "@blockly/field-colour": "^5.0.4",
         "@eslint/eslintrc": "^2.1.2",
         "@eslint/js": "^8.49.0",
@@ -308,19 +307,6 @@
         "node": ">=6.9.0"
       }
     },
-    "node_modules/@blockly/block-test": {
-      "version": "6.0.2",
-      "resolved": "https://registry.npmjs.org/@blockly/block-test/-/block-test-6.0.2.tgz",
-      "integrity": "sha512-kPihb4duEkXnJz+oVHwaDvwav+I8WSaaUCCd/Q3JUlJ3UFp0ert1kHBw4/C7LMrjmQOJPcSbbA5YyQ+9GNHwIw==",
-      "dev": true,
-      "license": "Apache 2.0",
-      "engines": {
-        "node": ">=8.17.0"
-      },
-      "peerDependencies": {
-        "blockly": "^11.0.0"
-      }
-    },
     "node_modules/@blockly/dev-scripts": {
       "version": "4.0.1",
       "resolved": "https://registry.npmjs.org/@blockly/dev-scripts/-/dev-scripts-4.0.1.tgz",
@@ -590,32 +576,6 @@
       "dev": true,
       "license": "MIT"
     },
-    "node_modules/@blockly/dev-tools": {
-      "version": "8.0.2",
-      "resolved": "https://registry.npmjs.org/@blockly/dev-tools/-/dev-tools-8.0.2.tgz",
-      "integrity": "sha512-eBSkdAEHy2P5Y52EnglLHT1gqXCBEklo1MMyfKak781OTMazDfFyZzIu+uwDMCbkEoCkgIvvi0WwCZ6s8G9vNQ==",
-      "dev": true,
-      "license": "Apache-2.0",
-      "dependencies": {
-        "@blockly/block-test": "^6.0.2",
-        "@blockly/theme-dark": "^7.0.1",
-        "@blockly/theme-deuteranopia": "^6.0.1",
-        "@blockly/theme-highcontrast": "^6.0.1",
-        "@blockly/theme-tritanopia": "^6.0.1",
-        "chai": "^4.2.0",
-        "dat.gui": "^0.7.7",
-        "lodash.assign": "^4.2.0",
-        "lodash.merge": "^4.6.2",
-        "monaco-editor": "^0.20.0",
-        "sinon": "^9.0.2"
-      },
-      "engines": {
-        "node": ">=8.0.0"
-      },
-      "peerDependencies": {
-        "blockly": "^11.0.0"
-      }
-    },
     "node_modules/@blockly/eslint-config": {
       "version": "4.0.1",
       "resolved": "https://registry.npmjs.org/@blockly/eslint-config/-/eslint-config-4.0.1.tgz",
@@ -848,58 +808,6 @@
       "version": "0.6.2",
       "resolved": "https://registry.npmjs.org/@blockly/keyboard-navigation/-/keyboard-navigation-0.6.2.tgz",
       "integrity": "sha512-02tFidBe9H9J5nQm+sLRmr/RqXpHZRI7ypItskbxsqsDowc2rfEp7mJJt9uh95ph4k11rB1+rgjD0vDM3kd/XQ==",
-      "license": "Apache-2.0",
-      "engines": {
-        "node": ">=8.17.0"
-      },
-      "peerDependencies": {
-        "blockly": "^11.0.0"
-      }
-    },
-    "node_modules/@blockly/theme-dark": {
-      "version": "7.0.1",
-      "resolved": "https://registry.npmjs.org/@blockly/theme-dark/-/theme-dark-7.0.1.tgz",
-      "integrity": "sha512-yJZmdV/8ZZQ/NvL1QncTwuxDay/XwyCPr8qYHpfqYii2zOBCtSTxpK5KaF/RHHVwBti0j2c8qEp/AdJ1J3nuSg==",
-      "dev": true,
-      "license": "Apache-2.0",
-      "engines": {
-        "node": ">=8.17.0"
-      },
-      "peerDependencies": {
-        "blockly": "^11.0.0"
-      }
-    },
-    "node_modules/@blockly/theme-deuteranopia": {
-      "version": "6.0.1",
-      "resolved": "https://registry.npmjs.org/@blockly/theme-deuteranopia/-/theme-deuteranopia-6.0.1.tgz",
-      "integrity": "sha512-7m0377jHlVjAPBAckLKM1diW0W2MrFak6P2p/ahgjsKwkdV+RZJxJQxDVOoZCnc4ax+qGmhvF6rs5AHOmplpGA==",
-      "dev": true,
-      "license": "Apache-2.0",
-      "engines": {
-        "node": ">=8.17.0"
-      },
-      "peerDependencies": {
-        "blockly": "^11.0.0"
-      }
-    },
-    "node_modules/@blockly/theme-highcontrast": {
-      "version": "6.0.1",
-      "resolved": "https://registry.npmjs.org/@blockly/theme-highcontrast/-/theme-highcontrast-6.0.1.tgz",
-      "integrity": "sha512-9kycvIHU1Osa+2VfMb9gZuSXwaesq8Np/Yy/KSumGvDfctU885T3cgKeAzu51eKPvHnBCqRj1N5Ud86ACNO5hQ==",
-      "dev": true,
-      "license": "Apache-2.0",
-      "engines": {
-        "node": ">=8.17.0"
-      },
-      "peerDependencies": {
-        "blockly": "^11.0.0"
-      }
-    },
-    "node_modules/@blockly/theme-tritanopia": {
-      "version": "6.0.1",
-      "resolved": "https://registry.npmjs.org/@blockly/theme-tritanopia/-/theme-tritanopia-6.0.1.tgz",
-      "integrity": "sha512-zAerfaiM/OqGXb194fqLGXwSMTKkUkN7PldA/qxsvfE8wVH3r2XRcOgiVIoAZsZthCXnHAq2w5FpBvJasMS9Cw==",
-      "dev": true,
       "license": "Apache-2.0",
       "engines": {
         "node": ">=8.17.0"
@@ -1177,45 +1085,6 @@
       "engines": {
         "node": ">= 8"
       }
-    },
-    "node_modules/@sinonjs/commons": {
-      "version": "1.8.6",
-      "resolved": "https://registry.npmjs.org/@sinonjs/commons/-/commons-1.8.6.tgz",
-      "integrity": "sha512-Ky+XkAkqPZSm3NLBeUng77EBQl3cmeJhITaGHdYH8kjVB+aun3S4XBRti2zt17mtt0mIUDiNxYeoJm6drVvBJQ==",
-      "dev": true,
-      "license": "BSD-3-Clause",
-      "dependencies": {
-        "type-detect": "4.0.8"
-      }
-    },
-    "node_modules/@sinonjs/fake-timers": {
-      "version": "6.0.1",
-      "resolved": "https://registry.npmjs.org/@sinonjs/fake-timers/-/fake-timers-6.0.1.tgz",
-      "integrity": "sha512-MZPUxrmFubI36XS1DI3qmI0YdN1gks62JtFZvxR67ljjSNCeK6U08Zx4msEWOXuofgqUt6zPHSi1H9fbjR/NRA==",
-      "dev": true,
-      "license": "BSD-3-Clause",
-      "dependencies": {
-        "@sinonjs/commons": "^1.7.0"
-      }
-    },
-    "node_modules/@sinonjs/samsam": {
-      "version": "5.3.1",
-      "resolved": "https://registry.npmjs.org/@sinonjs/samsam/-/samsam-5.3.1.tgz",
-      "integrity": "sha512-1Hc0b1TtyfBu8ixF/tpfSHTVWKwCBLY4QJbkgnE7HcwyvT2xArDxb4K7dMgqRm3szI+LJbzmW/s4xxEhv6hwDg==",
-      "dev": true,
-      "license": "BSD-3-Clause",
-      "dependencies": {
-        "@sinonjs/commons": "^1.6.0",
-        "lodash.get": "^4.4.2",
-        "type-detect": "^4.0.8"
-      }
-    },
-    "node_modules/@sinonjs/text-encoding": {
-      "version": "0.7.2",
-      "resolved": "https://registry.npmjs.org/@sinonjs/text-encoding/-/text-encoding-0.7.2.tgz",
-      "integrity": "sha512-sXXKG+uL9IrKqViTtao2Ws6dy0znu9sOaP1di/jKGW1M6VssO8vlpXCQcpZ+jisQ1tTFAC5Jo/EOzFbggBagFQ==",
-      "dev": true,
-      "license": "(Unlicense OR Apache-2.0)"
     },
     "node_modules/@types/body-parser": {
       "version": "1.19.5",
@@ -2130,16 +1999,6 @@
         "node": ">=8"
       }
     },
-    "node_modules/assertion-error": {
-      "version": "1.1.0",
-      "resolved": "https://registry.npmjs.org/assertion-error/-/assertion-error-1.1.0.tgz",
-      "integrity": "sha512-jgsaNduz+ndvGyFt3uSuWqvy4lCnIJiovtouQN5JZHOKCS2QuhEdbcQHFhVksz2N2U9hXJo8odG7ETyWlEeuDw==",
-      "dev": true,
-      "license": "MIT",
-      "engines": {
-        "node": "*"
-      }
-    },
     "node_modules/astral-regex": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/astral-regex/-/astral-regex-2.0.0.tgz",
@@ -2496,25 +2355,6 @@
       ],
       "license": "CC-BY-4.0"
     },
-    "node_modules/chai": {
-      "version": "4.4.1",
-      "resolved": "https://registry.npmjs.org/chai/-/chai-4.4.1.tgz",
-      "integrity": "sha512-13sOfMv2+DWduEU+/xbun3LScLoqN17nBeTLUsmDfKdoiC1fr0n9PU4guu4AhRcOVFk/sW8LyZWHuhWtQZiF+g==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "assertion-error": "^1.1.0",
-        "check-error": "^1.0.3",
-        "deep-eql": "^4.1.3",
-        "get-func-name": "^2.0.2",
-        "loupe": "^2.3.6",
-        "pathval": "^1.1.1",
-        "type-detect": "^4.0.8"
-      },
-      "engines": {
-        "node": ">=4"
-      }
-    },
     "node_modules/chalk": {
       "version": "4.1.2",
       "resolved": "https://registry.npmjs.org/chalk/-/chalk-4.1.2.tgz",
@@ -2530,19 +2370,6 @@
       },
       "funding": {
         "url": "https://github.com/chalk/chalk?sponsor=1"
-      }
-    },
-    "node_modules/check-error": {
-      "version": "1.0.3",
-      "resolved": "https://registry.npmjs.org/check-error/-/check-error-1.0.3.tgz",
-      "integrity": "sha512-iKEoDYaRmd1mxM90a2OEfWhjsjPpYPuQ+lMYsoxB126+t8fw7ySEO48nmDg5COTjxDI65/Y2OWpeEHk3ZOe8zg==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "get-func-name": "^2.0.2"
-      },
-      "engines": {
-        "node": "*"
       }
     },
     "node_modules/chokidar": {
@@ -2870,13 +2697,6 @@
         "node": ">=14"
       }
     },
-    "node_modules/dat.gui": {
-      "version": "0.7.9",
-      "resolved": "https://registry.npmjs.org/dat.gui/-/dat.gui-0.7.9.tgz",
-      "integrity": "sha512-sCNc1OHobc+Erc1HqiswYgHdVNpSJUlk/Hz8vzOCsER7rl+oF/4+v8GXFUyCgtXpoCX6+bnmg07DedLvBLwYKQ==",
-      "dev": true,
-      "license": "Apache-2.0"
-    },
     "node_modules/data-urls": {
       "version": "5.0.0",
       "resolved": "https://registry.npmjs.org/data-urls/-/data-urls-5.0.0.tgz",
@@ -2925,19 +2745,6 @@
       "resolved": "https://registry.npmjs.org/decimal.js/-/decimal.js-10.4.3.tgz",
       "integrity": "sha512-VBBaLc1MgL5XpzgIP7ny5Z6Nx3UrRkIViUkPUdtl9aya5amy3De1gsUUSB1g3+3sExYNjCAsAznmukyxCb1GRA==",
       "license": "MIT"
-    },
-    "node_modules/deep-eql": {
-      "version": "4.1.4",
-      "resolved": "https://registry.npmjs.org/deep-eql/-/deep-eql-4.1.4.tgz",
-      "integrity": "sha512-SUwdGfqdKOwxCPeVYjwSyRpJ7Z+fhpwIAtmCUdZIWZ/YP5R9WAsyuSgpLVDi9bjWoN2LXHNss/dk3urXtdQxGg==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "type-detect": "^4.0.0"
-      },
-      "engines": {
-        "node": ">=6"
-      }
     },
     "node_modules/deep-is": {
       "version": "0.1.4",
@@ -4214,16 +4021,6 @@
         "node": "6.* || 8.* || >= 10.*"
       }
     },
-    "node_modules/get-func-name": {
-      "version": "2.0.2",
-      "resolved": "https://registry.npmjs.org/get-func-name/-/get-func-name-2.0.2.tgz",
-      "integrity": "sha512-8vXOvuE167CtIc3OyItco7N/dpRtBbYOsPsXCz7X/PMnlGjYjSGuZJgM1Y7mmew7BKf9BqvLX2tnOVy1BBUsxQ==",
-      "dev": true,
-      "license": "MIT",
-      "engines": {
-        "node": "*"
-      }
-    },
     "node_modules/get-intrinsic": {
       "version": "1.2.4",
       "resolved": "https://registry.npmjs.org/get-intrinsic/-/get-intrinsic-1.2.4.tgz",
@@ -5030,13 +4827,6 @@
         "node": ">=8"
       }
     },
-    "node_modules/isarray": {
-      "version": "0.0.1",
-      "resolved": "https://registry.npmjs.org/isarray/-/isarray-0.0.1.tgz",
-      "integrity": "sha512-D2S+3GLxWH+uhrNEcoh/fnmYeP8E8/zHl644d/jdA0g2uyXvy3sb0qxotE+ne0LtccHknQzWwZEzhak7oJ0COQ==",
-      "dev": true,
-      "license": "MIT"
-    },
     "node_modules/isexe": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/isexe/-/isexe-2.0.0.tgz",
@@ -5222,13 +5012,6 @@
         "graceful-fs": "^4.1.6"
       }
     },
-    "node_modules/just-extend": {
-      "version": "4.2.1",
-      "resolved": "https://registry.npmjs.org/just-extend/-/just-extend-4.2.1.tgz",
-      "integrity": "sha512-g3UB796vUFIY90VIv/WX3L2c8CS2MdWUww3CNrYmqza1Fg0DURc2K/O4YrnklBdQarSJ/y8JnJYDGc+1iumQjg==",
-      "dev": true,
-      "license": "MIT"
-    },
     "node_modules/keyv": {
       "version": "4.5.4",
       "resolved": "https://registry.npmjs.org/keyv/-/keyv-4.5.4.tgz",
@@ -5329,20 +5112,6 @@
       "dev": true,
       "license": "MIT"
     },
-    "node_modules/lodash.assign": {
-      "version": "4.2.0",
-      "resolved": "https://registry.npmjs.org/lodash.assign/-/lodash.assign-4.2.0.tgz",
-      "integrity": "sha512-hFuH8TY+Yji7Eja3mGiuAxBqLagejScbG8GbG0j6o9vzn0YL14My+ktnqtZgFTosKymC9/44wP6s7xyuLfnClw==",
-      "dev": true,
-      "license": "MIT"
-    },
-    "node_modules/lodash.get": {
-      "version": "4.4.2",
-      "resolved": "https://registry.npmjs.org/lodash.get/-/lodash.get-4.4.2.tgz",
-      "integrity": "sha512-z+Uw/vLuy6gQe8cfaFWD7p0wVv8fJl3mbzXh33RS+0oW2wvUqiRXiQ69gLWSLpgB5/6sU+r6BlQR0MBILadqTQ==",
-      "dev": true,
-      "license": "MIT"
-    },
     "node_modules/lodash.merge": {
       "version": "4.6.2",
       "resolved": "https://registry.npmjs.org/lodash.merge/-/lodash.merge-4.6.2.tgz",
@@ -5372,16 +5141,6 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
-      }
-    },
-    "node_modules/loupe": {
-      "version": "2.3.7",
-      "resolved": "https://registry.npmjs.org/loupe/-/loupe-2.3.7.tgz",
-      "integrity": "sha512-zSMINGVYkdpYSOBmLi0D1Uo7JU9nVdQKrHxC8eYlV+9YKK9WePqAlL7lSlorG/U2Fw1w0hTBmaa/jrQ3UbPHtA==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "get-func-name": "^2.0.1"
       }
     },
     "node_modules/lower-case": {
@@ -5679,13 +5438,6 @@
         "url": "https://github.com/chalk/supports-color?sponsor=1"
       }
     },
-    "node_modules/monaco-editor": {
-      "version": "0.20.0",
-      "resolved": "https://registry.npmjs.org/monaco-editor/-/monaco-editor-0.20.0.tgz",
-      "integrity": "sha512-hkvf4EtPJRMQlPC3UbMoRs0vTAFAYdzFQ+gpMb8A+9znae1c43q8Mab9iVsgTcg/4PNiLGGn3SlDIa8uvK1FIQ==",
-      "dev": true,
-      "license": "MIT"
-    },
     "node_modules/ms": {
       "version": "2.1.2",
       "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.2.tgz",
@@ -5749,20 +5501,6 @@
       "integrity": "sha512-Yd3UES5mWCSqR+qNT93S3UoYUkqAZ9lLg8a7g9rimsWmYGK8cVToA4/sF3RrshdyV3sAGMXVUmpMYOw+dLpOuw==",
       "dev": true,
       "license": "MIT"
-    },
-    "node_modules/nise": {
-      "version": "4.1.0",
-      "resolved": "https://registry.npmjs.org/nise/-/nise-4.1.0.tgz",
-      "integrity": "sha512-eQMEmGN/8arp0xsvGoQ+B1qvSkR73B1nWSCh7nOt5neMCtwcQVYQGdzQMhcNscktTsWB54xnlSQFzOAPJD8nXA==",
-      "dev": true,
-      "license": "BSD-3-Clause",
-      "dependencies": {
-        "@sinonjs/commons": "^1.7.0",
-        "@sinonjs/fake-timers": "^6.0.0",
-        "@sinonjs/text-encoding": "^0.7.1",
-        "just-extend": "^4.0.2",
-        "path-to-regexp": "^1.7.0"
-      }
     },
     "node_modules/no-case": {
       "version": "3.0.4",
@@ -6138,16 +5876,6 @@
       "dev": true,
       "license": "MIT"
     },
-    "node_modules/path-to-regexp": {
-      "version": "1.8.0",
-      "resolved": "https://registry.npmjs.org/path-to-regexp/-/path-to-regexp-1.8.0.tgz",
-      "integrity": "sha512-n43JRhlUKUAlibEJhPeir1ncUID16QnEjNpwzNdO3Lm4ywrBpBZ5oLD0I6br9evr1Y9JTqwRtAh7JLoOzAQdVA==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "isarray": "0.0.1"
-      }
-    },
     "node_modules/path-type": {
       "version": "4.0.0",
       "resolved": "https://registry.npmjs.org/path-type/-/path-type-4.0.0.tgz",
@@ -6156,16 +5884,6 @@
       "license": "MIT",
       "engines": {
         "node": ">=8"
-      }
-    },
-    "node_modules/pathval": {
-      "version": "1.1.1",
-      "resolved": "https://registry.npmjs.org/pathval/-/pathval-1.1.1.tgz",
-      "integrity": "sha512-Dp6zGqpTdETdR63lehJYPeIOqpiNBNtc7BpWSLrOje7UaIsE5aY92r/AunQA7rsXvet3lrJ3JnZX29UPTKXyKQ==",
-      "dev": true,
-      "license": "MIT",
-      "engines": {
-        "node": "*"
       }
     },
     "node_modules/picocolors": {
@@ -7026,36 +6744,6 @@
       "dev": true,
       "license": "ISC"
     },
-    "node_modules/sinon": {
-      "version": "9.2.4",
-      "resolved": "https://registry.npmjs.org/sinon/-/sinon-9.2.4.tgz",
-      "integrity": "sha512-zljcULZQsJxVra28qIAL6ow1Z9tpattkCTEJR4RBP3TGc00FcttsP5pK284Nas5WjMZU5Yzy3kAIp3B3KRf5Yg==",
-      "deprecated": "16.1.1",
-      "dev": true,
-      "license": "BSD-3-Clause",
-      "dependencies": {
-        "@sinonjs/commons": "^1.8.1",
-        "@sinonjs/fake-timers": "^6.0.1",
-        "@sinonjs/samsam": "^5.3.1",
-        "diff": "^4.0.2",
-        "nise": "^4.0.4",
-        "supports-color": "^7.1.0"
-      },
-      "funding": {
-        "type": "opencollective",
-        "url": "https://opencollective.com/sinon"
-      }
-    },
-    "node_modules/sinon/node_modules/diff": {
-      "version": "4.0.2",
-      "resolved": "https://registry.npmjs.org/diff/-/diff-4.0.2.tgz",
-      "integrity": "sha512-58lmxKSA4BNyLz+HHMUzlOEpg09FV+ev6ZMe3vJihgdxzgcwZ8VoEEPmALCZG9LmqfVoNMMKpttIYTVG6uDY7A==",
-      "dev": true,
-      "license": "BSD-3-Clause",
-      "engines": {
-        "node": ">=0.3.1"
-      }
-    },
     "node_modules/slash": {
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/slash/-/slash-3.0.0.tgz",
@@ -7705,16 +7393,6 @@
       },
       "engines": {
         "node": ">= 0.8.0"
-      }
-    },
-    "node_modules/type-detect": {
-      "version": "4.0.8",
-      "resolved": "https://registry.npmjs.org/type-detect/-/type-detect-4.0.8.tgz",
-      "integrity": "sha512-0fr/mIH1dlO+x7TlcMy+bIDqKPsw/70tVyeHW787goQjhmqaZe10uwLujubK9q9Lg6Fiho1KUKDYz0Z7k7g5/g==",
-      "dev": true,
-      "license": "MIT",
-      "engines": {
-        "node": ">=4"
       }
     },
     "node_modules/type-fest": {

--- a/package.json
+++ b/package.json
@@ -42,7 +42,6 @@
   ],
   "devDependencies": {
     "@blockly/dev-scripts": "^4.0.1",
-    "@blockly/dev-tools": "^8.0.2",
     "@blockly/field-colour": "^5.0.4",
     "@eslint/eslintrc": "^2.1.2",
     "@eslint/js": "^8.49.0",

--- a/src/keynames.js
+++ b/src/keynames.js
@@ -136,7 +136,6 @@ function keyCodeToString(keycode) {
     strrep = keyNames[piece] ?? piece;
     result += `+${strrep}`;
   }
-  console.log(`${keycode}, ${result}`);
   return result;
 }
 

--- a/test/index.html
+++ b/test/index.html
@@ -9,6 +9,21 @@
         max-width: 100vw;
       }
 
+      #root {
+        display: flex;
+        overflow: hidden;
+        height: 100vh;
+        width: 100vw;
+        background: rgb(228, 228, 228);
+      }
+
+      #blocklyDiv {
+        height: 100%;
+        width: 100%;
+        max-height: 100%;
+        position: relative;
+      }
+
       pre,
       code {
         overflow: auto;
@@ -88,6 +103,7 @@
           </div>
         </div>
       </div>
+      <div id="blocklyDiv"></div>
     </div>
     <script src="../build/test_bundle.js"></script>
   </body>

--- a/test/index.ts
+++ b/test/index.ts
@@ -6,7 +6,6 @@
 
 import * as Blockly from 'blockly';
 import {installAllBlocks as installColourBlocks} from '@blockly/field-colour';
-import {createPlayground} from '@blockly/dev-tools';
 import {KeyboardNavigation} from '../src/index';
 // @ts-expect-error No types in js file
 import {forBlock} from '../src/blocks/p5_generators';
@@ -24,14 +23,14 @@ import {runCode, registerRunCodeShortcut} from './runCode';
  * Create the workspace, including installing keyboard navigation and
  * change listeners.
  *
- * @param blocklyDiv The blockly container div.
- * @param options The Blockly options.
  * @returns The created workspace.
  */
-function createWorkspace(
-  blocklyDiv: HTMLElement,
-  options: Blockly.BlocklyOptions,
-): Blockly.WorkspaceSvg {
+function createWorkspace(): Blockly.WorkspaceSvg {
+  const options = {
+    toolbox: toolbox,
+    renderer: 'zelos',
+  };
+  const blocklyDiv = document.getElementById('blocklyDiv')!;
   const workspace = Blockly.inject(blocklyDiv, options);
 
   const plugin = new KeyboardNavigation(workspace);
@@ -60,40 +59,8 @@ function addP5() {
   javascriptGenerator.addReservedWords('sketch');
 }
 
-/**
- * Clean up the appearance of the playground by hiding the developer
- * drawer.
- */
-function setOptionsDefaultCollapsed() {
-  const key = 'playgroundState_@blockly/keyboard-experiment';
-  const state = localStorage.getItem(key);
-  if (state === null) {
-    localStorage.setItem(
-      key,
-      JSON.stringify({
-        activeTab: 'JSON',
-        // This is the thing we're actually changing.
-        playgroundOpen: false,
-        autoGenerate: true,
-        workspaceJson: '',
-      }),
-    );
-  }
-}
-
 document.addEventListener('DOMContentLoaded', function () {
   addP5();
-  setOptionsDefaultCollapsed();
-  const defaultOptions = {
-    toolbox: toolbox,
-    renderer: 'zelos',
-  };
-
-  createPlayground(
-    document.getElementById('root')!,
-    createWorkspace,
-    defaultOptions,
-  );
-
+  createWorkspace();
   document.getElementById('run')?.addEventListener('click', runCode);
 });


### PR DESCRIPTION
Fixes https://github.com/google/blockly-keyboard-experimentation/issues/29

The dev-tools drawer gave lots of advanced options for the playground, as well as automatic save/load when refreshing the page. But we don't need those features on this test page, and don't want to confuse external testers.