### PR TITLE
feat: Show Paste menu item on connections.

### DIFF
--- a/src/actions/clipboard.ts
+++ b/src/actions/clipboard.ts
@@ -303,13 +303,17 @@ export class Clipboard {
     const pasteAction: ContextMenuRegistry.RegistryItem = {
       displayText: (scope) => `Paste (${this.getPlatformPrefix()}V)`,
       preconditionFn: (scope) => {
-        const ws = scope.block?.workspace;
+        const ws =
+          scope.block?.workspace ??
+          (scope as any).connection?.getSourceBlock().workspace;
         if (!ws) return 'hidden';
 
         return this.pastePrecondition(ws) ? 'enabled' : 'disabled';
       },
       callback: (scope) => {
-        const ws = scope.block?.workspace;
+        const ws =
+          scope.block?.workspace ??
+          (scope as any).connection?.getSourceBlock().workspace;
         if (!ws) return;
         return this.pasteCallback(ws);
       },

--- a/src/navigation.ts
+++ b/src/navigation.ts
@@ -1359,7 +1359,12 @@ export class Navigation {
         const insertAction =
           Blockly.ContextMenuRegistry.registry.getItem('insert');
         if (!insertAction) throw new Error("can't find insert action");
-        const possibleOptions = [insertAction /* etc.*/];
+
+        const pasteAction = Blockly.ContextMenuRegistry.registry.getItem(
+          'blockPasteFromContextMenu',
+        );
+        if (!pasteAction) throw new Error("can't find paste action");
+        const possibleOptions = [insertAction, pasteAction /* etc.*/];
 
         // Check preconditions and get menu texts.
         const scope = {


### PR DESCRIPTION
This PR fixes #238 by adding a Paste menu item to the action menu when invoked on connections. This follows the same pattern as was used for the Insert Block menu item.