### PR TITLE
fix: Cursor position after delete

### DIFF
--- a/src/actions/clipboard.ts
+++ b/src/actions/clipboard.ts
@@ -13,6 +13,7 @@ import {
 } from 'blockly';
 import * as Constants from '../constants';
 import type {BlockSvg, WorkspaceSvg} from 'blockly';
+import {LineCursor} from '../line_cursor';
 import {Navigation} from '../navigation';
 
 const KeyCodes = blocklyUtils.KeyCodes;
@@ -163,13 +164,13 @@ export class Clipboard {
    * @returns True if this function successfully handled cutting.
    */
   private cutCallback(workspace: WorkspaceSvg) {
-    const sourceBlock = workspace
-      .getCursor()
-      ?.getCurNode()
-      .getSourceBlock() as BlockSvg;
+    const cursor = workspace.getCursor();
+    if (!cursor) throw new TypeError('no cursor');
+    const sourceBlock = cursor.getCurNode().getSourceBlock() as BlockSvg | null;
+    if (!sourceBlock) throw new TypeError('no source block');
     this.copyData = sourceBlock.toCopyData();
     this.copyWorkspace = sourceBlock.workspace;
-    this.navigation.moveCursorOnBlockDelete(workspace, sourceBlock);
+    if (cursor instanceof LineCursor) cursor.prepareForDelete(sourceBlock);
     sourceBlock.checkAndDelete();
     return true;
   }

--- a/src/actions/clipboard.ts
+++ b/src/actions/clipboard.ts
@@ -170,8 +170,9 @@ export class Clipboard {
     if (!sourceBlock) throw new TypeError('no source block');
     this.copyData = sourceBlock.toCopyData();
     this.copyWorkspace = sourceBlock.workspace;
-    if (cursor instanceof LineCursor) cursor.prepareForDelete(sourceBlock);
+    if (cursor instanceof LineCursor) cursor.preDelete(sourceBlock);
     sourceBlock.checkAndDelete();
+    if (cursor instanceof LineCursor) cursor.postDelete();
     return true;
   }
 

--- a/src/actions/delete.ts
+++ b/src/actions/delete.ts
@@ -12,6 +12,7 @@ import {
 } from 'blockly';
 import * as Constants from '../constants';
 import type {BlockSvg, WorkspaceSvg} from 'blockly';
+import {LineCursor} from '../line_cursor';
 import {Navigation} from '../navigation';
 
 const KeyCodes = BlocklyUtils.KeyCodes;
@@ -181,7 +182,7 @@ export class DeleteAction {
     // Don't delete while dragging.  Jeez.
     if (Gesture.inProgress()) false;
 
-    this.navigation.moveCursorOnBlockDelete(workspace, sourceBlock);
+    if (cursor instanceof LineCursor) cursor.prepareForDelete(sourceBlock);
     sourceBlock.checkAndDelete();
     return true;
   }

--- a/src/actions/delete.ts
+++ b/src/actions/delete.ts
@@ -182,8 +182,9 @@ export class DeleteAction {
     // Don't delete while dragging.  Jeez.
     if (Gesture.inProgress()) false;
 
-    if (cursor instanceof LineCursor) cursor.prepareForDelete(sourceBlock);
+    if (cursor instanceof LineCursor) cursor.preDelete(sourceBlock);
     sourceBlock.checkAndDelete();
+    if (cursor instanceof LineCursor) cursor.postDelete();
     return true;
   }
 }

