### PR TITLE
chore: cleanup for october user testing

### DIFF
--- a/test/index.html
+++ b/test/index.html
@@ -101,27 +101,6 @@
               </select>
             </form>
           </div>
-          <h3 id="description"></h3>
-          <p>
-            This page is an active site for development of keyboard navigation
-            for Blockly.
-          </p>
-          <p>Keyboard navigation is enabled by default.</p>
-          <p>You can navigate with the arrow keys.</p>
-          <p>Press / to see a full list of shortcuts at any time.</p>
-          <p>
-            The announcer region (below) updates in response to some commands.
-          </p>
-          <p>
-            The code can be found on
-            <a href="https://github.com/google/blockly-keyboard-experimentation"
-              >github</a
-            >
-          </p>
-          <h3 id="announcerHeading">Announcer region:</h3>
-          <div id="announceWrapper">
-            <p id="announcer"></p>
-          </div>
         </div>
       </div>
       <div id="blocklyDiv"></div>

--- a/test/index.ts
+++ b/test/index.ts
@@ -27,7 +27,7 @@ import {runCode, registerRunCodeShortcut} from './runCode';
 function loadScenario(workspace: Blockly.WorkspaceSvg) {
   const scenarioSelector = location.search.match(/scenario=([^&]+)/);
   // Default to the sunny day example.
-  const scenarioString = scenarioSelector ? scenarioSelector[1] : 'sun';
+  const scenarioString = scenarioSelector ? scenarioSelector[1] : 'simpleCircle';
   const selector = document.getElementById(
     'scenarioSelect',
   ) as HTMLSelectElement;


### PR DESCRIPTION
- Remove description of the page and announcer region to reduce visual clutter
- Change default scenario to simple circle for testing purposes.