### PR TITLE
feat: Make workspace focus highlight more visible

### DIFF
--- a/test/index.html
+++ b/test/index.html
@@ -26,6 +26,18 @@
         width: 100%;
         max-height: 100%;
         position: relative;
+        --outline-width: 3px;
+      }
+
+      .blocklyMainBackground {
+        height: calc(100% - var(--outline-width));
+        width: calc(100% - var(--outline-width));
+      }
+
+      .blocklyFlyout {
+        top: var(--outline-width);
+        left: var(--outline-width);
+        height: calc(100% - calc(var(--outline-width) * 2.5));
       }
 
       pre,


### PR DESCRIPTION
A small hack (kludge?) from @bmxedd to make it a bit more obvious when the workspace is focused.

@bmxedd notes:

    "Many CSS styles don't work on internal SVG elements. This
    at least allows to the outline to be shown and not be
    obscured by the flyout.

    There is something going on with the width of the outline
    to the top and left side that I couldn't figure out."

A temporary, not-quite-adequate fix for #81.