--- a/src/actions/insert.ts
+++ b/src/actions/insert.ts
@@ -88,9 +88,9 @@ export class InsertAction {
     const insertAboveItem: ContextMenuRegistry.RegistryItem = {
       displayText: (scope) => {
         if (scope.block?.previousConnection) {
-          return 'Insert Block Above (I)'
+          return 'Insert Block Above (I)';
         } else {
-          return 'Insert Block (I)'
+          return 'Insert Block (I)';
         }
       },
       preconditionFn: (scope: Scope) => {

--- a/src/line_cursor.ts
+++ b/src/line_cursor.ts
@@ -47,7 +47,7 @@ export class LineCursor extends Marker {
 
   /** Locations to try moving the cursor to after a deletion. */
   private potentialNodes: Blockly.ASTNode[] | null = null;
-  
+
   /**
    * @param workspace The workspace this cursor belongs to.
    */
@@ -270,7 +270,10 @@ export class LineCursor extends Marker {
    * @returns True if the node should be visited, false otherwise.
    */
   protected validNode(node: ASTNode | null): boolean {
-    return !!node && (this.validInLineNode(node) || node.getType() === ASTNode.types.WORKSPACE);
+    return (
+      !!node &&
+      (this.validInLineNode(node) || node.getType() === ASTNode.types.WORKSPACE)
+    );
   }
 
   /**
@@ -527,11 +530,13 @@ export class LineCursor extends Marker {
     const curNode = this.getCurNode();
 
     const nodes: Blockly.ASTNode[] = [curNode];
-   // The connection to which the deleted block is attached.
-    const parentConnection = deletedBlock.previousConnection?.targetConnection ?? deletedBlock.outputConnection?.targetConnection;
+    // The connection to which the deleted block is attached.
+    const parentConnection =
+      deletedBlock.previousConnection?.targetConnection ??
+      deletedBlock.outputConnection?.targetConnection;
     if (parentConnection) {
       const parentNode = Blockly.ASTNode.createConnectionNode(parentConnection);
-      if (parentNode) nodes.push(parentNode)
+      if (parentNode) nodes.push(parentNode);
     }
     // The block connected to the next connection of the deleted block.
     const nextBlock = deletedBlock.getNextBlock();

--- a/src/navigation.ts
+++ b/src/navigation.ts
@@ -406,61 +406,6 @@ export class Navigation {
   }
 
   /**
-   * Moves the cursor to the appropriate location before a block is deleted.
-   * This is used when the user deletes a block using the delete or backspace
-   * key.
-   *
-   * @param workspace The workspace the block is being deleted on.
-   * @param deletedBlock The block that is being deleted.
-   */
-  moveCursorOnBlockDelete(
-    workspace: Blockly.WorkspaceSvg,
-    deletedBlock: Blockly.BlockSvg,
-  ) {
-    const cursor = workspace.getCursor();
-    if (!cursor) {
-      return;
-    }
-    const curNode = cursor.getCurNode();
-    const block = curNode ? curNode.getSourceBlock() : null;
-
-    if (block === deletedBlock) {
-      // If the block has a parent move the cursor to their connection point.
-      if (block.getParent()) {
-        const topConnection =
-          block.previousConnection || block.outputConnection;
-        if (topConnection?.targetConnection) {
-          cursor.setCurNode(
-            Blockly.ASTNode.createConnectionNode(
-              topConnection.targetConnection,
-            )!,
-          );
-        }
-      } else {
-        // If the block is by itself move the cursor to the workspace.
-        cursor.setCurNode(
-          Blockly.ASTNode.createWorkspaceNode(
-            block.workspace,
-            block.getRelativeToSurfaceXY(),
-          )!,
-        );
-      }
-      // If the cursor is on a block whose parent is being deleted, move the
-      // cursor to the workspace.
-    } else if (
-      block &&
-      deletedBlock.getChildren(false).includes(block as Blockly.BlockSvg)
-    ) {
-      cursor.setCurNode(
-        Blockly.ASTNode.createWorkspaceNode(
-          block.workspace,
-          block.getRelativeToSurfaceXY(),
-        )!,
-      );
-    }
-  }
-
-  /**
    * Sets the navigation state to toolbox and selects the first category in the
    * toolbox. No-op if a toolbox does not exist on the given workspace.
    *


### PR DESCRIPTION
Refactor to have `LineCursor` rather than `Navigation` decide where the cursor will move to when a block deletion occurs.

The cursor is moved to first of the following locations that is valid:

- The current location.
- The connection to which the deleted block is attached.
- The block connected to the next connection of the deleted block.
- The parent block of the deleted block.
- A location on the workspace beneath the deleted block.

Part of #254.