### PR TITLE
fix: Update cursor location in response to `SELECT` events

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -6,7 +6,7 @@
 
 import * as Blockly from 'blockly/core';
 import {NavigationController} from './navigation_controller';
-import {installCursor} from './line_cursor';
+import {LineCursor} from './line_cursor';
 
 /** Plugin for keyboard navigation. */
 export class KeyboardNavigation {
@@ -22,6 +22,9 @@ export class KeyboardNavigation {
   /** Keyboard navigation controller instance for the workspace. */
   private navigationController: NavigationController;
 
+  /** Cursor for the main workspace. */
+  private cursor: LineCursor;
+
   /**
    * These fields are used to preserve the workspace's initial state to restore
    * it when/if keyboard navigation is disabled.
@@ -29,7 +32,6 @@ export class KeyboardNavigation {
   private injectionDivTabIndex: string | null;
   private workspaceParentTabIndex: string | null;
   private originalTheme: Blockly.Theme;
-  private originalCursor: Blockly.Cursor | null;
 
   /**
    * Constructs the keyboard navigation.
@@ -48,8 +50,9 @@ export class KeyboardNavigation {
 
     this.originalTheme = workspace.getTheme();
     this.setGlowTheme();
-    this.originalCursor = workspace.getMarkerManager().getCursor();
-    installCursor(workspace);
+
+    this.cursor = new LineCursor(workspace);
+    this.cursor.install();
 
     // Ensure that only the root SVG G (group) has a tab index.
     this.injectionDivTabIndex = workspace
@@ -106,10 +109,7 @@ export class KeyboardNavigation {
         .setAttribute('tabindex', this.injectionDivTabIndex);
     }
 
-    if (this.originalCursor) {
-      const markerManager = this.workspace.getMarkerManager();
-      markerManager.setCursor(this.originalCursor);
-    }
+    this.cursor.uninstall();
 
     this.workspace.setTheme(this.originalTheme);
 

--- a/src/index.ts
+++ b/src/index.ts
@@ -49,7 +49,7 @@ export class KeyboardNavigation {
     this.originalTheme = workspace.getTheme();
     this.setGlowTheme();
     this.originalCursor = workspace.getMarkerManager().getCursor();
-    installCursor(workspace.getMarkerManager());
+    installCursor(workspace);
 
     // Ensure that only the root SVG G (group) has a tab index.
     this.injectionDivTabIndex = workspace

--- a/src/line_cursor.ts
+++ b/src/line_cursor.ts
@@ -27,6 +27,7 @@ export class LineCursor extends Marker {
    */
   constructor(public readonly workspace: Blockly.WorkspaceSvg) {
     super();
+    workspace.addChangeListener(this.selectListener.bind(this));
   }
 
   /**
@@ -410,10 +411,14 @@ export class LineCursor extends Marker {
    * if so, update the cursor location (and any highlighting) to
    * match.
    *
-   * This works reasonably well but has some glitches, most notably
-   * that if the cursor is not on a block (e.g. it is on a connection
-   * or the workspace) then it will remain visible in its previous
-   * location until a cursor key is pressed.
+   * Doing this only when getCurNode would naturally be called works
+   * reasonably well but has some glitches, most notably that if the
+   * cursor was not on a block (e.g. it was on a connection or the
+   * workspace) when the user selected a block then it will remain
+   * visible in its previous location until some keyboard navigation occurs.
+   *
+   * To ameliorate this, the LineCursor constructor adds an event
+   * listener that calls getCurNode in response to SELECTED events.
    *
    * TODO(#97): Remove this hack once Blockly is modified to update
    * the cursor/focus itself.
@@ -505,6 +510,13 @@ export class LineCursor extends Marker {
     }
 
     drawer.draw(oldNode, newNode);
+  }
+
+  private selectListener(event: Blockly.Events.Abstract) {
+    if (event.type !== Blockly.Events.SELECTED) return;
+    const selectedEvent = event as Blockly.Events.Selected;
+    if (selectedEvent.workspaceId !== this.workspace.id) return;
+    this.getCurNode();
   }
 }
 

--- a/src/line_cursor.ts
+++ b/src/line_cursor.ts
@@ -457,8 +457,8 @@ export class LineCursor extends Marker {
    * To ameliorate this, the LineCursor constructor adds an event
    * listener that calls getCurNode in response to SELECTED events.
    *
-   * TODO(#97): Remove this hack once Blockly is modified to update
-   * the cursor/focus itself.
+   * Remove this hack once Blockly is modified to update the
+   * cursor/focus itself.
    *
    * @returns The current field, connection, or block the cursor is on.
    */
@@ -549,6 +549,10 @@ export class LineCursor extends Marker {
     drawer.draw(oldNode, newNode);
   }
 
+  /**
+   * Event listener that syncs the cursor location to the selected
+   * block on SELECTED events.
+   */
   private selectListener(event: Blockly.Events.Abstract) {
     if (event.type !== Blockly.Events.SELECTED) return;
     const selectedEvent = event as Blockly.Events.Selected;

--- a/src/line_cursor.ts
+++ b/src/line_cursor.ts
@@ -23,9 +23,9 @@ export class LineCursor extends Marker {
   override type = 'cursor';
 
   /**
-   * Constructor for a line cursor.
+   * @param workspace The workspace this cursor belongs to.
    */
-  constructor() {
+  constructor(public readonly workspace: Blockly.WorkspaceSvg) {
     super();
   }
 
@@ -423,12 +423,7 @@ export class LineCursor extends Marker {
   override getCurNode(): ASTNode {
     const curNode = super.getCurNode();
     const selected = Blockly.common.getSelected();
-    if (
-      (selected?.workspace as Blockly.WorkspaceSvg)
-        ?.getMarkerManager()
-        .getCursor() !== this
-    )
-      return curNode;
+    if (selected?.workspace !== this.workspace) return curNode;
 
     // Selected item is on workspace that this cursor belongs to.
     const curLocation = curNode?.getLocation();
@@ -523,14 +518,15 @@ export const pluginInfo = {
 };
 
 /**
- * Install this cursor on the marker manager in the same position as
- * the previous cursor.
+ * Install a LineCursor in the specified workspace's marker manager,
+ * in the same position as any existing cursor.
  *
- * @param markerManager The currently active marker manager.
+ * @param workspace The workspace on which to install a LineCursor
  */
-export function installCursor(markerManager: Blockly.MarkerManager) {
+export function installCursor(workspace: Blockly.WorkspaceSvg) {
+  const markerManager = workspace.getMarkerManager();
   const oldCurNode = markerManager.getCursor()?.getCurNode();
-  const lineCursor = new LineCursor();
+  const lineCursor = new LineCursor(workspace);
   markerManager.setCursor(lineCursor);
   if (oldCurNode) {
     markerManager.getCursor()?.setCurNode(oldCurNode);


### PR DESCRIPTION
This adds an event listener for `SELECT` events to `LineCursor`.  This solves an issue where, when the cursor was not on a block, clicking on a block to select it would not immediately cause the cursor to disappear from its previous location, though it would eventually update when a cursor key was pressed.

Fixes #97 

