### PR TITLE
feat: remove 'e' shortcut for exit

### DIFF
--- a/src/navigation_controller.ts
+++ b/src/navigation_controller.ts
@@ -515,7 +515,7 @@ export class NavigationController {
             return false;
         }
       },
-      keyCodes: [KeyCodes.ESC, KeyCodes.E],
+      keyCodes: [KeyCodes.ESC],
       allowCollision: true,
     },
 


### PR DESCRIPTION
We prefer folks to learn Escape as it's more widely applicable, e.g. to close field editors.

Fixes #256 

I checked this in combination with #250 and the dialog just lists one "Exit - Escape" keybinding which looks good.

**This needs Blockly review of the issue to check you agree with the plan.  Just preparing this PR so it's trivial to proceed if desired**
