### PR TITLE
feat: add block copy as context menu item

### DIFF
--- a/src/navigation_controller.ts
+++ b/src/navigation_controller.ts
@@ -287,28 +287,26 @@ export class NavigationController {
    * @returns True iff `deleteCallbackFn` function should be called.
    */
   protected blockCopyPreconditionFn(workspace: WorkspaceSvg) {
-    if (this.canCurrentlyEdit(workspace)) {
-      switch (this.navigation.getState(workspace)) {
-        case Constants.STATE.WORKSPACE:
-          const curNode = workspace?.getCursor()?.getCurNode();
-          const source = curNode?.getSourceBlock();
-          return !!(
-            source?.isDeletable() &&
-            source?.isMovable() &&
-            !Blockly.Gesture.inProgress()
-          );
-        case Constants.STATE.FLYOUT:
-          const flyoutWorkspace = workspace.getFlyout()?.getWorkspace();
-          const sourceBlock = flyoutWorkspace
-            ?.getCursor()
-            ?.getCurNode()
-            ?.getSourceBlock();
-          return !!(sourceBlock && !Blockly.Gesture.inProgress());
-        default:
-          return false;
-      }
+    if (!this.canCurrentlyEdit(workspace))  return false;
+    switch (this.navigation.getState(workspace)) {
+      case Constants.STATE.WORKSPACE:
+        const curNode = workspace?.getCursor()?.getCurNode();
+        const source = curNode?.getSourceBlock();
+        return !!(
+          source?.isDeletable() &&
+          source?.isMovable() &&
+          !Blockly.Gesture.inProgress()
+        );
+      case Constants.STATE.FLYOUT:
+        const flyoutWorkspace = workspace.getFlyout()?.getWorkspace();
+        const sourceBlock = flyoutWorkspace
+          ?.getCursor()
+          ?.getCurNode()
+          ?.getSourceBlock();
+        return !!(sourceBlock && !Blockly.Gesture.inProgress());
+      default:
+        return false;
     }
-    return false;
   }
 
   /**

--- a/src/navigation_controller.ts
+++ b/src/navigation_controller.ts
@@ -930,9 +930,7 @@ export class NavigationController {
    */
   protected registerCopyAction() {
     const copyAction: ContextMenuRegistry.RegistryItem = {
-      displayText: (scope) => {
-        return 'Keyboard Navigation: copy';
-      },
+      displayText: (scope) => 'Keyboard Navigation: copy',
       preconditionFn: (scope) => {
         const ws = scope.block?.workspace;
         if (!ws) return 'hidden';


### PR DESCRIPTION
Part of https://github.com/google/blockly-keyboard-experimentation/issues/132

As discussed with @cpcallen on 20 Jan 2025, this adds a context menu item for an existing keyboard shortcut (copy). I intend to apply this transformation to several keyboard shortcuts by making changes in `navigation_controller.ts`, then find a general pattern for creating `Action`s that can be registered as both keyboard shortcuts and context menu items. In that second stage I will likely move these definitions out of the `navigation_controller.ts` and into separate per-action files, to improve code cleanliness/readability.

This change is related to https://github.com/google/blockly-keyboard-experimentation/pull/159