### PR TITLE
fix: Ensure visual indicating for focus loss.

### DIFF
--- a/src/line_cursor.ts
+++ b/src/line_cursor.ts
@@ -555,6 +555,22 @@ export class LineCursor extends Marker {
     this.updateFocusIndication(oldNode, newNode);
   }
 
+  override hide(): void {
+    super.hide();
+
+    // If there's a block currently selected, remove the selection since the
+    // cursor should now be hidden.
+    const curNode = this.getCurNode();
+    if (curNode.getType() === ASTNode.types.BLOCK) {
+      const block = curNode.getLocation() as Blockly.BlockSvg;
+      if (!block.isShadow()) {
+        Blockly.common.setSelected(null);
+      } else {
+        block.removeSelect();
+      }
+    }
+  }
+
   /**
    * Implements fake selection of shadow blocks as described in
    * documentation for setCurNode.

--- a/src/navigation.ts
+++ b/src/navigation.ts
@@ -1139,7 +1139,7 @@ export class Navigation {
     // Although it seems like this should never happen, the typings are wrong
     // in the base Marker class and this can therefore be null.
     if (this.markedNode) {
-      // this.passiveFocusIndicator.show(this.markedNode);
+      this.passiveFocusIndicator.show(this.markedNode);
     }
   }
 
@@ -1149,7 +1149,7 @@ export class Navigation {
    * @param workspace The workspace.
    */
   removeMark(workspace: Blockly.WorkspaceSvg) {
-    // this.passiveFocusIndicator.hide();
+    this.passiveFocusIndicator.hide();
     this.markedNode = null;
   }
 

