### PR TITLE
fix: Remove extra tab stop on XML group

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -32,8 +32,9 @@ export class KeyboardNavigation {
     this.setGlowTheme();
     installCursor(workspace.getMarkerManager());
 
-    // Ensure that only the root SVG group has a tab index.
+    // Ensure that only the root SVG G (group) has a tab index.
     workspace.getInjectionDiv().removeAttribute('tabindex');
+    workspace.getParentSvg().removeAttribute('tabindex');
 
     workspace.getSvgGroup().addEventListener('focus', () => {
       navigationController.setHasFocus(true);


### PR DESCRIPTION
Ben's PR #72 removed the tabindex on the enclosing DIV, but there's also a tabindex on the XML element that encloses the G that gets the focus/blur event listeners.  Remove it.

An alternative approach would be to add the event listeners to the XML element instead of the G element, and this might be preferable overall but breaks the visual indicator that you have tabbed to the workspace (and I don't know how to fix it) so I'm going with this approach for now.

Fixes #80
