### PR TITLE
feat: open flyout or toolbox when pressing enter on the workspace

### DIFF
--- a/src/navigation.ts
+++ b/src/navigation.ts
@@ -1233,6 +1233,11 @@ export class Navigation {
       nodeType == Blockly.ASTNode.types.WORKSPACE
     ) {
       this.markAtCursor(workspace);
+      if (!workspace.getToolbox()) {
+        this.focusFlyout(workspace);
+      } else {
+        this.focusToolbox(workspace);
+      }
     } else if (nodeType == Blockly.ASTNode.types.BLOCK) {
       this.warn('Cannot mark a block.');
     } else if (nodeType == Blockly.ASTNode.types.STACK) {

--- a/src/navigation.ts
+++ b/src/navigation.ts
@@ -1233,10 +1233,10 @@ export class Navigation {
       nodeType == Blockly.ASTNode.types.WORKSPACE
     ) {
       this.markAtCursor(workspace);
-      if (!workspace.getToolbox()) {
-        this.focusFlyout(workspace);
-      } else {
+      if (workspace.getToolbox()) {
         this.focusToolbox(workspace);
+      } else {
+        this.focusFlyout(workspace);
       }
     } else if (nodeType == Blockly.ASTNode.types.BLOCK) {
       this.warn('Cannot mark a block.');


### PR DESCRIPTION
Fixes one part of #102 

Pressing enter when on a connection now marks that connection and opens the toolbox or flyout and moves the cursor there. The user can then navigate to a block in the flyout and press enter again to insert it.

After insertion, the marker still sticks around (even though it should be made transient) so fixing that is a follow up, already tracked in #102.