### PR TITLE
release: Update publish config and publish v0.0.1

### DIFF
--- a/package.json
+++ b/package.json
@@ -10,6 +10,7 @@
     "lint": "eslint .",
     "format": "prettier --write .",
     "predeploy": "blockly-scripts predeploy",
+    "prepublishOnly": "npm login --registry https://wombat-dressing-room.appspot.com",
     "start": "blockly-scripts start",
     "test": "blockly-scripts test"
   },

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@blockly/keyboard-experiment",
-  "version": "0.0.0",
+  "version": "0.0.1",
   "description": "A plugin for keyboard navigation.",
   "scripts": {
     "audit:fix": "blockly-scripts auditFix",


### PR DESCRIPTION
* Add a `prepublishOnly` script, that will be invoked when `npm publish` is run, to run `npm login`.

  For some reason `npm login` does not by default use the same repository as `npm publish` does, so it's necessary to 
  specify the repo URL explicitly.  ಠ_ಠ

* Bump `version` to `0.0.1` and publish to NPM.

