### PR TITLE
feat: keyboard navigation delete option in context menu

### DIFF
--- a/src/navigation_controller.ts
+++ b/src/navigation_controller.ts
@@ -229,7 +229,7 @@ export class NavigationController {
    * Precondition function for deleting a block from keyboard
    * navigation. This precondition is shared between keyboard shortcuts
    * and context menu items.
-   * 
+   *
    * FIXME: This should be better encapsulated.
    *
    * @param workspace The `WorkspaceSvg` where the shortcut was
@@ -251,7 +251,7 @@ export class NavigationController {
    * Callback function for deleting a block from keyboard
    * navigation. This callback is shared between keyboard shortcuts
    * and context menu items.
-   * 
+   *
    * FIXME: This should be better encapsulated.
    *
    * @param workspace The `WorkspaceSvg` where the shortcut was
@@ -260,7 +260,7 @@ export class NavigationController {
    *     if called from a context menu.
    * @returns True if this function successfully handled deletion.
    */
-  protected deleteCallbackFn(workspace: WorkspaceSvg, e: Event|null) {
+  protected deleteCallbackFn(workspace: WorkspaceSvg, e: Event | null) {
     const cursor = workspace.getCursor();
     if (!cursor) {
       return false;
@@ -464,7 +464,7 @@ export class NavigationController {
      * - On the workspace: open the context menu.
      */
     enter: {
-      name: Constants.SHORTCUT_NAMES.MARK,  // FIXME
+      name: Constants.SHORTCUT_NAMES.MARK, // FIXME
       preconditionFn: (workspace) => this.canCurrentlyEdit(workspace),
       callback: (workspace) => {
         let flyoutCursor;
@@ -605,11 +605,11 @@ export class NavigationController {
             case Constants.STATE.WORKSPACE:
               const curNode = workspace?.getCursor()?.getCurNode();
               const source = curNode?.getSourceBlock();
-	              return !!(
-	                source?.isDeletable() &&
-	                source?.isMovable() &&
-	                !Blockly.Gesture.inProgress()
-	              );
+              return !!(
+                source?.isDeletable() &&
+                source?.isMovable() &&
+                !Blockly.Gesture.inProgress()
+              );
             case Constants.STATE.FLYOUT:
               const flyoutWorkspace = workspace.getFlyout()?.getWorkspace();
               const sourceBlock = flyoutWorkspace
@@ -866,7 +866,8 @@ export class NavigationController {
    * but only calls the keyboard callback.
    */
   protected registerDeleteAction() {
-    const originalDeleteItem = ContextMenuRegistry.registry.getItem('blockDelete');
+    const originalDeleteItem =
+      ContextMenuRegistry.registry.getItem('blockDelete');
     if (!originalDeleteItem) return;
 
     const deleteItem: ContextMenuRegistry.RegistryItem = {
@@ -881,7 +882,8 @@ export class NavigationController {
 
         // Run the original precondition code, from the context menu option.
         // If the item would be hidden or disabled, respect it.
-        const originalPreconditionResult = originalDeleteItem.preconditionFn(scope);
+        const originalPreconditionResult =
+          originalDeleteItem.preconditionFn(scope);
         if (!ws || originalPreconditionResult != 'enabled') {
           return originalPreconditionResult;
         }
@@ -901,8 +903,8 @@ export class NavigationController {
       },
       scopeType: ContextMenuRegistry.ScopeType.BLOCK,
       id: 'blockDeleteFromContextMenu',
-      weight: 10
-    }
+      weight: 10,
+    };
 
     // FIXME: Decide whether to unregister the original item.
     ContextMenuRegistry.registry.register(deleteItem);

--- a/src/navigation_controller.ts
+++ b/src/navigation_controller.ts
@@ -269,9 +269,7 @@ export class NavigationController {
       e.preventDefault();
     }
     // Don't delete while dragging.  Jeez.
-    if (Blockly.Gesture.inProgress()) {
-      return false;
-    }
+    if (Blockly.Gesture.inProgress()) false;
     this.navigation.moveCursorOnBlockDelete(workspace, sourceBlock);
     sourceBlock.checkAndDelete();
     return true;

--- a/src/navigation_controller.ts
+++ b/src/navigation_controller.ts
@@ -230,7 +230,8 @@ export class NavigationController {
    * navigation. This precondition is shared between keyboard shortcuts
    * and context menu items.
    * 
-   * FIXME: This should be better encapsulated
+   * FIXME: This should be better encapsulated.
+   *
    * @param workspace The `WorkspaceSvg` where the shortcut was
    *     invoked.
    * @returns True iff `deleteCallbackFn` function should be called.
@@ -251,7 +252,8 @@ export class NavigationController {
    * navigation. This callback is shared between keyboard shortcuts
    * and context menu items.
    * 
-   * FIXME: This should be better encapsulated
+   * FIXME: This should be better encapsulated.
+   *
    * @param workspace The `WorkspaceSvg` where the shortcut was
    *     invoked.
    * @param e The originating event for a keyboard shortcut, or null

--- a/src/navigation_controller.ts
+++ b/src/navigation_controller.ts
@@ -237,14 +237,9 @@ export class NavigationController {
    * @returns True iff `deleteCallbackFn` function should be called.
    */
   protected deletePreconditionFn(workspace: WorkspaceSvg) {
-    if (this.canCurrentlyEdit(workspace)) {
-      const curNode = workspace.getCursor()?.getCurNode();
-      if (curNode && curNode.getSourceBlock()) {
-        const sourceBlock = curNode.getSourceBlock();
-        return !!(sourceBlock && sourceBlock.isDeletable());
-      }
-    }
-    return false;
+    if (!this.canCurrentlyEdit(workspace)) return false;
+    const sourceBlock = workspace.getCursor()?.getCurNode().getSourceBlock();
+    return !!(sourceBlock?.isDeletable());
   }
 
   /**

--- a/src/navigation_controller.ts
+++ b/src/navigation_controller.ts
@@ -257,9 +257,7 @@ export class NavigationController {
    */
   protected deleteCallbackFn(workspace: WorkspaceSvg, e: Event | null) {
     const cursor = workspace.getCursor();
-    if (!cursor) {
-      return false;
-    }
+    if (!cursor) return false;
     const sourceBlock = cursor.getCurNode().getSourceBlock() as BlockSvg;
     // Delete or backspace.
     // There is an event if this is triggered from a keyboard shortcut,


### PR DESCRIPTION
This bodges together the keyboard shortcut item and the context menu item to register a "Keyboard navigation: delete" item into the context menu and show it at the appropriate time.

This is an example of how to transform a keyboard shortcut definition into a context menu item.

The added context menu item differs from the original context menu item because its precondition function updates the location of the cursor after deletion, rather than leaving it in an invalid state.

Parts of the code:
- Make the keyboard shortcut precondition and callback functions into methods on `NavigationController`.
- Cache the original context menu item to use its precondition function.
- Register a context menu item that mashes these functions together.