### PR TITLE
feat: Add options for `renderer` and `stackConnections`

### DIFF
--- a/test/index.html
+++ b/test/index.html
@@ -107,15 +107,32 @@
           <div id="p5output"></div>
           <div id="scenarioForm">
             <form id="options">
-              <label for="scenarioSelect">Scenario:</label>
+              <label for="scenario">Scenario:</label>
               <select
                 name="scenario"
-                id="scenarioSelect"
+                id="scenario"
                 onchange="document.forms.options.submit()">
                 <option value="simpleCircle">simple circle</option>
                 <option value="sun">sun</option>
                 <option value="blank">blank canvas</option>
               </select>
+              <br />
+              <label for="renderer">Renderer:</label>
+              <select
+                name="renderer"
+                id="renderer"
+                onchange="document.forms.options.submit()">
+                <option value="geras">Geras</option>
+                <option value="thrasos">Thrasos</option>
+                <option value="zelos">Zelos</option>
+              </select>
+              <br />
+              <label for="stackConnections">Disable stack connections:</label>
+              <input
+                type="checkbox"
+                name="noStack"
+                id="noStack"
+                onChange="document.forms.options.submit()" />
             </form>
           </div>
         </div>


### PR DESCRIPTION
Introduce `getOptions` function (replacing most of `loadScenario`) to parse query parameters for the `scenario`, `renderer` and `stackConnection` options and update the form controls to match (after a short delay so that Chrome does not later restore incorrect form state when page navigation has occurred).

N.B.: Because checkbox inputs do not send any parameter when not checked, it is not possible (without considerable extra trouble) to have a checkbox default to checked, so the checkbox for `stackConnections` is inverted from the option and is labelled accordingly.

Fixes #179.