### PR TITLE
fix: check isSimpleReporter to be sure of full block field

### DIFF
--- a/src/line_cursor.ts
+++ b/src/line_cursor.ts
@@ -245,9 +245,14 @@ export class LineCursor extends Marker {
         return true;
       case ASTNode.types.INPUT:
         return !(location as Blockly.Connection).isConnected();
-      case ASTNode.types.FIELD:
-        // @ts-expect-error isFullBlockField is a protected method.
-        return !(location as Blockly.Field).isFullBlockField();
+      case ASTNode.types.FIELD: {
+        const field = node.getLocation() as Blockly.Field;
+        return !(
+          field.getSourceBlock()?.isSimpleReporter() &&
+          // @ts-expect-error isFullBlockField is a protected method.
+          field.isFullBlockField()
+        );
+      }
       default:
         return false;
     }

--- a/src/navigation.ts
+++ b/src/navigation.ts
@@ -1458,12 +1458,14 @@ function fakeEventForNode(node: Blockly.ASTNode): PointerEvent {
  * @returns True if we showed the editor, false otherwise.
  */
 function tryShowFullBlockFieldEditor(block: Blockly.Block): boolean {
-  for (const input of block.inputList) {
-    for (const field of input.fieldRow) {
-      // @ts-expect-error isFullBlockField is a protected method.
-      if (field.isClickable() && field.isFullBlockField()) {
-        field.showEditor();
-        return true;
+  if (block.isSimpleReporter()) {
+    for (const input of block.inputList) {
+      for (const field of input.fieldRow) {
+        // @ts-expect-error isFullBlockField is a protected method.
+        if (field.isClickable() && field.isFullBlockField()) {
+          field.showEditor();
+          return true;
+        }
       }
     }
   }


### PR DESCRIPTION
isFullBlockField can be true in scenarios where it is not the only field and so needs visiting. This happens at least for MakeCode if block dummy input clickable image fields (add remove icons).

![Screenshot2025_02_14_165155](https://github.com/user-attachments/assets/ba9ed409-3d28-4399-9608-1e2114344de5)

The MakeCode block has quite a lot of logic but I think the part that relates to this field is simply:

```javascript
  appendDummyInput('ADDBUTTON')
            .appendField(
                new Blockly.FieldImage(this.ADD_IMAGE_DATAURI, 24, 24, "*", addElseIf, false))
```