### PR TITLE
fix: Remove tabindex if it wasn't originally present when disposing of KeyboardNavigation.

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -101,12 +101,16 @@ export class KeyboardNavigation {
       this.workspace
         .getParentSvg()
         .setAttribute('tabindex', this.workspaceParentTabIndex);
+    } else {
+      this.workspace.getParentSvg().removeAttribute('tabindex');
     }
 
     if (this.injectionDivTabIndex) {
       this.workspace
         .getInjectionDiv()
         .setAttribute('tabindex', this.injectionDivTabIndex);
+    } else {
+      this.workspace.getInjectionDiv().removeAttribute('tabindex');
     }
 
     this.cursor.uninstall();


### PR DESCRIPTION
This PR addresses @cpcallen's comment in https://github.com/google/blockly-keyboard-experimentation/pull/190 by removing the `tabindex` attribute on the workspace parent/injection divs if it wasn't originally present when `dispose()` is called on `KeyboardNavigation`.