### PR TITLE
feat: Allow render switching by query string

### DIFF
--- a/test/index.ts
+++ b/test/index.ts
@@ -46,9 +46,13 @@ function loadScenario(workspace: Blockly.WorkspaceSvg) {
  * @returns The created workspace.
  */
 function createWorkspace(): Blockly.WorkspaceSvg {
+  console.log(location.search);
+  const renderer =
+        location.search.includes('geras') ? 'geras' :
+        location.search.includes('thrasos') ? 'thrasos' : 'zelos';
   const options = {
     toolbox: toolbox,
-    renderer: 'zelos',
+    renderer,
   };
   const blocklyDiv = document.getElementById('blocklyDiv')!;
   const workspace = Blockly.inject(blocklyDiv, options);


### PR DESCRIPTION
This change allows you to select the renderer to be used by appending "?geras" or "?thrasos" to the URL.  Zelos remains the default.
