### PR TITLE
feat: Allow selection of next-statement connections in line cursor

### DIFF
--- a/src/line_cursor.ts
+++ b/src/line_cursor.ts
@@ -43,11 +43,10 @@ export class LineCursor extends Marker {
     }
     let newNode = this.getNextNode(curNode, this.validLineNode);
 
-    // Skip the input or next value if there is a connected block.
+    // Skip the input (but not next) connection if there is a connected block.
     if (
       newNode &&
-      (newNode.getType() == ASTNode.types.INPUT ||
-        newNode.getType() == ASTNode.types.NEXT) &&
+      newNode.getType() === ASTNode.types.INPUT &&
       (newNode.getLocation() as Blockly.Connection).targetBlock()
     ) {
       newNode = this.getNextNode(newNode, this.validLineNode);


### PR DESCRIPTION
Allow selection of next-statement connections in line cursor.

This allows insertion of new blocks into a stack.

