### PR TITLE
feat: Allow `LineCursor` to be positioned between stack blocks

### DIFF
--- a/src/line_cursor.ts
+++ b/src/line_cursor.ts
@@ -131,12 +131,14 @@ export class LineCursor extends Marker {
     const type = node && node.getType();
     switch (type) {
       case ASTNode.types.BLOCK:
-        return !((location as Blockly.Block).outputConnection?.isConnected());
+        return !(location as Blockly.Block).outputConnection?.isConnected();
       case ASTNode.types.INPUT:
-        const connection = (location as Blockly.Connection);
-        return connection.type === Blockly.NEXT_STATEMENT && !connection.isConnected();
+        const connection = location as Blockly.Connection;
+        return connection.type === Blockly.NEXT_STATEMENT;
       case ASTNode.types.NEXT:
-        return !((location as Blockly.Connection).isConnected());
+        return true;
+      case ASTNode.types.PREVIOUS:
+        return !(location as Blockly.Connection).isConnected();
       default:
         return false;
     }
@@ -164,7 +166,7 @@ export class LineCursor extends Marker {
         return true;
       case ASTNode.types.INPUT:
       case ASTNode.types.NEXT:
-        return !((location as Blockly.Connection).isConnected());
+        return !(location as Blockly.Connection).isConnected();
       case ASTNode.types.FIELD:
         return true;
       default:


### PR DESCRIPTION
Previously, the `LineCursor` could only visit next connections, and only if they were not connected to another block.  This was to allow the first block to be placed in a statement input, and to make it easier to place new blocks on the bottom of a stack.

This change allows the `LineCursor` to visit ALL next connections, and also to visit unconnected previous connections.  This allows the cursor to be positioned between blocks in a stack, as well as on the top connection of a statement input (on the _input's_ connection, since there may or may not be an attached block), as well as on the previous connection of any top-level block that has a previous connection.

This change is being made in response to comments from @kmcnaught:

- https://github.com/google/blockly-keyboard-experimentation/issues/129#issuecomment-2589875375
- https://github.com/google/blockly-keyboard-experimentation/issues/130#issuecomment-2595603541

…but should (like everything else in this repo) be considered experimental and subject to further discussion / evaluation / decisions.
