### PR TITLE
chore: remove verbose shortcut console log

### DIFF
--- a/src/shortcut_dialog.ts
+++ b/src/shortcut_dialog.ts
@@ -135,9 +135,6 @@ export class ShortcutDialog {
           `;
 
       for (const keyboardShortcut of shortcuts) {
-        console.log(keyboardShortcut, ShortcutRegistry.registry.getKeyCodesByShortcutName(
-              keyboardShortcut
-            ));
         if (categoryShortcuts.includes(keyboardShortcut)) {
           const codeArray =
             ShortcutRegistry.registry.getKeyCodesByShortcutName(


### PR DESCRIPTION
This is a copy of https://github.com/google/blockly-keyboard-experimentation/pull/153

Thanks @microbit-matt-hillsdon and let me know if you have any CLA issues.