--- a/src/navigation.ts
+++ b/src/navigation.ts
@@ -544,7 +544,7 @@ export class Navigation {
    *  - Resume editing by returning the cursor to its previous location, if any.
    *  - Move the cursor to the top connection point on on the first top block.
    *  - Move the cursor to the default location on the workspace.
-   * 
+   *
    * @param workspace The main Blockly workspace.
    * @param keepPosition Whether to retain the cursor's previous position.
    */
@@ -1139,7 +1139,7 @@ export class Navigation {
     // Although it seems like this should never happen, the typings are wrong
     // in the base Marker class and this can therefore be null.
     if (this.markedNode) {
-      this.passiveFocusIndicator.show(this.markedNode);
+      // this.passiveFocusIndicator.show(this.markedNode);
     }
   }
 
@@ -1149,7 +1149,7 @@ export class Navigation {
    * @param workspace The workspace.
    */
   removeMark(workspace: Blockly.WorkspaceSvg) {
-    this.passiveFocusIndicator.hide();
+    // this.passiveFocusIndicator.hide();
     this.markedNode = null;
   }
 

--- a/src/navigation.ts
+++ b/src/navigation.ts
@@ -559,6 +559,15 @@ export class Navigation {
     }
 
     if (this.markedNode) {
+      // Note that this hide happens twice, one before setCurNode() and once in
+      // removeMark. The latter is actually a logical no-op because setCurNode()
+      // will trigger a selection update of the currently marked node (if it's a
+      // block) and that, in turn, clones the underlying block's
+      // pathObject.svgPath. Since svgPath is updated to remove any passive
+      // focus indicator after selection clones it, the effect of removing the
+      // indicator doesn't do anything (hence it needs to be done *before*
+      // selection is added in order to immediately take effect).
+      this.passiveFocusIndicator.hide();
       cursor.setCurNode(this.markedNode);
       this.removeMark(workspace);
       return;

--- a/src/navigation_controller.ts
+++ b/src/navigation_controller.ts
@@ -159,6 +159,11 @@ export class NavigationController {
     this.hasNavigationFocus = isFocused;
     if (isFocused) {
       this.navigation.focusWorkspace(workspace, true);
+    } else {
+      // Hide cursor to indicate lost focus. Also, mark the current node so that
+      // it can be properly restored upon returning to the workspace.
+      this.navigation.markAtCursor(workspace);
+      workspace.getCursor()?.hide();
     }
   }
 

--- a/src/passive_focus.ts
+++ b/src/passive_focus.ts
@@ -96,7 +96,11 @@ export class PassiveFocus {
     const block = node.getLocation() as BlockSvg;
     // Note that this changes rendering but does not change Blockly's
     // internal selected state.
-    block.addSelect();
+    // If the block renders selected, the selection highlight is in
+    // front of the block's path and obscures these changes.
+    block.removeSelect();
+
+    utils.dom.addClass(block.pathObject.svgPath, 'passiveBlockFocus');
   }
 
   /**
@@ -106,9 +110,8 @@ export class PassiveFocus {
    */
   hideAtBlock(node: ASTNode) {
     const block = node.getLocation() as BlockSvg;
-    // Note that this changes rendering but does not change Blockly's
-    // internal selected state.
-    block.removeSelect();
+
+    utils.dom.removeClass(block.pathObject.svgPath, 'passiveBlockFocus');
   }
 
   /**
@@ -122,8 +125,6 @@ export class PassiveFocus {
       'width': 100,
       'height': 5,
       'class': 'passiveNextIndicator',
-      'stroke': '#4286f4',
-      'fill': '#4286f4',
     });
     return indicator;
   }

--- a/src/passive_focus.ts
+++ b/src/passive_focus.ts
@@ -98,9 +98,11 @@ export class PassiveFocus {
     // internal selected state.
     // If the block renders selected, the selection highlight is in
     // front of the block's path and obscures these changes.
-    block.removeSelect();
+    // block.removeSelect();
 
+    console.log('DBG: Show at block');
     utils.dom.addClass(block.pathObject.svgPath, 'passiveBlockFocus');
+    block.pathObject.svgPath.style.strokeDasharray = '5 3';
   }
 
   /**
@@ -111,7 +113,10 @@ export class PassiveFocus {
   hideAtBlock(node: ASTNode) {
     const block = node.getLocation() as BlockSvg;
 
+    // Note that removing the class is insufficient to disable the dash.
+    console.log('DBG: Hide at block');
     utils.dom.removeClass(block.pathObject.svgPath, 'passiveBlockFocus');
+    block.pathObject.svgPath.style.strokeDasharray = 'none';
   }
 
   /**

--- a/src/passive_focus.ts
+++ b/src/passive_focus.ts
@@ -94,15 +94,7 @@ export class PassiveFocus {
    */
   showAtBlock(node: ASTNode) {
     const block = node.getLocation() as BlockSvg;
-    // Note that this changes rendering but does not change Blockly's
-    // internal selected state.
-    // If the block renders selected, the selection highlight is in
-    // front of the block's path and obscures these changes.
-    // block.removeSelect();
-
-    console.log('DBG: Show at block');
     utils.dom.addClass(block.pathObject.svgPath, 'passiveBlockFocus');
-    block.pathObject.svgPath.style.strokeDasharray = '5 3';
   }
 
   /**
@@ -112,11 +104,7 @@ export class PassiveFocus {
    */
   hideAtBlock(node: ASTNode) {
     const block = node.getLocation() as BlockSvg;
-
-    // Note that removing the class is insufficient to disable the dash.
-    console.log('DBG: Hide at block');
     utils.dom.removeClass(block.pathObject.svgPath, 'passiveBlockFocus');
-    block.pathObject.svgPath.style.strokeDasharray = 'none';
   }
 
   /**

--- a/test/index.html
+++ b/test/index.html
@@ -98,7 +98,7 @@
       }
 
       .passiveBlockFocus.blocklyPath {
-        /* stroke-dasharray: 5 3; */
+        stroke-dasharray: 5 3;
         stroke-width: 3;
         stroke: #ff69b4;
       }

--- a/test/index.html
+++ b/test/index.html
@@ -100,12 +100,12 @@
       .passiveBlockFocus.blocklyPath {
         stroke-dasharray: 5 3;
         stroke-width: 3;
-        stroke: #ff69b4;
+        stroke: #ffa200;
       }
 
       .passiveNextIndicator {
-        stroke: #ff69b4;
-        fill: #ff69b4;
+        stroke: #ffa200;
+        fill: #ffa200;
       }
     </style>
   </head>

--- a/test/index.html
+++ b/test/index.html
@@ -96,6 +96,17 @@
       #announcer {
         height: 25%;
       }
+
+      .passiveBlockFocus.blocklyPath {
+        stroke-dasharray: 5 3;
+        stroke-width: 3;
+        stroke: #ff69b4;
+      }
+
+      .passiveNextIndicator {
+        stroke: #ff69b4;
+        fill: #ff69b4;
+      }
     </style>
   </head>
 

--- a/test/index.html
+++ b/test/index.html
@@ -98,7 +98,7 @@
       }
 
       .passiveBlockFocus.blocklyPath {
-        stroke-dasharray: 5 3;
+        /* stroke-dasharray: 5 3; */
         stroke-width: 3;
         stroke: #ff69b4;
       }


### PR DESCRIPTION
Fixes #92

If the workspace loses focus, any existing block selection or cursor visuals should be hidden to represent that the focus has been lost. Instead, the passive indicator should be shown so that the user has context on where they are returning when navigating back to the workspace.

This changes the hide behavior for the line cursor to also clear any block selection that may be present (since the cursor is using selection as a means of visually highlighting blocks today).

There was an issue restoring selection due to the passive focus indicator interfering with block selection (since it was using selection). This was updated to use non-selection CSS to keep the indicator without affecting the selection state. This pulls in the changes from #236.

See video for the new state:

[Screen recording 2025-03-11 4.15.41 PM.webm](https://github.com/user-attachments/assets/2b82f8a2-4e16-471f-b579-e0908d8dc6df)