### PR TITLE
feat: Only init the navigation cursor when needed

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -36,10 +36,10 @@ export class KeyboardNavigation {
     workspace.getParentSvg().removeAttribute('tabindex');
 
     workspace.getSvgGroup().addEventListener('focus', () => {
-      navigationController.setHasFocus(true);
+      navigationController.setHasFocus(workspace, true);
     });
     workspace.getSvgGroup().addEventListener('blur', () => {
-      navigationController.setHasFocus(false);
+      navigationController.setHasFocus(workspace, false);
     });
   }
 

--- a/src/navigation.ts
+++ b/src/navigation.ts
@@ -535,14 +535,15 @@ export class Navigation {
    * top block on a workspace or to the workspace.
    *
    * @param workspace The workspace to focus on.
+   * @param keepCursorPosition Whether to retain the cursor's previous position.
    */
-  focusWorkspace(workspace: Blockly.WorkspaceSvg) {
+  focusWorkspace(workspace: Blockly.WorkspaceSvg, keepCursorPosition: boolean = false) {
     workspace.hideChaff();
     const reset = !!workspace.getToolbox();
 
     this.resetFlyout(workspace, reset);
     this.setState(workspace, Constants.STATE.WORKSPACE);
-    this.setCursorOnWorkspaceFocus(workspace);
+    this.setCursorOnWorkspaceFocus(workspace, keepCursorPosition);
   }
 
   /**
@@ -551,11 +552,16 @@ export class Navigation {
    * the workspace.
    *
    * @param workspace The main Blockly workspace.
+   * @param keepPosition Whether to retain the cursor's previous position.
    */
-  setCursorOnWorkspaceFocus(workspace: Blockly.WorkspaceSvg) {
+  setCursorOnWorkspaceFocus(workspace: Blockly.WorkspaceSvg, keepPosition: boolean) {
     const topBlocks = workspace.getTopBlocks(true);
     const cursor = workspace.getCursor();
     if (!cursor) {
+      return;
+    }
+    if (cursor.getCurNode() && keepPosition) {
+      // Retain the cursor's previous position since it's set.
       return;
     }
     const wsCoordinates = new Blockly.utils.Coordinate(
@@ -1128,7 +1134,6 @@ export class Navigation {
       !workspace.keyboardAccessibilityMode
     ) {
       workspace.keyboardAccessibilityMode = true;
-      this.focusWorkspace(workspace);
     }
   }
 

--- a/src/navigation_controller.ts
+++ b/src/navigation_controller.ts
@@ -138,13 +138,18 @@ export class NavigationController {
   }
 
   /**
-   * Sets whether the navigation controller has focus. This has no side effect
-   * unless auto navigation is enabled via setHasAutoNavigationEnabled.
+   * Sets whether the navigation controller has focus. This will enable keyboard
+   * navigation if focus is now gained. Additionally, the cursor may be reset if
+   * it hasn't already been positioned in the workspace.
    *
+   * @param workspace the workspace that now has input focus.
    * @param isFocused whether the environment has browser focus.
    */
-  setHasFocus(isFocused: boolean) {
+  setHasFocus(workspace: WorkspaceSvg, isFocused: boolean) {
     this.hasNavigationFocus = isFocused;
+    if (isFocused) {
+      this.navigation.focusWorkspace(workspace, true);
+    }
   }
 
   /**


### PR DESCRIPTION
Fixes #140

This introduces improved initialization logic around the navigation cursor whereby it's only initialized upon focus (with previous position being retained when navigating back to the workspace after tabbing out of it) rather than upon enabling the controller (since the cursor doesn't actually need to be active when navigation isn't enabled).

Behaviorally, this change results in the blinking cursor mentioned in #140 not existing. It also has the nice benefit of highlighting the first top-level block upon tabbing to the workspace (which will affect readout with a screenreader enabled, but I think in a way that's consistent with other a11y environments--often the first interactive element is enabled by default).

Separately, this PR also fixes a small documentation inconsistency.
