### PR TITLE
feat: make Blockly cooperative with tab navigation

### DIFF
--- a/src/constants.ts
+++ b/src/constants.ts
@@ -28,7 +28,7 @@ export enum SHORTCUT_NAMES {
   IN = 'in',
   OUT = 'out',
   INSERT = 'insert',
-  MARK = 'mark',
+  ENTER_OR_MARK = 'enter_or_mark',
   DISCONNECT = 'disconnect',
   TOOLBOX = 'toolbox',
   EXIT = 'exit',
@@ -43,6 +43,15 @@ export enum SHORTCUT_NAMES {
   MOVE_WS_CURSOR_RIGHT = 'workspace_right',
   TOGGLE_KEYBOARD_NAV = 'toggle_keyboard_nav',
   /* eslint-enable @typescript-eslint/naming-convention */
+  LIST_SHORTCUTS = 'list_shortcuts',
+  ANNOUNCE = 'announce',
+  GO_TO_NEXT_SIBLING = 'go_to_next_sibling',
+  GO_TO_PREVIOUS_SIBLING = 'go_to_previous_sibling',
+  JUMP_TO_ROOT = 'jump_to_root_of_current_stack',
+  CONTEXT_OUT = 'context_out',
+  CONTEXT_IN = 'context_in',
+  CLEAN_UP = 'clean_up_workspace',
+  INTERCEPT_TAB = 'intercept_tab_navigation',
 }
 
 /**

--- a/src/index.ts
+++ b/src/index.ts
@@ -26,9 +26,19 @@ export class KeyboardNavigation {
     navigationController.init();
     navigationController.addWorkspace(workspace);
     // Turns on keyboard navigation.
-    navigationController.enable(workspace);
+    navigationController.setHasAutoNavigationEnabled(true);
     navigationController.listShortcuts();
 
     installCursor(workspace.getMarkerManager());
+
+    // Ensure that only the root SVG group has a tab index.
+    workspace.getInjectionDiv().removeAttribute('tabindex');
+
+    workspace.getSvgGroup().addEventListener('focus', () => {
+      navigationController.setHasFocus(true);
+    });
+    workspace.getSvgGroup().addEventListener('blur', () => {
+      navigationController.setHasFocus(false);
+    });
   }
 }


### PR DESCRIPTION
Fixes #71

This introduces more intentional tab navigation support in Blockly when using the keyboard navigation plugin, specifically by:
- Ensuring the top-level container is only in the tab index once. Without these changes, Blockly's top div and top group are both in the root tab index (which means both are tabbed to when trying to use tab navigation which can be confusing to the user since there's no feedback that one of the tabs is going 'nowhere').
- Introducing explicit 'enter' and 'escape' flows for giving Blockly keyboard focus (and taking away focus from the browser), otherwise the browser retains tab-based navigation.

See the following videos for demonstrations on the before/after behavior with these changes:

Before changes:

[before_without_reader.webm](https://github.com/user-attachments/assets/b4e8ea46-7f54-4237-9cf5-23841e6ca455)

After changes:

[after_without_reader.webm](https://github.com/user-attachments/assets/89df98f0-bd9a-4f6e-997b-e16ad933b044)

Note that there's still a "double tab navigation" issue for the main Blockly injection area with a screen reader (but not for normal navigation). This will require additional investigation outside this PR. The before/after behavior with the screen reader isn't included above since it's hard to see the results in the recording (the highlights and output of the reader aren't being captured).

Note also that this PR also includes a few cleanups:
- Some syntax simplification when using lambdas.
- Some constant renames/additions for consistency (and correctness in disposing of registered shortcuts).