### PR TITLE
fix: use valid colour in second colour picker

### DIFF
--- a/test/loadTestBlocks.js
+++ b/test/loadTestBlocks.js
@@ -236,7 +236,7 @@ const simpleCircle = {
                     'type': 'colour_picker',
                     'id': 'gq(POne}j:hVw%C3t{vx',
                     'fields': {
-                      'COLOUR': '#f59b42',
+                      'COLOUR': '#ffff00',
                     },
                   },
                 },


### PR DESCRIPTION
Patches over #68 by using a valid colour as the starting value. 