### PR TITLE
feat: handle inserting a block to replace a reporter

### DIFF
--- a/src/navigation.ts
+++ b/src/navigation.ts
@@ -752,6 +752,8 @@ export class Navigation {
           movingBlock,
           stationaryBlock.previousConnection,
         );
+      } else if (stationaryBlock.outputConnection) {
+        return this.insertBlock(movingBlock, stationaryBlock.outputConnection);
       }
     }
     this.warn('Unexpected state in tryToConnectNodes.');


### PR DESCRIPTION
Part of #177 

If the cursor is on a block with an output connection and the user tries to insert a compatible block from the flyout/toolbox, connect if legal.

If illegal (e.g. colour block where a number is expected) the new block will still be placed on the workspace and greyed out.

### Test steps
- Open the test playground
- Click on the workspace to start activate keyboard navigation
- Use arrow keys to navigate to the colour block connected to "set background colour to"
- Press T to open the toolbox
- Use arrow keys to navigate to the p5 blocks category
- Use arrow keys to select the "random colour" block
- Press enter to insert the block

Also tested with the repeat X times block and inserting a number block.

Contrary to the name of the branch, this also works for non-shadow blocks.

### Old behaviour
New block is bumped to the workspace and greyed out.

Zelos:
![f39a472e-35d7-49d8-befc-a3c46028542f](https://github.com/user-attachments/assets/e987baa9-0e40-4789-97ea-2928b6ec5e06)

Geras:
![71d6ae07-3f69-4ee9-8a70-5e23a0c51c3c](https://github.com/user-attachments/assets/33d1ee99-930d-4fb4-bd20-fcaf4b1563c0)


### New behaviour
New block replaces the old block. 

Zelos:
![04732ef2-39aa-4fa3-8669-5449cfd67766](https://github.com/user-attachments/assets/cd87348e-f041-4a97-986a-f6a2cfb2b880)

Geras:
![6b0eb3f6-e168-45ea-88d9-f00936ed151c](https://github.com/user-attachments/assets/409566ef-408b-478b-8aad-9da1ccdc6f77)
