### PR TITLE
feat: Add flag to enable/disable cursor visiting stack nodes

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -6,7 +6,17 @@
 
 import * as Blockly from 'blockly/core';
 import {NavigationController} from './navigation_controller';
-import {LineCursor} from './line_cursor';
+import {CursorOptions, LineCursor} from './line_cursor';
+
+/** Options object for KeyboardNavigation instances. */
+export type NavigationOptions = {
+  cursor: Partial<CursorOptions>;
+};
+
+/** Default options for LineCursor instances. */
+const defaultOptions: NavigationOptions = {
+  cursor: {},
+};
 
 /** Plugin for keyboard navigation. */
 export class KeyboardNavigation {
@@ -39,8 +49,14 @@ export class KeyboardNavigation {
    * @param workspace The workspace that the plugin will
    *     be added to.
    */
-  constructor(workspace: Blockly.WorkspaceSvg) {
+  constructor(
+    workspace: Blockly.WorkspaceSvg,
+    options: Partial<NavigationOptions>,
+  ) {
     this.workspace = workspace;
+
+    // Regularise options and apply defaults.
+    options = {...defaultOptions, ...options};
 
     this.navigationController = new NavigationController();
     this.navigationController.init();
@@ -51,7 +67,7 @@ export class KeyboardNavigation {
     this.originalTheme = workspace.getTheme();
     this.setGlowTheme();
 
-    this.cursor = new LineCursor(workspace);
+    this.cursor = new LineCursor(workspace, options.cursor);
     this.cursor.install();
 
     // Ensure that only the root SVG G (group) has a tab index.

--- a/src/line_cursor.ts
+++ b/src/line_cursor.ts
@@ -101,7 +101,7 @@ export class LineCursor extends Marker {
     if (!curNode) {
       return null;
     }
-    let newNode = this.getNextNode(curNode, this.validLineNode);
+    let newNode = this.getNextNode(curNode, this.validLineNode.bind(this));
 
     if (newNode) {
       this.setCurNode(newNode);
@@ -121,7 +121,7 @@ export class LineCursor extends Marker {
     if (!curNode) {
       return null;
     }
-    const newNode = this.getNextNode(curNode, this.validInLineNode);
+    const newNode = this.getNextNode(curNode, this.validInLineNode.bind(this));
 
     if (newNode) {
       this.setCurNode(newNode);
@@ -140,7 +140,7 @@ export class LineCursor extends Marker {
     if (!curNode) {
       return null;
     }
-    let newNode = this.getPreviousNode(curNode, this.validLineNode);
+    let newNode = this.getPreviousNode(curNode, this.validLineNode.bind(this));
 
     if (newNode) {
       this.setCurNode(newNode);
@@ -160,7 +160,10 @@ export class LineCursor extends Marker {
     if (!curNode) {
       return null;
     }
-    const newNode = this.getPreviousNode(curNode, this.validInLineNode);
+    const newNode = this.getPreviousNode(
+      curNode,
+      this.validInLineNode.bind(this),
+    );
 
     if (newNode) {
       this.setCurNode(newNode);

--- a/src/line_cursor.ts
+++ b/src/line_cursor.ts
@@ -16,11 +16,28 @@
 import * as Blockly from 'blockly/core';
 import {ASTNode, Marker} from 'blockly/core';
 
+/** Options object for LineCursor instances. */
+export type CursorOptions = {
+  /**
+   * Can the cursor visit all stack connections (next/previous), or
+   * (if false) only unconnected next connections?
+   */
+  stackConnections: boolean;
+};
+
+/** Default options for LineCursor instances. */
+const defaultOptions: CursorOptions = {
+  stackConnections: true,
+};
+
 /**
  * Class for a line cursor.
  */
 export class LineCursor extends Marker {
   override type = 'cursor';
+
+  /** Options for this line cursor. */
+  private readonly options: CursorOptions;
 
   /** Has the cursor been installed in a workspace's marker manager? */
   private installed = false;
@@ -31,10 +48,15 @@ export class LineCursor extends Marker {
   /**
    * @param workspace The workspace this cursor belongs to.
    */
-  constructor(public readonly workspace: Blockly.WorkspaceSvg) {
+  constructor(
+    public readonly workspace: Blockly.WorkspaceSvg,
+    options?: Partial<CursorOptions>,
+  ) {
     super();
     // Bind selectListener to facilitate future install/uninstall.
     this.selectListener = this.selectListener.bind(this);
+    // Regularise options and apply defaults.
+    this.options = {...defaultOptions, ...options};
   }
 
   /**

--- a/src/line_cursor.ts
+++ b/src/line_cursor.ts
@@ -185,9 +185,8 @@ export class LineCursor extends Marker {
    *
    * @param node The AST node to check.
    * @returns True if the node should be visited, false otherwise.
-   * @protected
    */
-  validLineNode(node: ASTNode | null): boolean {
+  protected validLineNode(node: ASTNode | null): boolean {
     if (!node) return false;
     const location = node.getLocation();
     const type = node && node.getType();
@@ -217,9 +216,8 @@ export class LineCursor extends Marker {
    *
    * @param node The AST node to check whether it is valid.
    * @returns True if the node should be visited, false otherwise.
-   * @protected
    */
-  validInLineNode(node: ASTNode | null): boolean {
+  protected validInLineNode(node: ASTNode | null): boolean {
     if (!node) return false;
     const location = node.getLocation();
     const type = node && node.getType();

--- a/src/line_cursor.ts
+++ b/src/line_cursor.ts
@@ -183,6 +183,14 @@ export class LineCursor extends Marker {
    *   This is to facilitate connecting additional blocks to a
    *   stack/substack.
    *
+   * If options.stackConnections is true (the default) then allow the
+   * cursor to visit all (useful) stack connection by additionally
+   * returning true for:
+   *
+   *   - Any next statement input
+   *   - Any 'next' connection.
+   *   - An unconnected previous statement input.
+   *
    * @param node The AST node to check.
    * @returns True if the node should be visited, false otherwise.
    */
@@ -195,11 +203,20 @@ export class LineCursor extends Marker {
         return !(location as Blockly.Block).outputConnection?.isConnected();
       case ASTNode.types.INPUT:
         const connection = location as Blockly.Connection;
-        return connection.type === Blockly.NEXT_STATEMENT;
+        return (
+          connection.type === Blockly.NEXT_STATEMENT &&
+          (this.options.stackConnections || !connection.isConnected())
+        );
       case ASTNode.types.NEXT:
-        return true;
+        return (
+          this.options.stackConnections ||
+          !(location as Blockly.Connection).isConnected()
+        );
       case ASTNode.types.PREVIOUS:
-        return !(location as Blockly.Connection).isConnected();
+        return (
+          this.options.stackConnections &&
+          !(location as Blockly.Connection).isConnected()
+        );
       default:
         return false;
     }

--- a/src/line_cursor.ts
+++ b/src/line_cursor.ts
@@ -207,10 +207,11 @@ export class LineCursor extends Marker {
 
   /**
    * Returns true iff the given node can be visited by the cursor when
-   * using the left/right arrow keys.  Specifically, if the node is for:
+   * using the left/right arrow keys.  Specifically, if the node is
+   * for any node for which valideLineNode would return true, plus:
    *
    * - Any block.
-   * - Any field.
+   * - Any field that is not a full block field.
    * - Any unconnected next or input connection.  This is to
    *   facilitate connecting additional blocks.
    *
@@ -219,13 +220,13 @@ export class LineCursor extends Marker {
    */
   protected validInLineNode(node: ASTNode | null): boolean {
     if (!node) return false;
+    if (this.validLineNode(node)) return true;
     const location = node.getLocation();
     const type = node && node.getType();
     switch (type) {
       case ASTNode.types.BLOCK:
         return true;
       case ASTNode.types.INPUT:
-      case ASTNode.types.NEXT:
         return !(location as Blockly.Connection).isConnected();
       case ASTNode.types.FIELD:
         // @ts-expect-error isFullBlockField is a protected method.


### PR DESCRIPTION
Refactor `LineCursor.prototype.validLineNode` and `.validInlineNode` to enable/disable visiting stack intermediate connections (as well as the previous connection on top-level blocks that have one), controlled by a new `stackConnections` option, plumbed through options objects for `LineCursor` and `KeyboardNavigation`.

The options objects are provided in anticipation of adding further flags for different test scenarios.  I had originally planned to directly inspect `location.search` but this seems like a better approach as it allows partners to set this and other such options in whatever way they want.

Code to actually set this option (probably based on UI control rather than URL search string) coming in a following PR.

Part of #179.
