### PR TITLE
fix: Scroll flyout contents into bounds.

### DIFF
--- a/src/flyout_cursor.ts
+++ b/src/flyout_cursor.ts
@@ -85,15 +85,22 @@ export class FlyoutCursor extends Blockly.Cursor {
     super.setCurNode(node);
 
     const location = node.getLocation();
+    let bounds: Blockly.utils.Rect | undefined;
     if (
-      !(
-        'getBoundingRectangle' in location &&
-        typeof location.getBoundingRectangle === 'function'
-      )
-    )
-      return;
+      'getBoundingRectangle' in location &&
+      typeof location.getBoundingRectangle === 'function'
+    ) {
+      bounds = location.getBoundingRectangle();
+    } else if (location instanceof Blockly.FlyoutButton) {
+      const {x, y} = location.getPosition();
+      bounds = new Blockly.utils.Rect(
+        y,
+        y + location.height,
+        x,
+        x + location.width,
+      );
+    }
 
-    const bounds = location.getBoundingRectangle();
     if (!(bounds instanceof Blockly.utils.Rect)) return;
 
     scrollBoundsIntoView(bounds, this.flyout.getWorkspace());

--- a/src/flyout_cursor.ts
+++ b/src/flyout_cursor.ts
@@ -10,6 +10,7 @@
  */
 
 import * as Blockly from 'blockly/core';
+import {scrollBoundsIntoView} from './workspace_utilities';
 
 /**
  * Class for a flyout cursor.
@@ -20,7 +21,7 @@ export class FlyoutCursor extends Blockly.Cursor {
   /**
    * The constructor for the FlyoutCursor.
    */
