### PR TITLE
Add keyboard shortcut modal dialog

### DIFF
--- a/src/announcer.ts
+++ b/src/announcer.ts
@@ -4,6 +4,7 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
+import * as Blockly from 'blockly/core';
 import {ShortcutRegistry} from 'blockly/core';
 // @ts-expect-error No types in js file
 import {keyCodeArrayToString} from './keynames';
@@ -13,6 +14,8 @@ import {keyCodeArrayToString} from './keynames';
  */
 export class Announcer {
   outputDiv: HTMLElement | null;
+  modalContainer: HTMLElement | null;
+  shortcutDialog: HTMLElement | null;
   /**
    * Constructor for an Announcer.
    */
@@ -20,6 +23,9 @@ export class Announcer {
     // For testing purposes, this assumes that the page has a
     // div named 'announcer'.
     this.outputDiv = document.getElementById('announcer');
+
+    this.modalContainer = null;
+    this.shortcutDialog = null;
   }
 
   /**

--- a/src/constants.ts
+++ b/src/constants.ts
@@ -54,3 +54,13 @@ export enum LOGGING_MSG_TYPE {
   WARN = 'warn',
   LOG = 'log',
 }
+
+/**
+ * Platform specific modifier key used in shortcuts.
+ */
+export enum  MODIFIER_KEY {
+  Window = 'Ctrl',
+  ChromeOS = 'Ctrl',
+  macOS ='⌘ Command',
+  Linux = 'Meta'
+}

--- a/src/constants.ts
+++ b/src/constants.ts
@@ -64,3 +64,27 @@ export enum  MODIFIER_KEY {
   macOS ='⌘ Command',
   Linux = 'Meta'
 }
+
+/**
+ * Categories used to organised the shortcut dialog.
+ * Shortcut name should match those obtained from the Blockly shortcut register.
+ */
+export const SHORTCUT_CATEGORIES = {
+  'General': [
+    'escape', 'exit', 'delete', 'run_code', 'toggle_keyboard_nav', 'Announce',
+    'List shortcuts', 'toolbox', 'disconnect'
+  ],
+  'Editing': [
+    'cut', 'copy', 'paste', 'undo', 'redo', 'mark', 'insert'
+  ],
+  'Code navigation': [
+    'previous', 'next', 'in', 'out', 'Context in', 'Context out',
+    'Go to previous sibling', 'Go to next sibling',
+    'Jump to root of current stack'
+  ],
+  'Workspace navigation' : [
+    'workspace_down', 'workspace_left', 'workspace_up', 'workspace_right',
+    'Clean up workspace'
+  ]
+}
+

--- a/src/index.ts
+++ b/src/index.ts
@@ -28,6 +28,7 @@ export class KeyboardNavigation {
     // Turns on keyboard navigation.
     navigationController.enable(workspace);
     navigationController.listShortcuts();
+    navigationController.initShortcutsModal();
 
     installCursor(workspace.getMarkerManager());
   }

--- a/src/keynames.js
+++ b/src/keynames.js
@@ -120,6 +120,23 @@ const keyNames = {
   224: 'win',
 };
 
+const modifierKeys = ['control', 'alt', 'meta'];
+
+
+/**
+ * Assign the appropriate class names for the key.
+ * Modifier keys are indicated so they can be switched to a platform specific
+ * key.
+ */
+function getKeyClassName(keyName) {
+  return modifierKeys.includes(keyName.toLowerCase()) ? 'key modifier' : 'key';
+}
+
+function toTitleCase(str) {
+  return str.charAt(0).toUpperCase() + str.substring(1).toLowerCase()
+}
+
+
 /**
  * Convert from a serialized key code to a HTML string.
  * This should be the inverse of ShortcutRegistry.createSerializedKey, but
@@ -128,33 +145,32 @@ const keyNames = {
  *     by the + character.
  * @returns {string} A single string representing the key code.
  */
-function keyCodeToString(keycode) {
-  let result = '<span class="shortcut-combo">';
+function keyCodeToString(keycode, index) {
+  let result = `<span class="shortcut-combo shortcut-combo-${index}">`;
   const pieces = keycode.split('+');
 
   let piece = pieces[0];
-  let strrep =  keyNames[piece] ?? piece;
-  result += '<span class="key">' + strrep + '</span>';
+  let strrep = keyNames[piece] ?? piece;
 
-  for (let i = 1; i < pieces.length; i++) {
+  for (let i = 0; i < pieces.length; i++) {
     piece = pieces[i];
     strrep = keyNames[piece] ?? piece;
-    result += `+<span class="key">${strrep}</span>`;
+    const className = getKeyClassName(strrep);
+
+    if (i === pieces.length - 1 && i !== 0) {
+      strrep = strrep.toUpperCase();
+    } else {
+      strrep = toTitleCase(strrep);
+    }
+
+    if (i > 0) {
+      result += '+';
+    }
+    result += `<span class="${className}">${strrep}</span>`;
   }
   result += '</span>';
   return result;
 }
-
-// /**
-//  * Convert an array of key codes into a comma-separated list of strings
-//  * @param {Array<string>} keycodeArr The array of key codes to convert.
-//  * @returns {string} The input array as a comma-separated list of
-//  *     human-readable strings.
-//  */
-// export function keyCodeArrayToString(keycodeArr) {
-//   const stringified = keycodeArr.map((keycode) => keyCodeToString(keycode));
-//   return stringified.join(', ');
-// }
 
 /**
  * Convert an array of key codes into a comma-separated list of strings
@@ -163,10 +179,7 @@ function keyCodeToString(keycode) {
  *     human-readable strings wrapped in HTML.
  */
 export function keyCodeArrayToString(keycodeArr) {
-  const stringified = keycodeArr.map((keycode) => keyCodeToString(keycode));
+  const stringified = keycodeArr.map((keycode, index) =>
+      keyCodeToString(keycode, index));
   return stringified.join('<span class="separator">/</span>');
 }
-
-
-
-

--- a/src/keynames.js
+++ b/src/keynames.js
@@ -121,7 +121,7 @@ const keyNames = {
 };
 
 /**
- * Convert from a serialized key code to a string.
+ * Convert from a serialized key code to a HTML string.
  * This should be the inverse of ShortcutRegistry.createSerializedKey, but
  * should also convert ascii characters to strings.
  * @param {string} keycode The key code as a string of characters separated
@@ -129,28 +129,44 @@ const keyNames = {
  * @returns {string} A single string representing the key code.
  */
 function keyCodeToString(keycode) {
-  let result = '';
+  let result = '<span class="shortcut-combo">';
   const pieces = keycode.split('+');
 
   let piece = pieces[0];
-  let strrep = keyNames[piece] ?? piece;
-  result += strrep;
+  let strrep =  keyNames[piece] ?? piece;
+  result += '<span class="key">' + strrep + '</span>';
 
   for (let i = 1; i < pieces.length; i++) {
     piece = pieces[i];
     strrep = keyNames[piece] ?? piece;
-    result += `+${strrep}`;
+    result += `+<span class="key">${strrep}</span>`;
   }
+  result += '</span>';
   return result;
 }
+
+// /**
+//  * Convert an array of key codes into a comma-separated list of strings
+//  * @param {Array<string>} keycodeArr The array of key codes to convert.
+//  * @returns {string} The input array as a comma-separated list of
+//  *     human-readable strings.
+//  */
+// export function keyCodeArrayToString(keycodeArr) {
+//   const stringified = keycodeArr.map((keycode) => keyCodeToString(keycode));
+//   return stringified.join(', ');
+// }
 
 /**
  * Convert an array of key codes into a comma-separated list of strings
  * @param {Array<string>} keycodeArr The array of key codes to convert.
  * @returns {string} The input array as a comma-separated list of
- *     human-readable strings.
+ *     human-readable strings wrapped in HTML.
  */
 export function keyCodeArrayToString(keycodeArr) {
   const stringified = keycodeArr.map((keycode) => keyCodeToString(keycode));
-  return stringified.join(', ');
+  return stringified.join('<span class="separator">/</span>');
 }
+
+
+
+

--- a/src/navigation_controller.ts
+++ b/src/navigation_controller.ts
@@ -26,6 +26,7 @@ import * as Constants from './constants';
 import {Navigation} from './navigation';
 import {Announcer} from './announcer';
 import {LineCursor} from './line_cursor';
+import {ShortcutDialog} from './shortcut_dialog';
 
 /**
  * Class for registering shortcuts for keyboard navigation.
@@ -38,6 +39,7 @@ export class NavigationController {
   copyWorkspace: WorkspaceSvg | null = null;
   navigation: Navigation = new Navigation();
   announcer: Announcer = new Announcer();
+  shortcutDialog: ShortcutDialog = new ShortcutDialog();
 
   /**
    * Registers the default keyboard shortcuts for keyboard navigation.
@@ -864,6 +866,16 @@ export class NavigationController {
   }
 
   /**
+   * Initalise the shortcut modal with available shortcuts.
+   * Needs to be done separately rather at construction, as many shortcuts are
+   * not registered at that point.
+   */
+  initShortcutsModal() {
+    this.shortcutDialog.createModalContent();
+  }
+
+
+  /**
    * Register a keyboard shortcut to list all current shortcuts.
    */
   registerListShortcuts() {
@@ -873,7 +885,7 @@ export class NavigationController {
         return true;
       },
       callback: (workspace) => {
-        this.announcer.listShortcuts();
+        this.shortcutDialog.toggle();
         return true;
       },
     };

--- a/src/shortcut_dialog.ts
+++ b/src/shortcut_dialog.ts
@@ -10,6 +10,7 @@ import {ShortcutRegistry} from 'blockly/core';
 // @ts-expect-error No types in js file
 import {keyCodeArrayToString} from './keynames';
 
+
 /**
  * Class for handling the shortcuts dialog.
  */
@@ -53,7 +54,7 @@ export class ShortcutDialog {
   /**
    * Update the modifier key to the user's specific platform.
    */
-  updatePlatformModifier () {
+  updatePlatformModifier() {
     const platform = this.getPlatform();
     const platformEl = this.outputDiv ?
         this.outputDiv.querySelector('.platform') : null;
@@ -102,13 +103,6 @@ export class ShortcutDialog {
   createModalContent() {
     const registry = ShortcutRegistry.registry.getRegistry();
 
-    // Missing category headings and groupings
-    // <thead>
-    //   <tr class="category">
-    //     <th colspan="2">Editing</th> General Workspace navigation
-    //   </tr>
-    // </thead>
-
     let modalContents = `<div class="modal-container">
   <dialog class="shortcut-modal">
     <div class="shortcut-container">
@@ -124,24 +118,38 @@ export class ShortcutDialog {
     <div class="shortcut-container">
       <table class="shortcuts">
         <tbody>
-          <thead>
-            <tr class="category">
-              <th colspan="2">General</th>
-            </tr>
-          </thead>
     `;
 
-    for (const keyboardShortcut of Object.keys(registry)) {
-      const codeArray =
-        ShortcutRegistry.registry.getKeyCodesByShortcutName(keyboardShortcut);
-      const prettyPrinted = keyCodeArrayToString(codeArray);
-      modalContents +=
-        `<tr>
-          <td>${this.getReadableShortcutName(keyboardShortcut)}</td>
-          <td>${prettyPrinted}</td>
-         </tr>`;
-    }
+    // Display shortcuts by their categories.
+    const categoryKeys = Object.keys(Constants.SHORTCUT_CATEGORIES);
+    for (const key of categoryKeys) {
+      const categoryShortcuts: string[] =
+          Constants.SHORTCUT_CATEGORIES[key as keyof typeof Constants.SHORTCUT_CATEGORIES];
 
+      modalContents += `
+          <thead>
+            <tr class="category">
+              <th colspan="2">${key}</th>
+            </tr>
+          </thead>
+          `;
+      for (const keyboardShortcut of Object.keys(registry)) {
+        if (categoryShortcuts.includes(keyboardShortcut)) {
+          const codeArray =
+            ShortcutRegistry.registry.getKeyCodesByShortcutName(keyboardShortcut);
+          // Only show the first shortcut if there are many
+          const prettyPrinted = codeArray.length > 2 ? 
+              keyCodeArrayToString(codeArray.slice(0,1)) :
+              keyCodeArrayToString(codeArray);
+
+          modalContents +=
+            `<tr>
+              <td>${this.getReadableShortcutName(keyboardShortcut)}</td>
+              <td>${prettyPrinted}</td>
+             </tr>`;
+        }
+      }
+    }
     if (this.outputDiv) {
       this.outputDiv.innerHTML = modalContents + `\n</tbody>
           </table>
@@ -198,7 +206,7 @@ Blockly.Css.register(`
   min-width: 300px;
   padding: 24px 12px 24px 32px;
   position: relative;
-  width: 70%;
+  width: 50%;
   z-index: 99;
 }
 
@@ -238,22 +246,23 @@ Blockly.Css.register(`
   padding: 1em 0 0.5em;
 }
 
-.key {
+.shortcuts .key {
   border-radius: 8px;
   border: 1px solid var(--key-border-color);
   display: inline-block;
   margin: 0 8px;
   min-width: 2em;
-  padding: .2em .5em;
+  padding: .5em .5em;
   text-align: center;
 }
 
-tr:not(.category, :last-child) {
+.shortcuts tr:not(.category, :last-child) {
   border-bottom: 1px solid var(--divider-border-color);
 }
 
-td {
-  padding: .5em 0 .6em;
+.shortcuts td {
+  padding: .5em 1em .6em 0;
+  text-wrap: nowrap
 }
 
 .shortcut-container {
@@ -262,7 +271,8 @@ td {
 
 .shortcuts .separator {
   display: inline-block;
-  padding: 0 1em
+  padding: 0 0.5em;
+  color: gray;
 }
 
 .shortcut-combo {

--- a/src/shortcut_dialog.ts
+++ b/src/shortcut_dialog.ts
@@ -102,6 +102,13 @@ export class ShortcutDialog {
   createModalContent() {
     const registry = ShortcutRegistry.registry.getRegistry();
 
+    // Missing category headings and groupings
+    // <thead>
+    //   <tr class="category">
+    //     <th colspan="2">Editing</th> General Workspace navigation
+    //   </tr>
+    // </thead>
+
     let modalContents = `<div class="modal-container">
   <dialog class="shortcut-modal">
     <div class="shortcut-container">
@@ -134,133 +141,7 @@ export class ShortcutDialog {
           <td>${prettyPrinted}</td>
          </tr>`;
     }
-    // Hard coding the keys for now
-    // Should dynamically output the table
-    let text = `
-<div class="modal-container">
-  <dialog class="shortcut-modal">
-    <div class="shortcut-container">
-    <div class="header">
-      <button class="close-modal">
-        <span class="material-symbols-outlined">close</span>
-      </button>
-      <h1>Keyboard shortcuts</h1>
-      <p class="intro">
-        <span class="platform">Windows</span>
-      </p>
-    </div>
-    <div class="shortcut-container">
-      <table class="shortcuts">
-        <tbody>
-          <thead>
-            <tr class="category">
-              <th colspan="2">General</th>
-            </tr>
-          </thead>
-          <tr>
-            <td>Show shortcuts</td>
-            <td><span class="key">/</span></td>
-          </tr>
-          <tr>
-            <td>Escape / exit</td>
-            <td><span class="key">Esc</span> / <span class="key">E</span></td>
-          </tr>
-          <tr>
-            <td>Run code</td>
-            <td><span class="key">Shift</span> + <span class="key">R</span></td>
-          </tr>
-          <tr>
-            <td>Toggle keyboard navigation</td>
-            <td><span class="key">Shift</span> + <span class="key modifier">Ctrl</span> + <span class="key">K</span></td>
-          </tr>
-          <thead>
-            <tr class="category">
-              <th colspan="2">Editing</th>
-            </tr>
-          </thead>
-          <tr>
-            <td>Cut</td>
-            <td><span class="key modifier">Ctrl</span> + <span class="key">X</span></td>
-          </tr>
-          <tr>
-            <td>Copy</td>
-            <td><span class="key modifier">Ctrl</span> + <span class="key">C</span></td>
-          </tr>
-          <tr>
-            <td>Paste</td>
-            <td><span class="key modifier">Ctrl</span> + <span class="key">V</span></td>
-          </tr>
-          <tr>
-            <td>Undo</td>
-            <td><span class="key modifier">Ctrl</span> + <span class="key">Z</span></td>
-          </tr>
-          <tr>
-            <td>Redo</td>
-            <td><span class="key">Shift</span> + <span class="key modifier">Ctrl</span> + <span class="key">Z</span></td>
-          </tr>
-          <thead>
-            <tr class="category">
-              <th colspan="2">Code navigation</th>
-            </tr>
-          </thead>
-          <tr>
-            <td>Previous</td>
-            <td><span class="key">↑</span></td>
-          </tr>
-          <tr>
-            <td>Next</td>
-            <td><span class="key">↓</span></td>
-          </tr>
-          <tr>
-            <td>In / right</td>
-            <td><span class="key">→</span></td>
-          </tr>
-          <tr>
-            <td>Out / left</td>
-            <td><span class="key">←</span></td>
-          </tr>
-          <tr>
-            <td>Context in</td>
-            <td><span class="key">Shift</span> + <span class="key">I</span></td>
-          </tr>
-          <tr>
-            <td>Context out</td>
-            <td><span class="key">Shift</span> + <span class="key">O</span></td>
-          </tr>
-          <tr>
-            <td>Go to previous sibling</td>
-            <td><span class="key">M</span></td>
-          </tr>
-          <tr>
-            <td>Go to next sibling</td>
-            <td><span class="key">N</span></td>
-          </tr>
-          <tr>
-            <td>Jump to root of current stack</td>
-            <td><span class="key">R</span></td>
-          </tr>
-          <thead>
-            <tr class="category">
-              <th colspan="2">Workspace navigation</th>
-            </tr>
-          </thead>
-          <tr>
-            <td>Up</td>
-            <td><span class="key">Shift</span> + <span class="key">W</span></td>
-          </tr>
-          <tr>
-            <td>Down</td>
-            <td><span class="key">Shift</span> + <span class="key">S</span></td>
-          </tr>
-          <tr>
-            <td>Left</td>
-            <td><span class="key">Shift</span> + <span class="key">A</span></td>
-          </tr>
-          <tr>
-            <td>Right</td>
-            <td><span class="key">Shift</span> + <span class="key">D</span></td>
-          </tr>
-          `;
+
     if (this.outputDiv) {
       this.outputDiv.innerHTML = modalContents + `\n</tbody>
           </table>

--- a/src/shortcut_dialog.ts
+++ b/src/shortcut_dialog.ts
@@ -1,0 +1,398 @@
+/**
+ * @license
+ * Copyright 2024 Google LLC
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import * as Blockly from 'blockly/core';
+import * as Constants from './constants';
+import {ShortcutRegistry} from 'blockly/core';
+// @ts-expect-error No types in js file
+import {keyCodeArrayToString} from './keynames';
+
+/**
+ * Class for handling the shortcuts dialog.
+ */
+export class ShortcutDialog {
+  outputDiv: HTMLElement | null;
+  modalContainer: HTMLElement | null;
+  shortcutDialog: HTMLElement | null;
+  open: Boolean;
+  closeButton: HTMLElement | null;
+  /**
+   * Constructor for an Announcer.
+   */
+  constructor() {
+    // For testing purposes, this assumes that the page has a
+    // div named 'shortcuts'.
+    this.outputDiv = document.getElementById('shortcuts');
+
+    this.open = false;
+    this.modalContainer = null;
+    this.shortcutDialog = null;
+    this.closeButton = null;
+  }
+
+  getPlatform() {
+    const platform = navigator.platform;
+    
+    // Check for Windows platforms
+    if (platform.startsWith('Win')) {
+      return 'Windows';
+    } else if (platform.startsWith('Mac')) {
+      return 'macOS';
+    } else if (platform.includes('Linux')) {
+      return 'Linux';
+    } else if (platform.includes('chromeOS')) {
+      return 'ChromeOS';
+    } else {
+      return 'Unknown';
+    }
+  }
+
+  /**
+   * Update the modifier key to the user's specific platform.
+   */
+  updatePlatformModifier () {
+    const platform = this.getPlatform();
+    const platformEl = this.outputDiv ?
+        this.outputDiv.querySelector('.platform') : null;
+
+    // Update platform string
+    if (platformEl) {
+      platformEl.textContent = platform;
+    }
+
+    if (this.shortcutDialog) {
+      const modifierKeys = this.shortcutDialog.querySelectorAll('.key.modifier');
+
+      if (modifierKeys.length > 0 && platform) {
+        for (let key of modifierKeys) {
+          key.textContent = Constants.MODIFIER_KEY[platform as keyof
+              typeof Constants.MODIFIER_KEY];
+        }
+      }
+    }
+  }
+
+  toggle() {
+    if (this.modalContainer && this.shortcutDialog) {
+      this.modalContainer.classList.toggle('open', !this.open);
+      if (this.open) {
+        this.shortcutDialog.removeAttribute('open');
+      } else {
+        this.shortcutDialog.setAttribute('open', '');
+      }
+      this.open = !this.open;
+    }
+  }
+
+  /**
+   * @param {string} shortcutName Shortcut name to convert.
+   * @returns {string}
+   */
+  getReadableShortcutName(shortcutName: string) {
+    shortcutName = shortcutName.replace(/_/ig, ' ');
+    return shortcutName;
+  }
+
+  /**
+   * List all currently registered shortcuts as a table.
+   */
+  createModalContent() {
+    const registry = ShortcutRegistry.registry.getRegistry();
+
+    let modalContents = `<div class="modal-container">
+  <dialog class="shortcut-modal">
+    <div class="shortcut-container">
+    <div class="header">
+      <button class="close-modal">
+        <span class="material-symbols-outlined">close</span>
+      </button>
+      <h1>Keyboard shortcuts</h1>
+      <p class="intro">
+        <span class="platform">Windows</span>
+      </p>
+    </div>
+    <div class="shortcut-container">
+      <table class="shortcuts">
+        <tbody>
+          <thead>
+            <tr class="category">
+              <th colspan="2">General</th>
+            </tr>
+          </thead>
+    `;
+
+    for (const keyboardShortcut of Object.keys(registry)) {
+      const codeArray =
+        ShortcutRegistry.registry.getKeyCodesByShortcutName(keyboardShortcut);
+      const prettyPrinted = keyCodeArrayToString(codeArray);
+      modalContents +=
+        `<tr>
+          <td>${this.getReadableShortcutName(keyboardShortcut)}</td>
+          <td>${prettyPrinted}</td>
+         </tr>`;
+    }
+    // Hard coding the keys for now
+    // Should dynamically output the table
+    let text = `
+<div class="modal-container">
+  <dialog class="shortcut-modal">
+    <div class="shortcut-container">
+    <div class="header">
+      <button class="close-modal">
+        <span class="material-symbols-outlined">close</span>
+      </button>
+      <h1>Keyboard shortcuts</h1>
+      <p class="intro">
+        <span class="platform">Windows</span>
+      </p>
+    </div>
+    <div class="shortcut-container">
+      <table class="shortcuts">
+        <tbody>
+          <thead>
+            <tr class="category">
+              <th colspan="2">General</th>
+            </tr>
+          </thead>
+          <tr>
+            <td>Show shortcuts</td>
+            <td><span class="key">/</span></td>
+          </tr>
+          <tr>
+            <td>Escape / exit</td>
+            <td><span class="key">Esc</span> / <span class="key">E</span></td>
+          </tr>
+          <tr>
+            <td>Run code</td>
+            <td><span class="key">Shift</span> + <span class="key">R</span></td>
+          </tr>
+          <tr>
+            <td>Toggle keyboard navigation</td>
+            <td><span class="key">Shift</span> + <span class="key modifier">Ctrl</span> + <span class="key">K</span></td>
+          </tr>
+          <thead>
+            <tr class="category">
+              <th colspan="2">Editing</th>
+            </tr>
+          </thead>
+          <tr>
+            <td>Cut</td>
+            <td><span class="key modifier">Ctrl</span> + <span class="key">X</span></td>
+          </tr>
+          <tr>
+            <td>Copy</td>
+            <td><span class="key modifier">Ctrl</span> + <span class="key">C</span></td>
+          </tr>
+          <tr>
+            <td>Paste</td>
+            <td><span class="key modifier">Ctrl</span> + <span class="key">V</span></td>
+          </tr>
+          <tr>
+            <td>Undo</td>
+            <td><span class="key modifier">Ctrl</span> + <span class="key">Z</span></td>
+          </tr>
+          <tr>
+            <td>Redo</td>
+            <td><span class="key">Shift</span> + <span class="key modifier">Ctrl</span> + <span class="key">Z</span></td>
+          </tr>
+          <thead>
+            <tr class="category">
+              <th colspan="2">Code navigation</th>
+            </tr>
+          </thead>
+          <tr>
+            <td>Previous</td>
+            <td><span class="key">↑</span></td>
+          </tr>
+          <tr>
+            <td>Next</td>
+            <td><span class="key">↓</span></td>
+          </tr>
+          <tr>
+            <td>In / right</td>
+            <td><span class="key">→</span></td>
+          </tr>
+          <tr>
+            <td>Out / left</td>
+            <td><span class="key">←</span></td>
+          </tr>
+          <tr>
+            <td>Context in</td>
+            <td><span class="key">Shift</span> + <span class="key">I</span></td>
+          </tr>
+          <tr>
+            <td>Context out</td>
+            <td><span class="key">Shift</span> + <span class="key">O</span></td>
+          </tr>
+          <tr>
+            <td>Go to previous sibling</td>
+            <td><span class="key">M</span></td>
+          </tr>
+          <tr>
+            <td>Go to next sibling</td>
+            <td><span class="key">N</span></td>
+          </tr>
+          <tr>
+            <td>Jump to root of current stack</td>
+            <td><span class="key">R</span></td>
+          </tr>
+          <thead>
+            <tr class="category">
+              <th colspan="2">Workspace navigation</th>
+            </tr>
+          </thead>
+          <tr>
+            <td>Up</td>
+            <td><span class="key">Shift</span> + <span class="key">W</span></td>
+          </tr>
+          <tr>
+            <td>Down</td>
+            <td><span class="key">Shift</span> + <span class="key">S</span></td>
+          </tr>
+          <tr>
+            <td>Left</td>
+            <td><span class="key">Shift</span> + <span class="key">A</span></td>
+          </tr>
+          <tr>
+            <td>Right</td>
+            <td><span class="key">Shift</span> + <span class="key">D</span></td>
+          </tr>
+          `;
+    if (this.outputDiv) {
+      this.outputDiv.innerHTML = modalContents + `\n</tbody>
+          </table>
+        </div>
+      </dialog>
+    </div>`;
+      this.modalContainer = this.outputDiv.querySelector('.modal-container');
+      this.shortcutDialog = this.outputDiv.querySelector('.shortcut-modal');
+      this.closeButton = this.outputDiv.querySelector('.close-modal');
+      this.updatePlatformModifier();
+      // Can we also intercept the Esc key to dismiss.
+      if (this.closeButton) {
+        this.closeButton.addEventListener('click', (e) => {
+            this.toggle()
+          });
+      }
+    }
+  }
+}
+
+
+/**
+ * Register classes used by the shortcuts modal
+ * Alt: plugin exports a register() function that updates the registry 
+ **/
+Blockly.Css.register(`
+:root {
+  --divider-border-color: #DADCE0;
+  --key-border-color: #BDC1C6;
+  --shortcut-modal-border-color: #9AA0A6;
+}
+
+.modal-container {
+  align-items: center;
+  display: none;
+  font-family: Roboto;
+  height: 100%;
+  justify-content: center;
+  left: 0;
+  position: absolute;
+  top: 0;
+  width: 100%;
+}
+
+.shortcut-modal {
+  border: 1px solid var(--shortcut-modal-border-color);
+  border-radius: 12px;
+  box-shadow: 6px 6px 32px  rgba(0,0,0,.5);
+  flex-direction: column;
+  gap: 12px;
+  margin: auto;
+  max-height: 82vh;
+  max-width: 800px;
+  min-width: 300px;
+  padding: 24px 12px 24px 32px;
+  position: relative;
+  width: 70%;
+  z-index: 99;
+}
+
+.modal-container.open,
+.shortcut-modal[open] {
+  display: flex;
+}
+
+.modal-container .close-modal {
+  border: 0;
+  background: transparent;
+  float: inline-end;
+  margin: 0 0 0 0;
+  position: absolute;
+  top: 16px;
+  right: 24px;
+}
+
+.modal-container h1 {
+  font-weight: 600;
+  font-size: 1.5em;
+}
+
+.modal-container {
+  background: radial-gradient(rgba(244, 244, 244, 0.43), rgba(75, 75, 75, 0.51));
+}
+
+.shortcuts {
+  width: 100%;
+  font-family: Roboto;
+  border-collapse: collapse;
+  font-size: .9em;
+}
+
+.shortcuts th {
+  text-align: left;
+  padding: 1em 0 0.5em;
+}
+
+.key {
+  border-radius: 8px;
+  border: 1px solid var(--key-border-color);
+  display: inline-block;
+  margin: 0 8px;
+  min-width: 2em;
+  padding: .2em .5em;
+  text-align: center;
+}
+
+tr:not(.category, :last-child) {
+  border-bottom: 1px solid var(--divider-border-color);
+}
+
+td {
+  padding: .5em 0 .6em;
+}
+
+.shortcut-container {
+  overflow: auto;
+}
+
+.shortcuts .separator {
+  display: inline-block;
+  padding: 0 1em
+}
+
+.shortcut-combo {
+  text-wrap: nowrap;
+  display: inline-block;
+  padding: 0.25em 0;
+}
+
+.shortcuts tr td:first-child {
+  text-transform: capitalize;
+}
+
+`);
+

--- a/test/index.html
+++ b/test/index.html
@@ -3,6 +3,8 @@
   <head>
     <meta charset="utf-8" />
     <title>Blockly Plugin Test</title>
+    <link rel="preconnect" href="https://fonts.googleapis.com">
+    <link rel="stylesheet" href="https://fonts.googleapis.com/css2?family=Material+Symbols+Outlined:opsz,wght,FILL,GRAD@20..48,100..700,0..1,-50..200">
     <style>
       body {
         margin: 0;
@@ -121,6 +123,7 @@
         </div>
       </div>
       <div id="blocklyDiv"></div>
+      <div id="shortcuts"></div>
     </div>
     <script src="../build/test_bundle.js"></script>
   </body>


### PR DESCRIPTION
Fixes #723

Adds a modal dialog to show a categorised list of Blockly keyboard shortcuts. The dialog is triggered using the '/' key.

At the moment the categories and shortcut names are manually curated, but the assigned shortcuts themselves are taken from the Blockly shortcut registry.