### PR TITLE
feat: add draw_emoji block

### DIFF
--- a/src/blocks/p5_blocks.js
+++ b/src/blocks/p5_blocks.js
@@ -170,6 +170,31 @@ const ellipse = {
   'helpUrl': 'https://p5js.org/reference/#/p5/ellipse',
 };
 
+const draw_emoji = {
+  'type': 'draw_emoji',
+  'tooltip': '',
+  'helpUrl': '',
+  'message0': 'draw %1 %2',
+  'args0': [
+    {
+      'type': 'field_dropdown',
+      'name': 'emoji',
+      'options': [
+        ['❤️', '❤️'],
+        ['✨', '✨'],
+        ['🐻', '🐻'],
+      ],
+    },
+    {
+      'type': 'input_dummy',
+      'name': '',
+    },
+  ],
+  'previousStatement': null,
+  'nextStatement': null,
+  'colour': 230,
+};
+
 // Create the block definitions for all the JSON-only blocks.
 // This does not register their definitions with Blockly.
 const jsonBlocks = Blockly.common.createBlockDefinitionsFromJsonArray([
@@ -177,6 +202,7 @@ const jsonBlocks = Blockly.common.createBlockDefinitionsFromJsonArray([
   stroke,
   fill,
   ellipse,
+  draw_emoji,
 ]);
 
 export const blocks = {

--- a/src/blocks/p5_generators.js
+++ b/src/blocks/p5_generators.js
@@ -61,3 +61,10 @@ forBlock['p5_ellipse'] = function (block, generator) {
   const height = generator.valueToCode(block, 'HEIGHT', Order.NONE) || 0;
   return `sketch.ellipse(${x}, ${y}, ${width}, ${height});\n`;
 };
+
+forBlock['draw_emoji'] = function (block) {
+  const dropdown_emoji = block.getFieldValue('emoji');
+  const code = `sketch.textSize(100);
+sketch.text('${dropdown_emoji}', 150, 200);\n`;
+  return code;
+};

--- a/src/blocks/toolbox.js
+++ b/src/blocks/toolbox.js
@@ -46,6 +46,10 @@ export const toolbox = {
     },
     {
       kind: 'block',
+      type: 'draw_emoji',
+    },
+    {
+      kind: 'block',
       type: 'p5_ellipse',
       inline: 'true',
       inputs: {


### PR DESCRIPTION
For testing purposes.

Simple block with a dropdown that draws an emoji in the middle-ish of the canvas.

![image](https://github.com/user-attachments/assets/b5050479-560f-493b-a952-c4e60a781934)
