### PR TITLE
feat: Simplify workspace navigation flow

### DIFF
--- a/src/constants.ts
+++ b/src/constants.ts
@@ -28,7 +28,7 @@ export enum SHORTCUT_NAMES {
   IN = 'in',
   OUT = 'out',
   INSERT = 'insert',
-  ENTER_OR_MARK = 'enter_or_mark',
+  MARK = 'mark',
   DISCONNECT = 'disconnect',
   TOOLBOX = 'toolbox',
   EXIT = 'exit',
@@ -51,7 +51,6 @@ export enum SHORTCUT_NAMES {
   CONTEXT_OUT = 'context_out',
   CONTEXT_IN = 'context_in',
   CLEAN_UP = 'clean_up_workspace',
-  INTERCEPT_TAB = 'intercept_tab_navigation',
 }
 
 /**

--- a/src/index.ts
+++ b/src/index.ts
@@ -25,8 +25,7 @@ export class KeyboardNavigation {
     const navigationController = new NavigationController();
     navigationController.init();
     navigationController.addWorkspace(workspace);
-    // Turns on keyboard navigation.
-    navigationController.setHasAutoNavigationEnabled(true);
+    navigationController.enable(workspace);
     navigationController.listShortcuts();
 
     this.setGlowTheme();

--- a/src/navigation_controller.ts
+++ b/src/navigation_controller.ts
@@ -47,7 +47,6 @@ export class NavigationController {
   announcer: Announcer = new Announcer();
   shortcutDialog: ShortcutDialog = new ShortcutDialog();
 
-  isAutoNavigationEnabled: boolean = false;
   hasNavigationFocus: boolean = false;
 
   /**
@@ -139,22 +138,6 @@ export class NavigationController {
   }
 
   /**
-   * Sets whether the navigation controller should automatically intercept tab,
-   * enter, and escape navigation events to ensure that the user needs to
-   * explicitly enter and exit the Blockly environment for keyboard shortcuts to
-   * be enabled.
-   *
-   * This mode has no effect unless setHasFocus is correctly used to communicate
-   * focus gained and lost contexts.
-   *
-   * @param autoNavEnabled whether the controller should automatically
-   *     intercept navigation events.
-   */
-  setHasAutoNavigationEnabled(autoNavEnabled: boolean) {
-    this.isAutoNavigationEnabled = autoNavEnabled;
-  }
-
-  /**
    * Sets whether the navigation controller has focus. This has no side effect
    * unless auto navigation is enabled via setHasAutoNavigationEnabled.
    *
@@ -162,6 +145,36 @@ export class NavigationController {
    */
   setHasFocus(isFocused: boolean) {
     this.hasNavigationFocus = isFocused;
+  }
+
+  /**
+   * Determines whether keyboard navigation should be allowed based on the
+   * current state of the workspace.
+   *
+   * A return value of 'true' generally indicates that the workspace both has
+   * enabled keyboard navigation and is currently in a state (e.g. focus) that
+   * can support keyboard navigation.
+   *
+   * @param workspace the workspace in which keyboard navigation may be allowed.
+   * @returns whether keyboard navigation is currently allowed.
+   */
+  private isKeyboardNavigationCurrentlyAllowed(workspace: WorkspaceSvg) {
+    return workspace.keyboardAccessibilityMode && this.hasNavigationFocus;
+  }
+
+  /**
+   * Determines whether the provided workspace is currently keyboard navigable
+   * and editable.
+   *
+   * For the criteria on keyboard navigability, see
+   * isKeyboardNavigationCurrentlyAllowed.
+   *
+   * @param workspace the workspace in which keyboard editing may be allowed.
+   * @returns whether keyboard navigation and editing is currently allowed.
+   */
+  private isWorkspaceCurrentlyKeyboardEditable(workspace: WorkspaceSvg) {
+    return this.isKeyboardNavigationCurrentlyAllowed(workspace) &&
+      !workspace.options.readOnly;
   }
 
   /**
@@ -224,7 +237,8 @@ export class NavigationController {
     /** Go to the previous location. */
     previous: {
       name: Constants.SHORTCUT_NAMES.PREVIOUS,
-      preconditionFn: (workspace) => workspace.keyboardAccessibilityMode,
+      preconditionFn: (workspace) =>
+        this.isKeyboardNavigationCurrentlyAllowed(workspace),
       callback: (workspace, _, shortcut) => {
         const flyout = workspace.getFlyout();
         const toolbox = workspace.getToolbox() as Blockly.Toolbox;
@@ -274,7 +288,8 @@ export class NavigationController {
     /** Go to the out location. */
     out: {
       name: Constants.SHORTCUT_NAMES.OUT,
-      preconditionFn: (workspace) => workspace.keyboardAccessibilityMode,
+      preconditionFn: (workspace) =>
+        this.isKeyboardNavigationCurrentlyAllowed(workspace),
       callback: (workspace, _, shortcut) => {
         const toolbox = workspace.getToolbox() as Blockly.Toolbox;
         let isHandled = false;
@@ -303,7 +318,8 @@ export class NavigationController {
     /** Go to the next location. */
     next: {
       name: Constants.SHORTCUT_NAMES.NEXT,
-      preconditionFn: (workspace) => workspace.keyboardAccessibilityMode,
+      preconditionFn: (workspace) =>
+        this.isKeyboardNavigationCurrentlyAllowed(workspace),
       callback: (workspace, _, shortcut) => {
         const toolbox = workspace.getToolbox() as Blockly.Toolbox;
         const flyout = workspace.getFlyout();
@@ -337,7 +353,8 @@ export class NavigationController {
     /** Go to the in location. */
     in: {
       name: Constants.SHORTCUT_NAMES.IN,
-      preconditionFn: (workspace) => workspace.keyboardAccessibilityMode,
+      preconditionFn: (workspace) =>
+        this.isKeyboardNavigationCurrentlyAllowed(workspace),
       callback: (workspace, _, shortcut) => {
         const toolbox = workspace.getToolbox() as Blockly.Toolbox;
         let isHandled = false;
@@ -369,7 +386,7 @@ export class NavigationController {
     insert: {
       name: Constants.SHORTCUT_NAMES.INSERT,
       preconditionFn: (workspace) =>
-        workspace.keyboardAccessibilityMode && !workspace.options.readOnly,
+        this.isWorkspaceCurrentlyKeyboardEditable(workspace),
       callback: (workspace) => {
         switch (this.navigation.getState(workspace)) {
           case Constants.STATE.WORKSPACE:
@@ -385,56 +402,39 @@ export class NavigationController {
      * Mark the current location, insert a block from the flyout at
      * the marked location, or press a flyout button.
      */
-    enter_or_mark: {
-      name: Constants.SHORTCUT_NAMES.ENTER_OR_MARK,
-      preconditionFn: (workspace) => {
-        if (workspace.keyboardAccessibilityMode) {
-          // If keyboard navigation is enabled, 'enter' corresponds to location
-          // marking.
-          return !workspace.options.readOnly;
-        } else {
-          // If keyboard navigation is disabled, 'enter' corresponds to enabling
-          // navigation only if auto-navigation is enabled and it's appropriate
-          // to enable navigation right now (i.e. Blockly has focus).
-          return this.isAutoNavigationEnabled && this.hasNavigationFocus;
-        }
-      },
+    mark: {
+      name: Constants.SHORTCUT_NAMES.MARK,
+      preconditionFn: (workspace) =>
+        this.isWorkspaceCurrentlyKeyboardEditable(workspace),
       callback: (workspace) => {
-        if (workspace.keyboardAccessibilityMode) {
-          // Handle location marking.
-          let flyoutCursor;
-          let curNode;
-          let nodeType;
+        let flyoutCursor;
+        let curNode;
+        let nodeType;
 
-          switch (this.navigation.getState(workspace)) {
-            case Constants.STATE.WORKSPACE:
-              this.navigation.handleEnterForWS(workspace);
-              return true;
-            case Constants.STATE.FLYOUT:
-              flyoutCursor = this.navigation.getFlyoutCursor(workspace);
-              if (!flyoutCursor) {
-                return false;
-              }
-              curNode = flyoutCursor.getCurNode();
-              nodeType = curNode.getType();
-
-              switch (nodeType) {
-                case ASTNode.types.STACK:
-                  this.navigation.insertFromFlyout(workspace);
-                  break;
-                case ASTNode.types.BUTTON:
-                  this.navigation.triggerButtonCallback(workspace);
-                  break;
-              }
-
-              return true;
-            default:
+        switch (this.navigation.getState(workspace)) {
+          case Constants.STATE.WORKSPACE:
+            this.navigation.handleEnterForWS(workspace);
+            return true;
+          case Constants.STATE.FLYOUT:
+            flyoutCursor = this.navigation.getFlyoutCursor(workspace);
+            if (!flyoutCursor) {
               return false;
-          }
-        } else {
-          // Handling auto-navigation.
-          this.enable(workspace);
-          return true;
+            }
+            curNode = flyoutCursor.getCurNode();
+            nodeType = curNode.getType();
+
+            switch (nodeType) {
+              case ASTNode.types.STACK:
+                this.navigation.insertFromFlyout(workspace);
+                break;
+              case ASTNode.types.BUTTON:
+                this.navigation.triggerButtonCallback(workspace);
+                break;
+            }
+
+            return true;
+          default:
+            return false;
         }
       },
       keyCodes: [KeyCodes.ENTER],
@@ -444,7 +444,7 @@ export class NavigationController {
     disconnect: {
       name: Constants.SHORTCUT_NAMES.DISCONNECT,
       preconditionFn: (workspace) =>
-        workspace.keyboardAccessibilityMode && !workspace.options.readOnly,
+        this.isWorkspaceCurrentlyKeyboardEditable(workspace),
       callback: (workspace) => {
         switch (this.navigation.getState(workspace)) {
           case Constants.STATE.WORKSPACE:
@@ -461,7 +461,7 @@ export class NavigationController {
     focusToolbox: {
       name: Constants.SHORTCUT_NAMES.TOOLBOX,
       preconditionFn: (workspace) =>
-        workspace.keyboardAccessibilityMode && !workspace.options.readOnly,
+        this.isWorkspaceCurrentlyKeyboardEditable(workspace),
       callback: (workspace) => {
         switch (this.navigation.getState(workspace)) {
           case Constants.STATE.WORKSPACE:
@@ -481,7 +481,8 @@ export class NavigationController {
     /** Exit the current location and focus on the workspace. */
     exit: {
       name: Constants.SHORTCUT_NAMES.EXIT,
-      preconditionFn: (workspace) => workspace.keyboardAccessibilityMode,
+      preconditionFn: (workspace) =>
+        this.isKeyboardNavigationCurrentlyAllowed(workspace),
       callback: (workspace) => {
         switch (this.navigation.getState(workspace)) {
           case Constants.STATE.FLYOUT:
@@ -490,13 +491,6 @@ export class NavigationController {
           case Constants.STATE.TOOLBOX:
             this.navigation.focusWorkspace(workspace);
             return true;
-          case Constants.STATE.WORKSPACE:
-            // 'Esc' in the workspace should disable keyboard navigation and
-            // allow the user to resume tab-based navigation.
-            if (this.isAutoNavigationEnabled) {
-              this.disable(workspace);
-              return true;
-            } else return false;
           default:
             return false;
         }
@@ -509,7 +503,7 @@ export class NavigationController {
     wsMoveLeft: {
       name: Constants.SHORTCUT_NAMES.MOVE_WS_CURSOR_LEFT,
       preconditionFn: (workspace) =>
-        workspace.keyboardAccessibilityMode && !workspace.options.readOnly,
+        this.isWorkspaceCurrentlyKeyboardEditable(workspace),
       callback: (workspace) => {
         return this.navigation.moveWSCursor(workspace, -1, 0);
       },
@@ -520,7 +514,7 @@ export class NavigationController {
     wsMoveRight: {
       name: Constants.SHORTCUT_NAMES.MOVE_WS_CURSOR_RIGHT,
       preconditionFn: (workspace) =>
-        workspace.keyboardAccessibilityMode && !workspace.options.readOnly,
+        this.isWorkspaceCurrentlyKeyboardEditable(workspace),
       callback: (workspace) => {
         return this.navigation.moveWSCursor(workspace, 1, 0);
       },
@@ -531,7 +525,7 @@ export class NavigationController {
     wsMoveUp: {
       name: Constants.SHORTCUT_NAMES.MOVE_WS_CURSOR_UP,
       preconditionFn: (workspace) =>
-        workspace.keyboardAccessibilityMode && !workspace.options.readOnly,
+        this.isWorkspaceCurrentlyKeyboardEditable(workspace),
       callback: (workspace) => {
         return this.navigation.moveWSCursor(workspace, 0, -1);
       },
@@ -542,7 +536,7 @@ export class NavigationController {
     wsMoveDown: {
       name: Constants.SHORTCUT_NAMES.MOVE_WS_CURSOR_DOWN,
       preconditionFn: (workspace) =>
-        workspace.keyboardAccessibilityMode && !workspace.options.readOnly,
+        this.isWorkspaceCurrentlyKeyboardEditable(workspace),
       callback: (workspace) => {
         return this.navigation.moveWSCursor(workspace, 0, 1);
       },
@@ -553,10 +547,7 @@ export class NavigationController {
     copy: {
       name: Constants.SHORTCUT_NAMES.COPY,
       preconditionFn: (workspace) => {
-        if (
-          workspace.keyboardAccessibilityMode &&
-          !workspace.options.readOnly
-        ) {
+        if (this.isWorkspaceCurrentlyKeyboardEditable(workspace)) {
           const curNode = workspace.getCursor()?.getCurNode();
           if (curNode && curNode.getSourceBlock()) {
             const sourceBlock = curNode.getSourceBlock();
@@ -595,8 +586,7 @@ export class NavigationController {
     paste: {
       name: Constants.SHORTCUT_NAMES.PASTE,
       preconditionFn: (workspace) =>
-        workspace.keyboardAccessibilityMode &&
-        !workspace.options.readOnly &&
+        this.isWorkspaceCurrentlyKeyboardEditable(workspace) &&
         !Blockly.Gesture.inProgress(),
       callback: () => {
         if (!this.copyData || !this.copyWorkspace) return false;
@@ -614,10 +604,7 @@ export class NavigationController {
     cut: {
       name: Constants.SHORTCUT_NAMES.CUT,
       preconditionFn: (workspace) => {
-        if (
-          workspace.keyboardAccessibilityMode &&
-          !workspace.options.readOnly
-        ) {
+        if (this.isWorkspaceCurrentlyKeyboardEditable(workspace)) {
           const curNode = workspace.getCursor()?.getCurNode();
           if (curNode && curNode.getSourceBlock()) {
             const sourceBlock = curNode.getSourceBlock();
@@ -654,11 +641,8 @@ export class NavigationController {
     /** Keyboard shortcut to delete the block the cursor is currently on. */
     delete: {
       name: Constants.SHORTCUT_NAMES.DELETE,
-      preconditionFn: function (workspace) {
-        if (
-          workspace.keyboardAccessibilityMode &&
-          !workspace.options.readOnly
-        ) {
+      preconditionFn: (workspace) => {
+        if (this.isWorkspaceCurrentlyKeyboardEditable(workspace)) {
           const curNode = workspace.getCursor()?.getCurNode();
           if (curNode && curNode.getSourceBlock()) {
             const sourceBlock = curNode.getSourceBlock();
@@ -693,7 +677,7 @@ export class NavigationController {
     /** List all of the currently registered shortcuts. */
     announceShortcuts: {
       name: Constants.SHORTCUT_NAMES.LIST_SHORTCUTS,
-      callback: (workspace) => {
+      callback: () => {
         this.shortcutDialog.toggle();
         return true;
       },
@@ -716,7 +700,8 @@ export class NavigationController {
     /** Go to the next sibling of the cursor's current location. */
     nextSibling: {
       name: Constants.SHORTCUT_NAMES.GO_TO_NEXT_SIBLING,
-      preconditionFn: (workspace) => workspace.keyboardAccessibilityMode,
+      preconditionFn: (workspace) =>
+        this.isKeyboardNavigationCurrentlyAllowed(workspace),
       // Jump to the next node at the same level, when in the workspace.
       callback: (workspace, e, shortcut) => {
         const cursor = workspace.getCursor() as LineCursor;
@@ -740,7 +725,8 @@ export class NavigationController {
     /** Go to the previous sibling of the cursor's current location. */
     previousSibling: {
       name: Constants.SHORTCUT_NAMES.GO_TO_PREVIOUS_SIBLING,
-      preconditionFn: (workspace) => workspace.keyboardAccessibilityMode,
+      preconditionFn: (workspace) =>
+        this.isKeyboardNavigationCurrentlyAllowed(workspace),
       // Jump to the previous node at the same level, when in the workspace.
       callback: (workspace, e, shortcut) => {
         const cursor = workspace.getCursor() as LineCursor;
@@ -764,7 +750,8 @@ export class NavigationController {
     /** Jump to the root of the current stack. */
     jumpToRoot: {
       name: Constants.SHORTCUT_NAMES.JUMP_TO_ROOT,
-      preconditionFn: (workspace) => workspace.keyboardAccessibilityMode,
+      preconditionFn: (workspace) =>
+        this.isKeyboardNavigationCurrentlyAllowed(workspace),
       // Jump to the root of the current stack.
       callback: (workspace) => {
         const cursor = workspace.getCursor();
@@ -787,7 +774,8 @@ export class NavigationController {
     /** Move the cursor out of its current context, such as a loop block. */
     contextOut: {
       name: Constants.SHORTCUT_NAMES.CONTEXT_OUT,
-      preconditionFn: (workspace) => workspace.keyboardAccessibilityMode,
+      preconditionFn: (workspace) =>
+        this.isKeyboardNavigationCurrentlyAllowed(workspace),
       callback: (workspace) => {
         if (this.navigation.getState(workspace) == Constants.STATE.WORKSPACE) {
           this.announcer.setText('context out');
@@ -805,7 +793,8 @@ export class NavigationController {
     /** Move the cursor in a level of context, such as into a loop. */
     contextIn: {
       name: Constants.SHORTCUT_NAMES.CONTEXT_IN,
-      preconditionFn: (workspace) => workspace.keyboardAccessibilityMode,
+      preconditionFn: (workspace) =>
+        this.isKeyboardNavigationCurrentlyAllowed(workspace),
       // Print out the type of the current node.
       callback: (workspace) => {
         if (this.navigation.getState(workspace) == Constants.STATE.WORKSPACE) {
@@ -831,24 +820,6 @@ export class NavigationController {
         return true;
       },
       keyCodes: [KeyCodes.C],
-    },
-
-    /**
-     * Register a tab override so that tab navigation is disabled while keyboard
-     * navigation is enabled.
-     */
-    interceptTab: {
-      name: Constants.SHORTCUT_NAMES.INTERCEPT_TAB,
-      preconditionFn: (workspace) =>
-        this.isAutoNavigationEnabled && workspace.keyboardAccessibilityMode,
-      callback: (_, event) => {
-        event.preventDefault();
-        return true;
-      },
-      keyCodes: [
-        createSerializedKey(KeyCodes.TAB, [KeyCodes.SHIFT]),
-        KeyCodes.TAB,
-      ],
     },
   };
 

--- a/src/navigation_controller.ts
+++ b/src/navigation_controller.ts
@@ -158,7 +158,7 @@ export class NavigationController {
    * @param workspace the workspace in which keyboard navigation may be allowed.
    * @returns whether keyboard navigation is currently allowed.
    */
-  private isKeyboardNavigationCurrentlyAllowed(workspace: WorkspaceSvg) {
+  private canCurrentlyNavigate(workspace: WorkspaceSvg) {
     return workspace.keyboardAccessibilityMode && this.hasNavigationFocus;
   }
 
@@ -166,15 +166,13 @@ export class NavigationController {
    * Determines whether the provided workspace is currently keyboard navigable
    * and editable.
    *
-   * For the criteria on keyboard navigability, see
-   * isKeyboardNavigationCurrentlyAllowed.
+   * For the navigability criteria, see canCurrentlyKeyboardNavigate.
    *
    * @param workspace the workspace in which keyboard editing may be allowed.
    * @returns whether keyboard navigation and editing is currently allowed.
    */
-  private isWorkspaceCurrentlyKeyboardEditable(workspace: WorkspaceSvg) {
-    return this.isKeyboardNavigationCurrentlyAllowed(workspace) &&
-      !workspace.options.readOnly;
+  private canCurrentlyEdit(workspace: WorkspaceSvg) {
+    return this.canCurrentlyNavigate(workspace) && !workspace.options.readOnly;
   }
 
   /**
@@ -237,8 +235,7 @@ export class NavigationController {
     /** Go to the previous location. */
     previous: {
       name: Constants.SHORTCUT_NAMES.PREVIOUS,
-      preconditionFn: (workspace) =>
-        this.isKeyboardNavigationCurrentlyAllowed(workspace),
+      preconditionFn: (workspace) => this.canCurrentlyNavigate(workspace),
       callback: (workspace, _, shortcut) => {
         const flyout = workspace.getFlyout();
         const toolbox = workspace.getToolbox() as Blockly.Toolbox;
@@ -288,8 +285,7 @@ export class NavigationController {
     /** Go to the out location. */
     out: {
       name: Constants.SHORTCUT_NAMES.OUT,
-      preconditionFn: (workspace) =>
-        this.isKeyboardNavigationCurrentlyAllowed(workspace),
+      preconditionFn: (workspace) => this.canCurrentlyNavigate(workspace),
       callback: (workspace, _, shortcut) => {
         const toolbox = workspace.getToolbox() as Blockly.Toolbox;
         let isHandled = false;
@@ -318,8 +314,7 @@ export class NavigationController {
     /** Go to the next location. */
     next: {
       name: Constants.SHORTCUT_NAMES.NEXT,
-      preconditionFn: (workspace) =>
-        this.isKeyboardNavigationCurrentlyAllowed(workspace),
+      preconditionFn: (workspace) => this.canCurrentlyNavigate(workspace),
       callback: (workspace, _, shortcut) => {
         const toolbox = workspace.getToolbox() as Blockly.Toolbox;
         const flyout = workspace.getFlyout();
@@ -353,8 +348,7 @@ export class NavigationController {
     /** Go to the in location. */
     in: {
       name: Constants.SHORTCUT_NAMES.IN,
-      preconditionFn: (workspace) =>
-        this.isKeyboardNavigationCurrentlyAllowed(workspace),
+      preconditionFn: (workspace) => this.canCurrentlyNavigate(workspace),
       callback: (workspace, _, shortcut) => {
         const toolbox = workspace.getToolbox() as Blockly.Toolbox;
         let isHandled = false;
@@ -385,8 +379,7 @@ export class NavigationController {
     /** Connect a block to a marked location. */
     insert: {
       name: Constants.SHORTCUT_NAMES.INSERT,
-      preconditionFn: (workspace) =>
-        this.isWorkspaceCurrentlyKeyboardEditable(workspace),
+      preconditionFn: (workspace) => this.canCurrentlyEdit(workspace),
       callback: (workspace) => {
         switch (this.navigation.getState(workspace)) {
           case Constants.STATE.WORKSPACE:
@@ -404,8 +397,7 @@ export class NavigationController {
      */
     mark: {
       name: Constants.SHORTCUT_NAMES.MARK,
-      preconditionFn: (workspace) =>
-        this.isWorkspaceCurrentlyKeyboardEditable(workspace),
+      preconditionFn: (workspace) => this.canCurrentlyEdit(workspace),
       callback: (workspace) => {
         let flyoutCursor;
         let curNode;
@@ -443,8 +435,7 @@ export class NavigationController {
     /** Disconnect two blocks. */
     disconnect: {
       name: Constants.SHORTCUT_NAMES.DISCONNECT,
-      preconditionFn: (workspace) =>
-        this.isWorkspaceCurrentlyKeyboardEditable(workspace),
+      preconditionFn: (workspace) => this.canCurrentlyEdit(workspace),
       callback: (workspace) => {
         switch (this.navigation.getState(workspace)) {
           case Constants.STATE.WORKSPACE:
@@ -460,8 +451,7 @@ export class NavigationController {
     /** Move focus to or from the toolbox. */
     focusToolbox: {
       name: Constants.SHORTCUT_NAMES.TOOLBOX,
-      preconditionFn: (workspace) =>
-        this.isWorkspaceCurrentlyKeyboardEditable(workspace),
+      preconditionFn: (workspace) => this.canCurrentlyEdit(workspace),
       callback: (workspace) => {
         switch (this.navigation.getState(workspace)) {
           case Constants.STATE.WORKSPACE:
@@ -481,8 +471,7 @@ export class NavigationController {
     /** Exit the current location and focus on the workspace. */
     exit: {
       name: Constants.SHORTCUT_NAMES.EXIT,
-      preconditionFn: (workspace) =>
-        this.isKeyboardNavigationCurrentlyAllowed(workspace),
+      preconditionFn: (workspace) => this.canCurrentlyNavigate(workspace),
       callback: (workspace) => {
         switch (this.navigation.getState(workspace)) {
           case Constants.STATE.FLYOUT:
@@ -502,8 +491,7 @@ export class NavigationController {
     /** Move the cursor on the workspace to the left. */
     wsMoveLeft: {
       name: Constants.SHORTCUT_NAMES.MOVE_WS_CURSOR_LEFT,
-      preconditionFn: (workspace) =>
-        this.isWorkspaceCurrentlyKeyboardEditable(workspace),
+      preconditionFn: (workspace) => this.canCurrentlyEdit(workspace),
       callback: (workspace) => {
         return this.navigation.moveWSCursor(workspace, -1, 0);
       },
@@ -513,8 +501,7 @@ export class NavigationController {
     /** Move the cursor on the workspace to the right. */
     wsMoveRight: {
       name: Constants.SHORTCUT_NAMES.MOVE_WS_CURSOR_RIGHT,
-      preconditionFn: (workspace) =>
-        this.isWorkspaceCurrentlyKeyboardEditable(workspace),
+      preconditionFn: (workspace) => this.canCurrentlyEdit(workspace),
       callback: (workspace) => {
         return this.navigation.moveWSCursor(workspace, 1, 0);
       },
@@ -524,8 +511,7 @@ export class NavigationController {
     /** Move the cursor on the workspace up. */
     wsMoveUp: {
       name: Constants.SHORTCUT_NAMES.MOVE_WS_CURSOR_UP,
-      preconditionFn: (workspace) =>
-        this.isWorkspaceCurrentlyKeyboardEditable(workspace),
+      preconditionFn: (workspace) => this.canCurrentlyEdit(workspace),
       callback: (workspace) => {
         return this.navigation.moveWSCursor(workspace, 0, -1);
       },
@@ -535,8 +521,7 @@ export class NavigationController {
     /** Move the cursor on the workspace down. */
     wsMoveDown: {
       name: Constants.SHORTCUT_NAMES.MOVE_WS_CURSOR_DOWN,
-      preconditionFn: (workspace) =>
-        this.isWorkspaceCurrentlyKeyboardEditable(workspace),
+      preconditionFn: (workspace) => this.canCurrentlyEdit(workspace),
       callback: (workspace) => {
         return this.navigation.moveWSCursor(workspace, 0, 1);
       },
@@ -547,7 +532,7 @@ export class NavigationController {
     copy: {
       name: Constants.SHORTCUT_NAMES.COPY,
       preconditionFn: (workspace) => {
-        if (this.isWorkspaceCurrentlyKeyboardEditable(workspace)) {
+        if (this.canCurrentlyEdit(workspace)) {
           const curNode = workspace.getCursor()?.getCurNode();
           if (curNode && curNode.getSourceBlock()) {
             const sourceBlock = curNode.getSourceBlock();
@@ -586,8 +571,7 @@ export class NavigationController {
     paste: {
       name: Constants.SHORTCUT_NAMES.PASTE,
       preconditionFn: (workspace) =>
-        this.isWorkspaceCurrentlyKeyboardEditable(workspace) &&
-        !Blockly.Gesture.inProgress(),
+        this.canCurrentlyEdit(workspace) && !Blockly.Gesture.inProgress(),
       callback: () => {
         if (!this.copyData || !this.copyWorkspace) return false;
         return this.navigation.paste(this.copyData, this.copyWorkspace);
@@ -604,7 +588,7 @@ export class NavigationController {
     cut: {
       name: Constants.SHORTCUT_NAMES.CUT,
       preconditionFn: (workspace) => {
-        if (this.isWorkspaceCurrentlyKeyboardEditable(workspace)) {
+        if (this.canCurrentlyEdit(workspace)) {
           const curNode = workspace.getCursor()?.getCurNode();
           if (curNode && curNode.getSourceBlock()) {
             const sourceBlock = curNode.getSourceBlock();
@@ -642,7 +626,7 @@ export class NavigationController {
     delete: {
       name: Constants.SHORTCUT_NAMES.DELETE,
       preconditionFn: (workspace) => {
-        if (this.isWorkspaceCurrentlyKeyboardEditable(workspace)) {
+        if (this.canCurrentlyEdit(workspace)) {
           const curNode = workspace.getCursor()?.getCurNode();
           if (curNode && curNode.getSourceBlock()) {
             const sourceBlock = curNode.getSourceBlock();
@@ -700,8 +684,7 @@ export class NavigationController {
     /** Go to the next sibling of the cursor's current location. */
     nextSibling: {
       name: Constants.SHORTCUT_NAMES.GO_TO_NEXT_SIBLING,
-      preconditionFn: (workspace) =>
-        this.isKeyboardNavigationCurrentlyAllowed(workspace),
+      preconditionFn: (workspace) => this.canCurrentlyNavigate(workspace),
       // Jump to the next node at the same level, when in the workspace.
       callback: (workspace, e, shortcut) => {
         const cursor = workspace.getCursor() as LineCursor;
@@ -725,8 +708,7 @@ export class NavigationController {
     /** Go to the previous sibling of the cursor's current location. */
     previousSibling: {
       name: Constants.SHORTCUT_NAMES.GO_TO_PREVIOUS_SIBLING,
-      preconditionFn: (workspace) =>
-        this.isKeyboardNavigationCurrentlyAllowed(workspace),
+      preconditionFn: (workspace) => this.canCurrentlyNavigate(workspace),
       // Jump to the previous node at the same level, when in the workspace.
       callback: (workspace, e, shortcut) => {
         const cursor = workspace.getCursor() as LineCursor;
@@ -750,8 +732,7 @@ export class NavigationController {
     /** Jump to the root of the current stack. */
     jumpToRoot: {
       name: Constants.SHORTCUT_NAMES.JUMP_TO_ROOT,
-      preconditionFn: (workspace) =>
-        this.isKeyboardNavigationCurrentlyAllowed(workspace),
+      preconditionFn: (workspace) => this.canCurrentlyNavigate(workspace),
       // Jump to the root of the current stack.
       callback: (workspace) => {
         const cursor = workspace.getCursor();
@@ -774,8 +755,7 @@ export class NavigationController {
     /** Move the cursor out of its current context, such as a loop block. */
     contextOut: {
       name: Constants.SHORTCUT_NAMES.CONTEXT_OUT,
-      preconditionFn: (workspace) =>
-        this.isKeyboardNavigationCurrentlyAllowed(workspace),
+      preconditionFn: (workspace) => this.canCurrentlyNavigate(workspace),
       callback: (workspace) => {
         if (this.navigation.getState(workspace) == Constants.STATE.WORKSPACE) {
           this.announcer.setText('context out');
@@ -793,8 +773,7 @@ export class NavigationController {
     /** Move the cursor in a level of context, such as into a loop. */
     contextIn: {
       name: Constants.SHORTCUT_NAMES.CONTEXT_IN,
-      preconditionFn: (workspace) =>
-        this.isKeyboardNavigationCurrentlyAllowed(workspace),
+      preconditionFn: (workspace) => this.canCurrentlyNavigate(workspace),
       // Print out the type of the current node.
       callback: (workspace) => {
         if (this.navigation.getState(workspace) == Constants.STATE.WORKSPACE) {


### PR DESCRIPTION
Fixes part of #101
Fixes #89

This change removes the need for using enter and escape to enable keyboard navigation when the workspace is focused.

Instead, simply focusing the workspace is sufficient to allow keyboard navigation. Note that this PR goes back to the previous behavior of always enabling keyboard navigation on page load and instead limits the preconditions of navigation keys to check focus rather than feature enabled state. This allows for #89 to be fully mitigated. Since keyboard navigation is never disabled, the cursor position is never lost (and thus doesn't need to be cached). The removal of enter/escape fixes the first part of #101.

This PR also performs some other minor cleanup work in ``navigation_controller.ts``.