### PR TITLE
feat: make draw code only run once

### DIFF
--- a/src/blocks/p5_generators.js
+++ b/src/blocks/p5_generators.js
@@ -19,7 +19,11 @@ forBlock['text_print'] = function (block, generator) {
 forBlock['p5_setup'] = function (block, generator) {
   const statements = generator.statementToCode(block, 'STATEMENTS');
   const code = `sketch.setup = function() {
-${statements}};\n`;
+  ${statements}
+  // Only run draw code once.
+  sketch.noLoop();
+};
+`;
   return code;
 };
 


### PR DESCRIPTION
Fixes #69 


Uses [`noLoop`](https://p5js.org/reference/p5/noLoop/) to make `draw` only run once. This keeps the generated code in a standard p5 structure, which means it's easy to change it back to running repeatedly for animations.

It would be simple to just move all of the code into the `setup` block instead of separating into `setup` and `draw`, but even simple micro:bit programs often have multiple block stacks.