### PR TITLE
fix: always select block after flyout insert

### DIFF
--- a/src/navigation.ts
+++ b/src/navigation.ts
@@ -600,20 +600,18 @@ export class Navigation {
     if (!newBlock) {
       return;
     }
-    if (!this.markedNode) {
-      this.warn('No marked node when inserting from flyout.');
-      return;
-    }
-    if (
-      !this.tryToConnectNodes(
-        workspace,
-        this.markedNode,
-        Blockly.ASTNode.createBlockNode(newBlock)!,
-      )
-    ) {
-      this.warn(
-        'Something went wrong while inserting a block from the flyout.',
-      );
+    if (this.markedNode) {
+      if (
+        !this.tryToConnectNodes(
+          workspace,
+          this.markedNode,
+          Blockly.ASTNode.createBlockNode(newBlock)!,
+        )
+      ) {
+        this.warn(
+          'Something went wrong while inserting a block from the flyout.',
+        );
+      }
     }
 
     this.focusWorkspace(workspace);


### PR DESCRIPTION
In MakeCode at least, it's possible to open the flyout by tabbing to the toolbox without first interacting with the workspace/keyboard nav. In that scenario there is no marker. Because of the early return keyboard nav flow was broken as the new block wasn't selected

I suspect the same will be possible in the Blockly toolbox when it integrates better with focus see #149 and the planning on #142.