### PR TITLE
fix: don't keep cursor on disposed blocks

### DIFF
--- a/src/navigation.ts
+++ b/src/navigation.ts
@@ -511,10 +511,10 @@ export class Navigation {
       return;
     }
 
-    // This can happen if blocks are reloaded.
-    const isDisposed = cursor.getCurNode()?.getSourceBlock()?.disposed;
-    if (cursor.getCurNode() && !isDisposed && keepPosition) {
-      // Retain the cursor's previous position since it's set.
+    const disposed = cursor.getCurNode()?.getSourceBlock()?.disposed;
+    if (cursor.getCurNode() && !disposed && keepPosition) {
+      // Retain the cursor's previous position since it's set, but only if not
+      // disposed (which can happen when blocks are reloaded).
       return;
     }
     const wsCoordinates = new Blockly.utils.Coordinate(

--- a/src/navigation.ts
+++ b/src/navigation.ts
@@ -511,7 +511,9 @@ export class Navigation {
       return;
     }
 
-    if (cursor.getCurNode() && keepPosition) {
+    // This can happen if blocks are reloaded.
+    const isDisposed = cursor.getCurNode()?.getSourceBlock()?.disposed;
+    if (cursor.getCurNode() && !isDisposed && keepPosition) {
       // Retain the cursor's previous position since it's set.
       return;
     }


### PR DESCRIPTION
Perhaps this should be cleared earlier, but this scenario happens in MakeCode when switching back to Blocks mode from JavaScript.

One approach to https://github.com/google/blockly-keyboard-experimentation/issues/146

This feels like a last-ditch way to notice an invalid selection but I think it's common (as in MakeCode and the test app) to disable events during loading so the listeners can't do this for us.