### PR TITLE
fix: shortcut dialog ChromeOS detection, tweak Linux

### DIFF
--- a/src/constants.ts
+++ b/src/constants.ts
@@ -65,16 +65,6 @@ export enum LOGGING_MSG_TYPE {
 }
 
 /**
- * Platform specific modifier key used in shortcuts.
- */
-export enum MODIFIER_KEY {
-  Windows = 'Ctrl',
-  ChromeOS = 'Ctrl',
-  macOS = '⌘ Command',
-  Linux = 'Meta',
-}
-
-/**
  * Categories used to organised the shortcut dialog.
  * Shortcut name should match those obtained from the Blockly shortcut register.
  */

--- a/src/shortcut_dialog.ts
+++ b/src/shortcut_dialog.ts
@@ -34,17 +34,16 @@ export class ShortcutDialog {
   }
 
   getPlatform() {
-    const platform = navigator.platform;
-
-    // Check for Windows platforms
+    const {platform, userAgent} = navigator;
     if (platform.startsWith('Win')) {
       return 'Windows';
     } else if (platform.startsWith('Mac')) {
       return 'macOS';
+    } else if (/\bCrOS\b/.test(userAgent)) {
+      // Order is important because platform matches the Linux case below.
+      return 'ChromeOS';
     } else if (platform.includes('Linux')) {
       return 'Linux';
-    } else if (platform.includes('chromeOS')) {
-      return 'ChromeOS';
     } else {
       return 'Unknown';
     }
@@ -69,11 +68,9 @@ export class ShortcutDialog {
         this.shortcutDialog.querySelectorAll('.key.modifier');
 
       if (modifierKeys.length > 0 && platform) {
-        for (let key of modifierKeys) {
+        for (const key of modifierKeys) {
           key.textContent =
-            Constants.MODIFIER_KEY[
-              platform as keyof typeof Constants.MODIFIER_KEY
-            ];
+            this.getPlatform() === 'macOS' ? '⌘ Command' : 'Ctrl';
         }
       }
     }


### PR DESCRIPTION
navigator.platform is "Linux x86_64" so we need the user agent to distinguish.

I've also changed Meta -> Ctrl for Linux users too as I think it's really only
Emacs users who talk about a meta key these days and Ctrl is what will work for
current Linux environments.

Essentially we're only distinguishing ChromeOS for the dialog title.

Flagged by @kmcnaught as an issue for user testing but we'll merge this PR locally so no rush to review.

Demo: https://fix-chromeos.blockly-keyboard-experimentation.pages.dev/

I have tested on ChromeOS, Mac and Windows.
I'll review Linux this evening UK time.