### PR TITLE
feat: Press enter on block to open action menu

### DIFF
--- a/src/navigation.ts
+++ b/src/navigation.ts
@@ -1231,13 +1231,15 @@ export class Navigation {
    */
   handleEnterForWS(workspace: Blockly.WorkspaceSvg) {
     const cursor = workspace.getCursor();
-    if (!cursor) {
-      return;
-    }
+    if (!cursor) return;
     const curNode = cursor.getCurNode();
     const nodeType = curNode.getType();
     if (nodeType == Blockly.ASTNode.types.FIELD) {
       (curNode.getLocation() as Blockly.Field).showEditor();
+    } else if (nodeType == Blockly.ASTNode.types.BLOCK) {
+      const fakeEvent = new PointerEvent('pointerdown');
+      // FIXME: set coordinates.
+      (curNode.getLocation() as Blockly.BlockSvg).showContextMenu(fakeEvent);
     } else if (
       curNode.isConnection() ||
       nodeType == Blockly.ASTNode.types.WORKSPACE
@@ -1248,8 +1250,6 @@ export class Navigation {
       } else {
         this.focusFlyout(workspace);
       }
-    } else if (nodeType == Blockly.ASTNode.types.BLOCK) {
-      this.warn('Cannot mark a block.');
     } else if (nodeType == Blockly.ASTNode.types.STACK) {
       this.warn('Cannot mark a stack.');
     }

--- a/src/navigation.ts
+++ b/src/navigation.ts
@@ -1237,8 +1237,7 @@ export class Navigation {
     if (nodeType == Blockly.ASTNode.types.FIELD) {
       (curNode.getLocation() as Blockly.Field).showEditor();
     } else if (nodeType == Blockly.ASTNode.types.BLOCK) {
-      const fakeEvent = new PointerEvent('pointerdown');
-      // FIXME: set coordinates.
+      const fakeEvent = fakeEventForNode(curNode);
       (curNode.getLocation() as Blockly.BlockSvg).showContextMenu(fakeEvent);
     } else if (
       curNode.isConnection() ||
@@ -1332,4 +1331,33 @@ export class Navigation {
       this.removeWorkspace(workspace);
     }
   }
+}
+
+/**
+ * Create a fake PointerEvent for opening the context menu for the
+ * given ASTNode.
+ *
+ * Currently only works for block nodes.
+ *
+ * @param node The node to open the context menu for.
+ * @returns A synthetic pointerdown PointerEvent.
+ */
+function fakeEventForNode(node: Blockly.ASTNode): PointerEvent {
+  if (node.getType() !== Blockly.ASTNode.types.BLOCK) {
+    throw new TypeError('can only create PointerEvents for BLOCK nodes');
+  }
+
+  // Get the location of the top-left corner of the block in
+  // screen coordinates.
+  const block = node.getLocation() as Blockly.BlockSvg;
+  const coords = Blockly.utils.svgMath.wsToScreenCoordinates(
+    block.workspace,
+    block.getRelativeToSurfaceXY(),
+  );
+
+  // Create a fake event for the context menu code to work from.
+  return new PointerEvent('pointerdown', {
+    clientX: coords.x,
+    clientY: coords.y,
+  });
 }

--- a/src/navigation_controller.ts
+++ b/src/navigation_controller.ts
@@ -397,11 +397,14 @@ export class NavigationController {
     },
 
     /**
-     * Mark the current location, insert a block from the flyout at
-     * the marked location, or press a flyout button.
+     * Enter key:
+     *
+     * - On the flyout: press a button or choose a block to place.
+     * - On a stack: open a block's context menu or field's editor.
+     * - On the workspace: open the context menu.
      */
-    mark: {
-      name: Constants.SHORTCUT_NAMES.MARK,
+    enter: {
+      name: Constants.SHORTCUT_NAMES.MARK,  // FIXME
       preconditionFn: (workspace) => this.canCurrentlyEdit(workspace),
       callback: (workspace) => {
         let flyoutCursor;


### PR DESCRIPTION
Part of #130.

Introduce the "action menu", which uses the `Blockly.ContextMenu` machinery to display a custom menu of shortcut actions on a block when you press enter.

For now the action menu contents are identical to the normal context menu contents, but it is created in a way that will allow us to control the contents of the action menu independently of the block's custom context menu (or request not to have a context menu at all).
