### PR TITLE
fix: suppress tab stop due to focus listener

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -78,7 +78,8 @@ export class KeyboardNavigation {
     this.workspaceParentTabIndex = workspace
       .getParentSvg()
       .getAttribute('tabindex');
-    workspace.getParentSvg().removeAttribute('tabindex');
+    // We add a focus listener below so use -1 so it doesn't become focusable.
+    workspace.getParentSvg().setAttribute('tabindex', '-1');
 
     this.focusListener = () => {
       this.navigationController.setHasFocus(workspace, true);


### PR DESCRIPTION
Previous demo tab stops: button, select, toolbox, parentSvg, svgGroup
New demo tab stops: button, select, toolbox, svgGroup

Remaining related tab stop/high-level focus issues:
- toolbox is still an invisible tab stop, see #149 
- parentSvg is focussed programatically after a field edit, at which point there's no longer a workspace focus outline (related to #136 workaround, no clear short term fix)

Part of https://github.com/google/blockly-keyboard-experimentation/issues/180