-  constructor() {
+  constructor(private readonly flyout: Blockly.IFlyout) {
     super();
   }
 
@@ -78,6 +79,24 @@ export class FlyoutCursor extends Blockly.Cursor {
    */
   override out(): null {
     return null;
+  }
+
+  override setCurNode(node: Blockly.ASTNode) {
+    super.setCurNode(node);
+
+    const location = node.getLocation();
+    if (
+      !(
+        'getBoundingRectangle' in location &&
+        typeof location.getBoundingRectangle === 'function'
+      )
+    )
+      return;
+
+    const bounds = location.getBoundingRectangle();
+    if (!(bounds instanceof Blockly.utils.Rect)) return;
+
+    scrollBoundsIntoView(bounds, this.flyout.getWorkspace());
   }
 }
 

--- a/src/line_cursor.ts
+++ b/src/line_cursor.ts
@@ -15,6 +15,7 @@
 
 import * as Blockly from 'blockly/core';
 import {ASTNode, Marker} from 'blockly/core';
+import {scrollBoundsIntoView} from './workspace_utilities';
 
 /** Options object for LineCursor instances. */
 export type CursorOptions = {
@@ -553,60 +554,13 @@ export class LineCursor extends Marker {
     const oldNode = this.getCurNode();
     super.setCurNode(newNode);
     if (newNode?.getType() === ASTNode.types.BLOCK) {
-      this.scrollBlockIntoView(newNode.getLocation() as Blockly.BlockSvg);
+      const block = newNode.getLocation() as Blockly.BlockSvg;
+      scrollBoundsIntoView(
+        block.getBoundingRectangleWithoutChildren(),
+        block.workspace,
+      );
     }
     this.updateFocusIndication(oldNode, newNode);
-  }
-
-  /**
-   * Scrolls the provided block into view.
-   *
-   * This is a basic implementation that scrolls just enough to get the block
-   * into bounds. For very small workspaces/high zoom levels the entire block
-   * may not fit, but a decent portion of it should still be visible at least.
-   *
-   * @param block The block to scroll into bounds.
-   */
-  private scrollBlockIntoView(block: Blockly.BlockSvg) {
-    const workspace = block.workspace;
-    const scale = workspace.getScale();
-    const bounds = block.getBoundingRectangleWithoutChildren();
-    const rawViewport = workspace.getMetricsManager().getViewMetrics(true);
-    const viewport = new Blockly.utils.Rect(
-      rawViewport.top,
-      rawViewport.top + rawViewport.height,
-      rawViewport.left,
-      rawViewport.left + rawViewport.width,
-    );
-
-    if (
-      bounds.left >= viewport.left &&
-      bounds.top >= viewport.top &&
-      bounds.right <= viewport.right &&
-      bounds.bottom <= viewport.bottom
-    ) {
-      // Do nothing if the block is fully inside the viewport.
-      return;
-    }
-
-    let deltaX = 0;
-    let deltaY = 0;
-
-    if (bounds.left < viewport.left) {
-      deltaX = viewport.left - bounds.left;
-    } else if (bounds.right > viewport.right) {
-      deltaX = viewport.right - bounds.right;
-    }
-
-    if (bounds.top < viewport.top) {
-      deltaY = viewport.top - bounds.top;
-    } else if (bounds.bottom > viewport.bottom) {
-      deltaY = viewport.bottom - bounds.bottom;
-    }
-
-    deltaX *= scale;
-    deltaY *= scale;
-    workspace.scroll(workspace.scrollX + deltaX, workspace.scrollY + deltaY);
   }
 
   /**

--- a/src/navigation.ts
+++ b/src/navigation.ts
@@ -1454,7 +1454,7 @@ export class Navigation {
     );
     if (typeof buttonCallback === 'function') {
       buttonCallback(button);
-    } else {
+    } else if (!button.isLabel()) {
       throw new Error('No callback function found for flyout button.');
     }
   }

--- a/src/navigation.ts
+++ b/src/navigation.ts
@@ -162,7 +162,9 @@ export class Navigation {
       cursorRegistrationName,
     );
     if (FlyoutCursorClass) {
-      flyoutWorkspace.getMarkerManager().setCursor(new FlyoutCursorClass());
+      flyoutWorkspace
+        .getMarkerManager()
+        .setCursor(new FlyoutCursorClass(flyout));
     }
   }
 

--- a/src/workspace_utilities.ts
+++ b/src/workspace_utilities.ts
@@ -1,0 +1,68 @@
+/**
+ * @license
+ * Copyright 2025 Google LLC
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import * as Blockly from 'blockly/core';
+
+/**
+ * Scrolls the provided bounds into view.
+ *
+ * In the case of small workspaces/large bounds, this function prioritizes
+ * getting the top left corner of the bounds into view. It also adds some
+ * padding around the bounds to allow the element to be comfortably in view.
+ *
+ * @param bounds A rectangle to scroll into view, as best as possible.
+ * @param workspace The workspace to scroll the given bounds into view in.
+ */
+export function scrollBoundsIntoView(
+  bounds: Blockly.utils.Rect,
+  workspace: Blockly.WorkspaceSvg,
+) {
+  const scale = workspace.getScale();
+
+  // Add some padding to the bounds so the element is scrolled comfortably
+  // into view.
+  bounds.top -= 10;
+  bounds.bottom += 10;
+  bounds.left -= 10;
+  bounds.right += 10;
+
+  const rawViewport = workspace.getMetricsManager().getViewMetrics(true);
+  const viewport = new Blockly.utils.Rect(
+    rawViewport.top,
+    rawViewport.top + rawViewport.height,
+    rawViewport.left,
+    rawViewport.left + rawViewport.width,
+  );
+
+  if (
+    bounds.left >= viewport.left &&
+    bounds.top >= viewport.top &&
+    bounds.right <= viewport.right &&
+    bounds.bottom <= viewport.bottom
+  ) {
+    // Do nothing if the block is fully inside the viewport.
+    return;
+  }
+
+  let deltaX = 0;
+  let deltaY = 0;
+
+  if (bounds.left < viewport.left) {
+    deltaX = viewport.left - bounds.left;
+  } else if (bounds.right > viewport.right) {
+    deltaX = viewport.right - bounds.right;
+  }
+
+  if (bounds.top < viewport.top) {
+    deltaY = viewport.top - bounds.top;
+  } else if (bounds.bottom > viewport.bottom) {
+    deltaY = viewport.bottom - bounds.bottom;
+  }
+
+  deltaX *= scale;
+  deltaY *= scale;
+  workspace.scroll(workspace.scrollX + deltaX, workspace.scrollY + deltaY);
+}

--- a/src/workspace_utilities.ts
+++ b/src/workspace_utilities.ts
@@ -17,10 +17,12 @@ import * as Blockly from 'blockly/core';
  * @param workspace The workspace to scroll the given bounds into view in.
  */
 export function scrollBoundsIntoView(
-  bounds: Blockly.utils.Rect,
+  originalBounds: Blockly.utils.Rect,
   workspace: Blockly.WorkspaceSvg,
 ) {
   const scale = workspace.getScale();
+
+  const bounds = originalBounds.clone();
 
   // Add some padding to the bounds so the element is scrolled comfortably
   // into view.

--- a/test/blocks/toolbox.js
+++ b/test/blocks/toolbox.js
@@ -36,6 +36,10 @@ export const p5CategoryContents = [
     },
   },
   {
+    kind: 'label',
+    text: 'Writing text',
+  },
+  {
     kind: 'block',
     type: 'write_text_with_shadow',
     inputs: {


### PR DESCRIPTION
This PR fixes #90 by updating the flyout to scroll the selected item into view. It refactors similar logic for the main workspace out into a shared function used by both. It also fixes #150.