### PR TITLE
chore: simplify inheritance for Line Cursor class

### DIFF
--- a/src/navigation_controller.ts
+++ b/src/navigation_controller.ts
@@ -13,7 +13,13 @@
 import './gesture_monkey_patch';
 
 import * as Blockly from 'blockly/core';
-import {ASTNode, ShortcutRegistry, BlockSvg, WorkspaceSvg, ICopyData} from 'blockly/core';
+import {
+  ASTNode,
+  ShortcutRegistry,
+  BlockSvg,
+  WorkspaceSvg,
+  ICopyData,
+} from 'blockly/core';
 import {utils as BlocklyUtils} from 'blockly/core';
 
 import * as Constants from './constants';
@@ -822,9 +828,7 @@ export class NavigationController {
         if (!cursor) {
           return false;
         }
-        const sourceBlock = cursor
-          .getCurNode()
-          .getSourceBlock() as BlockSvg;
+        const sourceBlock = cursor.getCurNode().getSourceBlock() as BlockSvg;
         // Delete or backspace.
         // Stop the browser from going back to the previous page.
         // Do this first to prevent an error in the delete code from resulting


### PR DESCRIPTION
Previously the `LineCursor` extended `BasicCursor`, which extended `Cursor`, which extended `Marker`. I copied in the methods and properties we were getting from `Cursor` and `BasicCursor`, and switched to just extend `Marker` directly.

Reason for changes: reduce number of places we have to look to see which code does what; reduce need to make changes in core in order to get changes in keyboard-experimentation.

While working on this change I also took a look at the rendering code, which is primarily in `marker_svg.ts` in core. I did not yet pull that over, but may when I start modifying the rendering.
