### PR TITLE
fix: Allow line cursor next/prev to visit connected inputs

### DIFF
--- a/src/line_cursor.ts
+++ b/src/line_cursor.ts
@@ -44,14 +44,6 @@ export class LineCursor extends Marker {
     }
     let newNode = this.getNextNode(curNode, this.validLineNode);
 
-    // Skip the input (but not next) connection if there is a connected block.
-    if (
-      newNode &&
-      newNode.getType() === ASTNode.types.INPUT &&
-      (newNode.getLocation() as Blockly.Connection).targetBlock()
-    ) {
-      newNode = this.getNextNode(newNode, this.validLineNode);
-    }
     if (newNode) {
       this.setCurNode(newNode);
     }
@@ -90,15 +82,6 @@ export class LineCursor extends Marker {
       return null;
     }
     let newNode = this.getPreviousNode(curNode, this.validLineNode);
-
-    // Skip the input (but not next) connection if there is a connected block.
-    if (
-      newNode &&
-      newNode.getType() == ASTNode.types.INPUT &&
-      (newNode.getLocation() as Blockly.Connection).targetBlock()
-    ) {
-      newNode = this.getPreviousNode(newNode, this.validLineNode);
-    }
 
     if (newNode) {
       this.setCurNode(newNode);


### PR DESCRIPTION
Allow the next/prev methods on LineCursor to visit inputs, even if the input has a block connected to it.

Without this it's impossible to visit the connection between an statement input and the top block of the connected substack.

Fixes #99.