### PR TITLE
feat: Focus the first contextual menu item by default.

### DIFF
--- a/src/navigation.ts
+++ b/src/navigation.ts
@@ -1387,6 +1387,20 @@ export class Navigation {
     if (!menuOptions?.length) return true;
     const fakeEvent = fakeEventForNode(node);
     Blockly.ContextMenu.show(fakeEvent, menuOptions, rtl, workspace);
+    setTimeout(() => {
+      Blockly.WidgetDiv.getDiv()
+        ?.querySelector('.blocklyMenu')
+        ?.dispatchEvent(
+          new KeyboardEvent('keydown', {
+            key: 'ArrowDown',
+            code: 'ArrowDown',
+            keyCode: 40,
+            which: 40,
+            bubbles: true,
+            cancelable: true,
+          }),
+        );
+    }, 10);
     return true;
   }
 

--- a/src/navigation.ts
+++ b/src/navigation.ts
@@ -1394,8 +1394,8 @@ export class Navigation {
           new KeyboardEvent('keydown', {
             key: 'ArrowDown',
             code: 'ArrowDown',
-            keyCode: 40,
-            which: 40,
+            keyCode: Blockly.utils.KeyCodes.DOWN,
+            which: Blockly.utils.KeyCodes.DOWN,
             bubbles: true,
             cancelable: true,
           }),


### PR DESCRIPTION
This PR fixes #244 by firing a synthetic keydown event after a brief delay to select the first item in contextual menus. The contextualmenu module unfortunately doesn't provide a method to get at the backing menu in order to call its selection methods.