### PR TITLE
feat: add application role to Blockly workspace div

### DIFF
--- a/src/extended_navigation_controller.js
+++ b/src/extended_navigation_controller.js
@@ -301,6 +301,17 @@ export class ExtendedNavigationController extends NavigationController {
   }
 }
 
+function addAriaInfo(workspace, navController) {
+  const injectionDiv = workspace.getInjectionDiv();
+  injectionDiv.setAttribute('role', 'application');
+  injectionDiv.setAttribute('aria-label', 'Blockly workspace');
+  injectionDiv.setAttribute('tabindex', '0');
+  // Set focus when entering the region.
+  injectionDiv.addEventListener('focusin', (event) => {
+    navController.navigation.focusWorkspace(workspace);
+  })
+}
+
 export function installNavController(workspace) {
   const navigationController = new ExtendedNavigationController();
   navigationController.init();
@@ -308,4 +319,6 @@ export function installNavController(workspace) {
   // Turns on keyboard navigation.
   navigationController.enable(workspace);
   navigationController.listShortcuts();
+
+  addAriaInfo(workspace, navigationController);
 }


### PR DESCRIPTION
Fixes #27 

This makes a few changes:
- Add the application role and a relevant label to the injection div.
- Set the tabindex to 0 to ensure that the workspace is in the focus ring.
- Add a handler to focus the workspace when tab focus hits it.

I tested this by deploying it to my own github pages site, and then using NVDA on windows to move around the page.