### PR TITLE
feat: Allow using space or enter to activate items.

### DIFF
--- a/src/navigation_controller.ts
+++ b/src/navigation_controller.ts
@@ -424,7 +424,9 @@ export class NavigationController {
     enter: {
       name: Constants.SHORTCUT_NAMES.MARK, // FIXME
       preconditionFn: (workspace) => this.canCurrentlyEdit(workspace),
-      callback: (workspace) => {
+      callback: (workspace, event) => {
+        event.preventDefault();
+
         let flyoutCursor;
         let curNode;
         let nodeType;

--- a/src/navigation_controller.ts
+++ b/src/navigation_controller.ts
@@ -455,7 +455,7 @@ export class NavigationController {
             return false;
         }
       },
-      keyCodes: [KeyCodes.ENTER],
+      keyCodes: [KeyCodes.ENTER, KeyCodes.SPACE],
     },
 
     /**


### PR DESCRIPTION
This PR fixes #138 by adding `space` as an alias for `enter` for activating/marking elements in the workspace. 