### PR TITLE
feat: make it possible to copy a block from the flyout and paste it into the workspace

### DIFF
--- a/src/navigation_controller.ts
+++ b/src/navigation_controller.ts
@@ -536,16 +536,12 @@ export class NavigationController {
           switch (this.navigation.getState(workspace)) {
             case Constants.STATE.WORKSPACE:
               const curNode = workspace?.getCursor()?.getCurNode();
-              if (curNode && curNode.getSourceBlock()) {
-                const sourceBlock = curNode.getSourceBlock();
-                return !!(
-                  !Blockly.Gesture.inProgress() &&
-                  sourceBlock &&
-                  sourceBlock.isDeletable() &&
-                  sourceBlock.isMovable()
-                );
-              }
-              return false;
+              const source = curNode?.getSourceBlock();
+	              return !!(
+	                source?.isDeletable() &&
+	                source?.isMovable() &&
+	                !Blockly.Gesture.inProgress()
+	              );
             case Constants.STATE.FLYOUT:
               const flyoutWorkspace = workspace.getFlyout()?.getWorkspace();
               const sourceBlock = flyoutWorkspace


### PR DESCRIPTION
Fixes part of https://github.com/google/blockly-keyboard-experimentation/issues/103

The issue is that the shortcut is always passed the main workspace, but that it needs to get the cursor on the flyout workspace (not the main workspace) if that's currently active. I added code to query the correct workspace. Also, blocks in the flyout are not movable, so the other condition failed as well.

I changed paste to check if hte source workspace was a flyout and if so, paste to the main workspace.

This still pastes at the location of the marker, not the cursor. The marker location is set when entering the flyout. If the user copies in the flyout, returns to the main workspace, navigates, and pastes, they will still end up pasting at the site of the marker.

The fix to that issue is part of the general plan to remove or significantly reduce the marker, by making it transient and only active in specific situations. That's outside the scope of this change.