### PR TITLE
feat: use CSS for passive focus on blocks and next connections

### DIFF
--- a/src/passive_focus.ts
+++ b/src/passive_focus.ts
@@ -96,7 +96,11 @@ export class PassiveFocus {
     const block = node.getLocation() as BlockSvg;
     // Note that this changes rendering but does not change Blockly's
     // internal selected state.
-    block.addSelect();
+    // If the block renders selected, the selection highlight is in
+    // front of the block's path and obscures these changes.
+    block.removeSelect();
+
+    utils.dom.addClass(block.pathObject.svgPath, 'passiveBlockFocus');
   }
 
   /**
@@ -106,9 +110,8 @@ export class PassiveFocus {
    */
   hideAtBlock(node: ASTNode) {
     const block = node.getLocation() as BlockSvg;
-    // Note that this changes rendering but does not change Blockly's
-    // internal selected state.
-    block.removeSelect();
+
+    utils.dom.removeClass(block.pathObject.svgPath, 'passiveBlockFocus');
   }
 
   /**
@@ -122,8 +125,6 @@ export class PassiveFocus {
       'width': 100,
       'height': 5,
       'class': 'passiveNextIndicator',
-      'stroke': '#4286f4',
-      'fill': '#4286f4',
     });
     return indicator;
   }

--- a/test/index.html
+++ b/test/index.html
@@ -96,6 +96,17 @@
       #announcer {
         height: 25%;
       }
+
+      .passiveBlockFocus.blocklyPath {
+        stroke-dasharray: 5 3;
+        stroke-width: 3;
+        stroke: #ff69b4;
+      }
+
+      .passiveNextIndicator {
+        stroke: #ff69b4;
+        fill: #ff69b4;
+      }
     </style>
   </head>
 


### PR DESCRIPTION
Demo code for how to do https://github.com/google/blockly-keyboard-experimentation/issues/212 with CSS for blocks and next connections.

Passive focus on a next connection:
![](https://github.com/user-attachments/assets/e19e999f-1d77-45da-aeca-66b233cb1aef)


Passive focus on a block:
![](https://github.com/user-attachments/assets/e35fb8b8-5f6c-4d7a-86a8-0e0bd703205f)


These can be controlled with the CSS in `test/index.html`, or CSS in the page where you are doing testing.

The use of hot pink with dashes is a cry for help, not a suggestion. It should not be merged with that color--I just wanted to make it easy to see in the screenshots.