### PR TITLE
feat: return cursor to marked location when exiting toolbox

### DIFF
--- a/src/navigation.ts
+++ b/src/navigation.ts
@@ -538,10 +538,13 @@ export class Navigation {
   }
 
   /**
-   * Moves the cursor to the top connection point on on the first top block.
-   * If the workspace is empty, moves the cursor to the default location on
-   * the workspace.
-   *
+   * Sets the cursor location when focusing the workspace.
+   * Tries the following, in order, stopping after the first success:
+   *  - Resume editing by putting the cursor at the marker location, if any.
+   *  - Resume editing by returning the cursor to its previous location, if any.
+   *  - Move the cursor to the top connection point on on the first top block.
+   *  - Move the cursor to the default location on the workspace.
+   * 
    * @param workspace The main Blockly workspace.
    * @param keepPosition Whether to retain the cursor's previous position.
    */

--- a/src/navigation.ts
+++ b/src/navigation.ts
@@ -554,6 +554,13 @@ export class Navigation {
     if (!cursor) {
       return;
     }
+
+    if (this.markedNode) {
+      cursor.setCurNode(this.markedNode);
+      this.removeMark(workspace);
+      return;
+    }
+
     if (cursor.getCurNode() && keepPosition) {
       // Retain the cursor's previous position since it's set.
       return;


### PR DESCRIPTION
Fixes #168 

If navigation is tracking a marked node, `setCursorOnWorkspaceFocus` moves the cursor to the marked location and removes the mark, making it ephemeral. Resolves an issue when the user opens the toolbox (with T) and then closes it without selecting a block (using Esc).

My original implementation tried to handle `keepPosition = false` but that required plumbing `keepCursorPosition` up from `focusWorkspace` and into the calls in `navigation_controller`. 

Instead, I opted to treat the presence of the marker as a sign that the cursor position should be kept. I'm open to argument on this point.