### PR TITLE
fix: Disallow disconnecting immovable blocks.

### DIFF
--- a/src/navigation.ts
+++ b/src/navigation.ts
@@ -1116,6 +1116,12 @@ export class Navigation {
       this.log('Cannot disconnect a shadow block');
       return;
     }
+
+    if (!inferiorConnection.getSourceBlock().isMovable()) {
+      this.log('Cannot disconnect an immovable block');
+      return;
+    }
+
     superiorConnection.disconnect();
     inferiorConnection.bumpAwayFrom(superiorConnection);
 


### PR DESCRIPTION
This PR fixes #253 by checking if blocks are movable before disconnecting them.