### PR TITLE
feat: Display action menu, containing insert action, for stack connections

### DIFF
--- a/src/navigation.ts
+++ b/src/navigation.ts
@@ -724,22 +724,22 @@ export class Navigation {
       // Connect the moving block to the stationary connection using
       // the most plausible connection on the moving block.
       if (
-        movingType == Blockly.ASTNode.types.BLOCK ||
-        movingType == Blockly.ASTNode.types.STACK
+        movingType === Blockly.ASTNode.types.BLOCK ||
+        movingType === Blockly.ASTNode.types.STACK
       ) {
         const stationaryAsConnection =
           stationaryLoc as Blockly.RenderedConnection;
         const movingAsBlock = movingLoc as Blockly.BlockSvg;
         return this.insertBlock(movingAsBlock, stationaryAsConnection);
       }
-    } else if (stationaryType == Blockly.ASTNode.types.WORKSPACE) {
+    } else if (stationaryType === Blockly.ASTNode.types.WORKSPACE) {
       const block = movingNode
         ? (movingNode.getSourceBlock() as Blockly.BlockSvg)
         : null;
       return this.moveBlockToWorkspace(block, stationaryNode);
     } else if (
-      stationaryType == Blockly.ASTNode.types.BLOCK &&
-      movingType == Blockly.ASTNode.types.BLOCK
+      stationaryType === Blockly.ASTNode.types.BLOCK &&
+      movingType === Blockly.ASTNode.types.BLOCK
     ) {
       // Insert the moving block above the stationary block, if the
       // appropriate connections exist.
@@ -783,19 +783,19 @@ export class Navigation {
     const cursorType = cursorNode.getType();
 
     // Check the marker for invalid types.
-    if (markerType == Blockly.ASTNode.types.FIELD) {
+    if (markerType === Blockly.ASTNode.types.FIELD) {
       this.warn('Should not have been able to mark a field.');
       return false;
-    } else if (markerType == Blockly.ASTNode.types.STACK) {
+    } else if (markerType === Blockly.ASTNode.types.STACK) {
       this.warn('Should not have been able to mark a stack.');
       return false;
     }
 
     // Check the cursor for invalid types.
-    if (cursorType == Blockly.ASTNode.types.FIELD) {
+    if (cursorType === Blockly.ASTNode.types.FIELD) {
       this.warn('Cannot attach a field to anything else.');
       return false;
-    } else if (cursorType == Blockly.ASTNode.types.WORKSPACE) {
+    } else if (cursorType === Blockly.ASTNode.types.WORKSPACE) {
       this.warn('Cannot attach a workspace to anything else.');
       return false;
     }
@@ -1255,9 +1255,9 @@ export class Navigation {
     if (!cursor) return;
     const curNode = cursor.getCurNode();
     const nodeType = curNode.getType();
-    if (nodeType == Blockly.ASTNode.types.FIELD) {
+    if (nodeType === Blockly.ASTNode.types.FIELD) {
       (curNode.getLocation() as Blockly.Field).showEditor();
-    } else if (nodeType == Blockly.ASTNode.types.BLOCK) {
+    } else if (nodeType === Blockly.ASTNode.types.BLOCK) {
       const block = curNode.getLocation() as Blockly.Block;
       if (!tryShowFullBlockFieldEditor(block)) {
         const metaKey = navigator.platform.startsWith('Mac') ? 'Cmd' : 'Ctrl';
@@ -1271,10 +1271,10 @@ export class Navigation {
       }
     } else if (
       curNode.isConnection() ||
-      nodeType == Blockly.ASTNode.types.WORKSPACE
+      nodeType === Blockly.ASTNode.types.WORKSPACE
     ) {
       this.openToolboxOrFlyout(workspace);
-    } else if (nodeType == Blockly.ASTNode.types.STACK) {
+    } else if (nodeType === Blockly.ASTNode.types.STACK) {
       this.warn('Cannot mark a stack.');
     }
   }

--- a/src/navigation_controller.ts
+++ b/src/navigation_controller.ts
@@ -323,7 +323,7 @@ export class NavigationController {
   protected blockCopyCallbackFn(workspace: WorkspaceSvg) {
     const navigationState = this.navigation.getState(workspace);
     let activeWorkspace: Blockly.WorkspaceSvg | undefined = workspace;
-    if (navigationState == Constants.STATE.FLYOUT) {
+    if (navigationState === Constants.STATE.FLYOUT) {
       activeWorkspace = workspace.getFlyout()?.getWorkspace();
     }
     const sourceBlock = activeWorkspace
@@ -373,7 +373,7 @@ export class NavigationController {
             }
             return isHandled;
           case Constants.STATE.TOOLBOX:
-            return toolbox && typeof toolbox.onShortcut == 'function'
+            return toolbox && typeof toolbox.onShortcut === 'function'
               ? toolbox.onShortcut(shortcut)
               : false;
           default:
@@ -418,7 +418,7 @@ export class NavigationController {
             this.navigation.focusToolbox(workspace);
             return true;
           case Constants.STATE.TOOLBOX:
-            return toolbox && typeof toolbox.onShortcut == 'function'
+            return toolbox && typeof toolbox.onShortcut === 'function'
               ? toolbox.onShortcut(shortcut)
               : false;
           default:
@@ -452,7 +452,7 @@ export class NavigationController {
             }
             return isHandled;
           case Constants.STATE.TOOLBOX:
-            return toolbox && typeof toolbox.onShortcut == 'function'
+            return toolbox && typeof toolbox.onShortcut === 'function'
               ? toolbox.onShortcut(shortcut)
               : false;
           default:
@@ -479,7 +479,7 @@ export class NavigationController {
             return isHandled;
           case Constants.STATE.TOOLBOX:
             isHandled =
-              toolbox && typeof toolbox.onShortcut == 'function'
+              toolbox && typeof toolbox.onShortcut === 'function'
                 ? toolbox.onShortcut(shortcut)
                 : false;
             if (!isHandled) {
@@ -790,7 +790,7 @@ export class NavigationController {
       callback: (workspace, e, shortcut) => {
         const cursor = workspace.getCursor() as LineCursor;
 
-        if (this.navigation.getState(workspace) == Constants.STATE.WORKSPACE) {
+        if (this.navigation.getState(workspace) === Constants.STATE.WORKSPACE) {
           if (this.fieldShortcutHandler(workspace, shortcut)) {
             this.announcer.setText('next sibling (handled by field)');
             return true;
@@ -814,7 +814,7 @@ export class NavigationController {
       callback: (workspace, e, shortcut) => {
         const cursor = workspace.getCursor() as LineCursor;
 
-        if (this.navigation.getState(workspace) == Constants.STATE.WORKSPACE) {
+        if (this.navigation.getState(workspace) === Constants.STATE.WORKSPACE) {
           if (this.fieldShortcutHandler(workspace, shortcut)) {
             this.announcer.setText('previous sibling (handled by field)');
             return true;
@@ -858,7 +858,7 @@ export class NavigationController {
       name: Constants.SHORTCUT_NAMES.CONTEXT_OUT,
       preconditionFn: (workspace) => this.canCurrentlyNavigate(workspace),
       callback: (workspace) => {
-        if (this.navigation.getState(workspace) == Constants.STATE.WORKSPACE) {
+        if (this.navigation.getState(workspace) === Constants.STATE.WORKSPACE) {
           this.announcer.setText('context out');
           const cursor = workspace.getCursor() as LineCursor;
           if (cursor.contextOut()) {
@@ -877,7 +877,7 @@ export class NavigationController {
       preconditionFn: (workspace) => this.canCurrentlyNavigate(workspace),
       // Print out the type of the current node.
       callback: (workspace) => {
-        if (this.navigation.getState(workspace) == Constants.STATE.WORKSPACE) {
+        if (this.navigation.getState(workspace) === Constants.STATE.WORKSPACE) {
           const cursor = workspace.getCursor() as LineCursor;
           if (cursor.contextIn()) {
             this.announcer.setText('context in');
@@ -996,7 +996,7 @@ export class NavigationController {
         const ws = scope.block?.workspace;
         if (!ws) return false;
 
-        if (this.navigation.getState(ws) == Constants.STATE.WORKSPACE) {
+        if (this.navigation.getState(ws) === Constants.STATE.WORKSPACE) {
           this.navigation.openToolboxOrFlyout(ws);
           return true;
         }

--- a/src/navigation_controller.ts
+++ b/src/navigation_controller.ts
@@ -562,13 +562,8 @@ export class NavigationController {
       preconditionFn: (workspace) => this.canCurrentlyNavigate(workspace),
       callback: (workspace) => {
         switch (this.navigation.getState(workspace)) {
-          case Constants.STATE.WORKSPACE: {
-            const node = workspace.getCursor()?.getCurNode();
-            if (node?.getType() === Blockly.ASTNode.types.BLOCK)
-              this.navigation.openActionMenu(node);
-
-            return true;
-          }
+          case Constants.STATE.WORKSPACE:
+            return this.navigation.openActionMenu(workspace);
           default:
             return false;
         }

--- a/src/navigation_controller.ts
+++ b/src/navigation_controller.ts
@@ -998,8 +998,6 @@ export class NavigationController {
         const ws = block?.workspace as WorkspaceSvg | null;
         if (!ws) return 'hidden';
 
-        // if (!scope.block?.previousConnection) return 'hidden';
-
         return this.canCurrentlyEdit(ws) ? 'enabled' : 'hidden';
       },
       callback: (scope) => {


### PR DESCRIPTION
Have the context menu shortcut display an action menu, containing for now only an insert action, on stack `NEXT`/`PREVIOUS` connection nodes.

* The `blockInsertAbove` action is renamed `insert` and modified so it will work with a `{connection: Connection}` scope.
* The action menu cribs some code from the shortcut registry to run the `preconditionFn` and `displayText` methods.
* For now the action menu is positioned in the same place as its parent block's context menu would be—to be improved in a following PR.

Part of #184.