### PR TITLE
chore: remove verbose shortcut console log

### DIFF
--- a/src/shortcut_dialog.ts
+++ b/src/shortcut_dialog.ts
@@ -135,9 +135,6 @@ export class ShortcutDialog {
           `;
 
       for (const keyboardShortcut of shortcuts) {
-        console.log(keyboardShortcut, ShortcutRegistry.registry.getKeyCodesByShortcutName(
-              keyboardShortcut
-            ));
         if (categoryShortcuts.includes(keyboardShortcut)) {
           const codeArray =
             ShortcutRegistry.registry.getKeyCodesByShortcutName(


### PR DESCRIPTION
This makes it hard to follow other debug output and doesn't seem useful now the shortcuts dialog works.