### PR TITLE
feat: outline only the current block instead of the block and its children

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -29,6 +29,24 @@ export class KeyboardNavigation {
     navigationController.enable(workspace);
     navigationController.listShortcuts();
 
+    this.setGlowTheme();
     installCursor(workspace.getMarkerManager());
+  }
+  
+  /**
+   * Update the theme to match the selected glow colour to the cursor
+   * colour.
+   */
+  setGlowTheme() {
+    const newTheme = Blockly.Theme.defineTheme('zelosDerived', 
+      {
+        name: 'zelosDerived',
+        base: Blockly.Themes.Zelos,
+        componentStyles: {
+          selectedGlowColour: '#ffa200',
+        }
+      }
+    );
+    this.workspace.setTheme(newTheme);
   }
 }

--- a/src/line_cursor.ts
+++ b/src/line_cursor.ts
@@ -409,6 +409,35 @@ export class LineCursor extends Marker {
     }
     return this.getRightMostChild(newNode);
   }
+
+  /**
+   * Set the location of the marker and call the update method.
+   * Setting isStack to true will only work if the newLocation is the top most
+   * output or previous connection on a stack.
+   * 
+   * Overrides drawing logic to call `setSelected` if the location is
+   * a block, for testing on October 28 2024.
+   *
+   * @param newNode The new location of the marker.
+   */
+  setCurNode(newNode: ASTNode) {
+    const oldNode = (this as any).curNode;
+    (this as any).curNode = newNode;
+    const drawer = (this as any).drawer;
+    if (newNode?.getType() == ASTNode.types.BLOCK) {
+      if (drawer) {
+        drawer.hide();
+      }
+      const block = newNode.getLocation() as Blockly.BlockSvg;
+      Blockly.common.setSelected(block);
+    } else if (drawer) {
+      if (oldNode?.getType() == ASTNode.types.BLOCK) {
+        Blockly.common.setSelected(null);
+      }
+
+      drawer.draw(oldNode, newNode);
+    }
+  }
 }
 
 export const registrationName = 'LineCursor';


### PR DESCRIPTION
Fixes https://github.com/google/blockly-keyboard-experimentation/issues/28 for testing on October 28 2024.

This is not a great long-term fix. It disables the marker drawer and just calls setSelected instead. If we want to do that long term, it should be less hacky and done by changing the drawer instead of the cursor's `setCurNode`.