### PR TITLE
fix: Adjust the focus outline for the workspace so it is more visible

### DIFF
--- a/test/index.html
+++ b/test/index.html
@@ -29,18 +29,18 @@
         width: 100%;
         max-height: 100%;
         position: relative;
-        --outline-width: 3px;
+        --outline-width: 5px;
       }
 
-      .blocklyMainBackground {
-        height: calc(100% - var(--outline-width));
-        width: calc(100% - var(--outline-width));
+      .blocklyWorkspace:focus .blocklyMainBackground {
+        outline: Highlight solid var(--outline-width);
+        outline-offset: -5px;
       }
 
       .blocklyFlyout {
         top: var(--outline-width);
         left: var(--outline-width);
-        height: calc(100% - calc(var(--outline-width) * 2.5));
+        height: calc(100% - calc(var(--outline-width) * 2));
       }
 
       pre,


### PR DESCRIPTION
Fixes #81 

This fixes the previous hack to get the focus outline to display more prominently on the workspace.

I've opted to use the Highlight colour for better cross browser support as opposed to --webkit-focus-ring-color. This shows up as a different colour on webkit browsers.

Note: in my tests, Firefox does not show any focus on the workspace after the tabindex was explicitly removed from the container elements.