### PR TITLE
feat: enter now edits full field blocks

### DIFF
--- a/src/constants.ts
+++ b/src/constants.ts
@@ -32,6 +32,7 @@ export enum SHORTCUT_NAMES {
   DISCONNECT = 'disconnect',
   TOOLBOX = 'toolbox',
   EXIT = 'exit',
+  MENU = 'menu',
   COPY = 'keyboard_nav_copy',
   CUT = 'keyboard_nav_cut',
   PASTE = 'keyboard_nav_paste',

--- a/src/line_cursor.ts
+++ b/src/line_cursor.ts
@@ -167,7 +167,8 @@ export class LineCursor extends Marker {
       case ASTNode.types.NEXT:
         return !(location as Blockly.Connection).isConnected();
       case ASTNode.types.FIELD:
-        return true;
+        // @ts-expect-error isFullBlockField is a protected method.
+        return !(location as Blockly.Field).isFullBlockField();
       default:
         return false;
     }

--- a/src/navigation.ts
+++ b/src/navigation.ts
@@ -1242,7 +1242,17 @@ export class Navigation {
     if (nodeType == Blockly.ASTNode.types.FIELD) {
       (curNode.getLocation() as Blockly.Field).showEditor();
     } else if (nodeType == Blockly.ASTNode.types.BLOCK) {
-      this.openActionMenu(curNode);
+      const block = curNode.getLocation() as Blockly.Block;
+      if (!tryShowFullBlockFieldEditor(block)) {
+        const metaKey = navigator.platform.startsWith('Mac') ? 'Cmd' : 'Ctrl';
+        const canMoveInHint = `Press right arrow to move in or ${metaKey} + Enter for more options`;
+        const genericHint = `Press ${metaKey} + Enter for options`;
+        const hint =
+          curNode.in()?.getSourceBlock() === block
+            ? canMoveInHint
+            : genericHint;
+        alert(hint);
+      }
     } else if (
       curNode.isConnection() ||
       nodeType == Blockly.ASTNode.types.WORKSPACE
@@ -1416,4 +1426,23 @@ function fakeEventForNode(node: Blockly.ASTNode): PointerEvent {
     clientX: coords.x,
     clientY: coords.y,
   });
+}
+
+/**
+ * If this block has a full block field then show its editor.
+ *
+ * @param block A block.
+ * @returns True if we showed the editor, false otherwise.
+ */
+function tryShowFullBlockFieldEditor(block: Blockly.Block): boolean {
+  for (const input of block.inputList) {
+    for (const field of input.fieldRow) {
+      // @ts-expect-error isFullBlockField is a protected method.
+      if (field.isClickable() && field.isFullBlockField()) {
+        field.showEditor();
+        return true;
+      }
+    }
+  }
+  return false;
 }

--- a/src/navigation_controller.ts
+++ b/src/navigation_controller.ts
@@ -552,6 +552,34 @@ export class NavigationController {
       keyCodes: [KeyCodes.ENTER],
     },
 
+    /**
+     * Cmd/Ctrl/Alt+Enter key:
+     *
+     * Shows the action menu.
+     */
+    menu: {
+      name: Constants.SHORTCUT_NAMES.MENU,
+      preconditionFn: (workspace) => this.canCurrentlyNavigate(workspace),
+      callback: (workspace) => {
+        switch (this.navigation.getState(workspace)) {
+          case Constants.STATE.WORKSPACE: {
+            const node = workspace.getCursor()?.getCurNode();
+            if (node?.getType() === Blockly.ASTNode.types.BLOCK)
+              this.navigation.openActionMenu(node);
+
+            return true;
+          }
+          default:
+            return false;
+        }
+      },
+      keyCodes: [
+        createSerializedKey(KeyCodes.ENTER, [KeyCodes.CTRL]),
+        createSerializedKey(KeyCodes.ENTER, [KeyCodes.ALT]),
+        createSerializedKey(KeyCodes.ENTER, [KeyCodes.META]),
+      ],
+    },
+
     /** Disconnect two blocks. */
     disconnect: {
       name: Constants.SHORTCUT_NAMES.DISCONNECT,


### PR DESCRIPTION
- Skip the field positions for those blocks
- Move the action menu to Ctrl/Cmd+Enter

This is a tidied up subset of what we've discussed as Demo A.

The alert is not intended to be the final UX but to indicate that there's a point where we need to offer the user a hint. We can drop it from this PR and add it after more UX discussion if preferred.

I've assumed that we're OK with calling isFullBlockField for now (protected in core).

Deployment of this PR: https://enter-to-edit.blockly-keyboard-experimentation.pages.dev/
