### PR TITLE
chore: bump version to 0.0.2

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@blockly/keyboard-experiment",
-  "version": "0.0.1",
+  "version": "0.0.2",
   "description": "A plugin for keyboard navigation.",
   "scripts": {
     "audit:fix": "blockly-scripts auditFix",


### PR DESCRIPTION
Published on [npmjs.com](https://www.npmjs.com/package/@blockly/keyboard-experiment?activeTab=versions) as v0.0.2.