### PR TITLE
fix: add a focus listener on the parent svg

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -41,6 +41,14 @@ export class KeyboardNavigation {
     workspace.getSvgGroup().addEventListener('blur', () => {
       navigationController.setHasFocus(workspace, false);
     });
+    // Temporary workaround for #136.
+    // TODO(#136): fix in core.
+    workspace.getParentSvg().addEventListener('focus', () => {
+      navigationController.setHasFocus(workspace, true);
+    });
+    workspace.getParentSvg().addEventListener('blur', () => {
+      navigationController.setHasFocus(workspace, false);
+    });
   }
 
   /**

--- a/src/navigation_controller.ts
+++ b/src/navigation_controller.ts
@@ -124,6 +124,12 @@ export class NavigationController {
    */
   addWorkspace(workspace: WorkspaceSvg) {
     this.navigation.addWorkspace(workspace);
+
+    // Temporary workaround for #136.
+    // TODO(#136): fix in core.
+    workspace.getParentSvg().addEventListener('focus', () => {
+      this.setHasFocus(workspace, true);
+    });
   }
 
   /**

--- a/src/navigation_controller.ts
+++ b/src/navigation_controller.ts
@@ -124,12 +124,6 @@ export class NavigationController {
    */
   addWorkspace(workspace: WorkspaceSvg) {
     this.navigation.addWorkspace(workspace);
-
-    // Temporary workaround for #136.
-    // TODO(#136): fix in core.
-    workspace.getParentSvg().addEventListener('focus', () => {
-      this.setHasFocus(workspace, true);
-    });
   }
 
   /**


### PR DESCRIPTION
This works around the issue reported in #136 to unblock testing, but does not fix the root cause.