### PR TITLE
fix: use ICopyable for copy data

### DIFF
--- a/src/navigation_controller.ts
+++ b/src/navigation_controller.ts
@@ -13,22 +13,20 @@
 import './gesture_monkey_patch';
 
 import * as Blockly from 'blockly/core';
-import {ASTNode, ShortcutRegistry, BlockSvg, WorkspaceSvg} from 'blockly/core';
+import {ASTNode, ShortcutRegistry, BlockSvg, WorkspaceSvg, ICopyData} from 'blockly/core';
 import {utils as BlocklyUtils} from 'blockly/core';
 
 import * as Constants from './constants';
 import {Navigation} from './navigation';
 import {Announcer} from './announcer';
 import {LineCursor} from './line_cursor';
-// TODO (#40): Use ICopyable instead.
-import {BlockCopyData} from 'node_modules/blockly/core/clipboard/block_paster';
 
 /**
  * Class for registering shortcuts for keyboard navigation.
  */
 export class NavigationController {
   /** Data copied by the copy or cut keyboard shortcuts. */
-  copyData: BlockCopyData | null = null;
+  copyData: ICopyData | null = null;
 
   /** The workspace a copy or cut keyboard shortcut happened in. */
   copyWorkspace: WorkspaceSvg | null = null;


### PR DESCRIPTION
Fixes https://github.com/google/blockly-keyboard-experimentation/issues/40

Future work will be needed to handle workspace comments--the current code just casts to a `Blockly.BlockSvg`--but I'm not going to invest time in that until we have more testing on the basic setup.