### PR TITLE
fix: pass empty options object to navigation constructor

### DIFF
--- a/test/index.ts
+++ b/test/index.ts
@@ -63,7 +63,7 @@ function createWorkspace(): Blockly.WorkspaceSvg {
   const blocklyDiv = document.getElementById('blocklyDiv')!;
   const workspace = Blockly.inject(blocklyDiv, options);
 
-  new KeyboardNavigation(workspace);
+  new KeyboardNavigation(workspace, {});
   registerRunCodeShortcut();
 
   // Disable blocks that aren't inside the setup or draw loops.


### PR DESCRIPTION
Fixes broken build triggered by passing one argument instead of two to `KeyboardNavigation`'s constructor.

@cpcallen FYI. Tests did not catch this.

