### PR TITLE
feat: toasts for move/cut/copy and enter on a block

### DIFF
--- a/src/actions/enter.ts
+++ b/src/actions/enter.ts
@@ -153,11 +153,11 @@ export class EnterAction {
     workspace.getCursor()?.setCurNode(ASTNode.createBlockNode(newBlock)!);
     this.mover.startMove(workspace);
 
-    const isTopLevelBlock =
+    const isStartBlock =
       !newBlock.outputConnection &&
       !newBlock.nextConnection &&
       !newBlock.previousConnection;
-    if (isTopLevelBlock) {
+    if (isStartBlock) {
       showUnconstrainedMoveHint(workspace, false);
     } else {
       showConstrainedMovementHint(workspace);

--- a/src/actions/mover.ts
+++ b/src/actions/mover.ts
@@ -17,6 +17,7 @@ import * as Constants from '../constants';
 import {Direction, getXYFromDirection} from '../drag_direction';
 import {KeyboardDragStrategy} from '../keyboard_drag_strategy';
 import {Navigation} from '../navigation';
+import {clearMoveHints} from '../hints';
 
 /**
  * The distance to move an item, in workspace coordinates, when
@@ -134,6 +135,8 @@ export class Mover {
    * @returns True iff move successfully finished.
    */
   finishMove(workspace: WorkspaceSvg) {
+    clearMoveHints(workspace);
+
     const info = this.moves.get(workspace);
     if (!info) throw new Error('no move info for workspace');
 
@@ -157,6 +160,8 @@ export class Mover {
    * @returns True iff move successfully aborted.
    */
   abortMove(workspace: WorkspaceSvg) {
+    clearMoveHints(workspace);
+
     const info = this.moves.get(workspace);
     if (!info) throw new Error('no move info for workspace');
 

--- a/src/hints.ts
+++ b/src/hints.ts
@@ -1,0 +1,121 @@
+/**
+ * Centralises hints that we show.
+ *
+ * @license
+ * Copyright 2025 Google LLC
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import {WorkspaceSvg, Toast} from 'blockly';
+import {SHORTCUT_NAMES} from './constants';
+import {getShortActionShortcut} from './shortcut_formatting';
+
+const unconstrainedMoveHintId = 'unconstrainedMoveHint';
+const constrainedMoveHintId = 'constrainedMoveHint';
+const copiedHintId = 'copiedHint';
+const cutHintId = 'cutHint';
+const helpHintId = 'helpHint';
+
+/**
+ * Nudge the user to use unconstrained movement.
+ *
+ * @param workspace Workspace.
+ * @param force Set to show it even if previously shown.
+ */
+export function showUnconstrainedMoveHint(
+  workspace: WorkspaceSvg,
+  force = false,
+) {
+  const enter = getShortActionShortcut(SHORTCUT_NAMES.EDIT_OR_CONFIRM);
+  const modifier = navigator.platform.startsWith('Mac') ? '⌥' : 'Ctrl';
+  const message = `Hold ${modifier} and use arrow keys to move freely, then ${enter} to accept the position`;
+  Toast.show(workspace, {
+    message,
+    id: unconstrainedMoveHintId,
+    oncePerSession: !force,
+  });
+}
+
+/**
+ * Nudge the user to move a block that's in move mode.
+ *
+ * @param workspace Workspace.
+ */
+export function showConstrainedMovementHint(workspace: WorkspaceSvg) {
+  const enter = getShortActionShortcut(SHORTCUT_NAMES.EDIT_OR_CONFIRM);
+  const message = `Use the arrow keys to move, then ${enter} to accept the position`;
+  Toast.show(workspace, {
+    message,
+    id: constrainedMoveHintId,
+    oncePerSession: true,
+  });
+}
+
+/**
+ * Clear active move-related hints, if any.
+ *
+ * @param workspace The workspace.
+ */
+export function clearMoveHints(workspace: WorkspaceSvg) {
+  Toast.hide(workspace, constrainedMoveHintId);
+  Toast.hide(workspace, unconstrainedMoveHintId);
+}
+
+/**
+ * Nudge the user to paste after a copy.
+ *
+ * @param workspace Workspace.
+ */
+export function showCopiedHint(workspace: WorkspaceSvg) {
+  Toast.show(workspace, {
+    message: `Copied. Press ${getShortActionShortcut('paste')} to paste.`,
+    duration: 7000,
+    id: copiedHintId,
+  });
+}
+
+/**
+ * Nudge the user to paste after a cut.
+ *
+ * @param workspace Workspace.
+ */
+export function showCutHint(workspace: WorkspaceSvg) {
+  Toast.show(workspace, {
+    message: `Cut. Press ${getShortActionShortcut('paste')} to paste.`,
+    duration: 7000,
+    id: cutHintId,
+  });
+}
+
+/**
+ * Clear active paste-related hints, if any.
+ *
+ * @param workspace The workspace.
+ */
+export function clearPasteHints(workspace: WorkspaceSvg) {
+  Toast.hide(workspace, cutHintId);
+  Toast.hide(workspace, copiedHintId);
+}
+
+/**
+ * Nudge the user to open the help.
+ *
+ * @param workspace The workspace.
+ */
+export function showHelpHint(workspace: WorkspaceSvg) {
+  const shortcut = getShortActionShortcut('list_shortcuts');
+  const message = `Press ${shortcut} for help on keyboard controls`;
+  const id = helpHintId;
+  Toast.show(workspace, {message, id});
+}
+
+/**
+ * Clear the help hint.
+ *
+ * @param workspace The workspace.
+ */
+export function clearHelpHint(workspace: WorkspaceSvg) {
+  // TODO: We'd like to do this in MakeCode too as we override.
+  // Could have an option for showing help in the plugin?
+  Toast.hide(workspace, helpHintId);
+}

--- a/src/index.ts
+++ b/src/index.ts
@@ -290,7 +290,7 @@ export class KeyboardNavigation {
    * Toggle visibility of a help dialog for the keyboard shortcuts.
    */
   toggleShortcutDialog(): void {
-    this.navigationController.shortcutDialog.toggle();
+    this.navigationController.shortcutDialog.toggle(this.workspace);
   }
 
   /**

--- a/src/keyboard_drag_strategy.ts
+++ b/src/keyboard_drag_strategy.ts
@@ -13,6 +13,7 @@ import {
   utils,
 } from 'blockly';
 import {Direction, getDirectionFromXY} from './drag_direction';
+import {showUnconstrainedMoveHint} from './hints';
 
 // Copied in from core because it is not exported.
 interface ConnectionCandidate {
@@ -70,6 +71,12 @@ export class KeyboardDragStrategy extends dragging.BlockDragStrategy {
     } else {
       // Handle the case when unconstrained drag was far from any candidate.
       this.searchNode = null;
+
+      if (this.isConstrainedMovement()) {
+        // @ts-expect-error private field
+        const workspace = this.workspace;
+        showUnconstrainedMoveHint(workspace, true);
+      }
     }
   }
 

--- a/src/shortcut_dialog.ts
+++ b/src/shortcut_dialog.ts
@@ -11,6 +11,7 @@ import {
   getLongActionShortcutsAsKeys,
   upperCaseFirst,
 } from './shortcut_formatting';
+import {clearHelpHint} from './hints';
 
 /**
  * Class for handling the shortcuts dialog.
@@ -64,7 +65,12 @@ export class ShortcutDialog {
     }
   }
 
-  toggle() {
+  toggle(workspace: Blockly.WorkspaceSvg) {
+    clearHelpHint(workspace);
+    this.toggleInternal();
+  }
+
+  toggleInternal() {
     if (this.modalContainer && this.shortcutDialog) {
       // Use built in dialog methods.
       if (this.shortcutDialog.hasAttribute('open')) {
@@ -132,7 +138,7 @@ export class ShortcutDialog {
       // Can we also intercept the Esc key to dismiss.
       if (this.closeButton) {
         this.closeButton.addEventListener('click', (e) => {
-          this.toggle();
+          this.toggleInternal();
         });
       }
     }
@@ -161,8 +167,8 @@ export class ShortcutDialog {
     /** List all of the currently registered shortcuts. */
     const announceShortcut: ShortcutRegistry.KeyboardShortcut = {
       name: Constants.SHORTCUT_NAMES.LIST_SHORTCUTS,
-      callback: () => {
-        this.toggle();
+      callback: (workspace) => {
+        this.toggle(workspace);
         return true;
       },
       keyCodes: [Blockly.utils.KeyCodes.SLASH],


### PR DESCRIPTION
The enter on a block toast shows generic help and we might consider showing it earlier if e.g. the user tabs to the workspace or otherwise focusses it by keyboard.

This logically conflicts with https://github.com/google/blockly-keyboard-experimentation/pull/458 which moves some related text to Blockly.Msg but (obviously!) not the new text. We can merge in either order and clean up after or block one on the other.
