### PR TITLE
feat: Allow selection of next-statement connections in line cursor (part II)

### DIFF
--- a/src/line_cursor.ts
+++ b/src/line_cursor.ts
@@ -91,10 +91,10 @@ export class LineCursor extends Marker {
     }
     let newNode = this.getPreviousNode(curNode, this.validLineNode);
 
+    // Skip the input (but not next) connection if there is a connected block.
     if (
       newNode &&
-      (newNode.getType() == ASTNode.types.INPUT ||
-        newNode.getType() == ASTNode.types.NEXT) &&
+      newNode.getType() == ASTNode.types.INPUT &&
       (newNode.getLocation() as Blockly.Connection).targetBlock()
     ) {
       newNode = this.getPreviousNode(newNode, this.validLineNode);


### PR DESCRIPTION
Allow selection of next-statement connections in line cursor.

This allows insertion of new blocks into a stack.

This finishes a change that was inadvertently only partially completed in #54.

Fixes #98.