### PR TITLE
chore: move workspace movement into a separate file

### DIFF
--- a/src/actions/ws_movement.ts
+++ b/src/actions/ws_movement.ts
@@ -1,0 +1,133 @@
+/**
+ * @license
+ * Copyright 2025 Google LLC
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import {ASTNode, ShortcutRegistry, utils as blocklyUtils} from 'blockly';
+import * as Constants from '../constants';
+import type {WorkspaceSvg} from 'blockly';
+
+const KeyCodes = blocklyUtils.KeyCodes;
+const createSerializedKey = ShortcutRegistry.registry.createSerializedKey.bind(
+  ShortcutRegistry.registry,
+);
+
+/**
+ * Logic for free movement of the cursor on the workspace with keyboard
+ * shortcuts.
+ */
+export class WorkspaceMovement {
+  /**
+   * Function provided by the navigation controller to say whether editing
+   * is allowed.
+   */
+  private canCurrentlyEdit: (ws: WorkspaceSvg) => boolean;
+
+  /**
+   * The distance to move the cursor when the cursor is on the workspace.
+   */
+  WS_MOVE_DISTANCE = 40;
+
+  constructor(canEdit: (ws: WorkspaceSvg) => boolean) {
+    this.canCurrentlyEdit = canEdit;
+  }
+
+  /**
+   * Install these actions as both keyboard shortcuts and context menu items.
+   */
+  install() {
+    const shortcutList: {
+      [name: string]: ShortcutRegistry.KeyboardShortcut;
+    } = {
+      /** Move the cursor on the workspace to the left. */
+      wsMoveLeft: {
+        name: Constants.SHORTCUT_NAMES.MOVE_WS_CURSOR_LEFT,
+        preconditionFn: (workspace) => this.canCurrentlyEdit(workspace),
+        callback: (workspace) => this.moveWSCursor(workspace, -1, 0),
+        keyCodes: [createSerializedKey(KeyCodes.A, [KeyCodes.SHIFT])],
+      },
+      /** Move the cursor on the workspace to the right. */
+      wsMoveRight: {
+        name: Constants.SHORTCUT_NAMES.MOVE_WS_CURSOR_RIGHT,
+        preconditionFn: (workspace) => this.canCurrentlyEdit(workspace),
+        callback: (workspace) => this.moveWSCursor(workspace, 1, 0),
+        keyCodes: [createSerializedKey(KeyCodes.D, [KeyCodes.SHIFT])],
+      },
+
+      /** Move the cursor on the workspace up. */
+      wsMoveUp: {
+        name: Constants.SHORTCUT_NAMES.MOVE_WS_CURSOR_UP,
+        preconditionFn: (workspace) => this.canCurrentlyEdit(workspace),
+        callback: (workspace) => this.moveWSCursor(workspace, 0, -1),
+        keyCodes: [createSerializedKey(KeyCodes.W, [KeyCodes.SHIFT])],
+      },
+
+      /** Move the cursor on the workspace down. */
+      wsMoveDown: {
+        name: Constants.SHORTCUT_NAMES.MOVE_WS_CURSOR_DOWN,
+        preconditionFn: (workspace) => this.canCurrentlyEdit(workspace),
+        callback: (workspace) => this.moveWSCursor(workspace, 0, 1),
+        keyCodes: [createSerializedKey(KeyCodes.S, [KeyCodes.SHIFT])],
+      },
+    };
+    for (const shortcut of Object.values(shortcutList)) {
+      ShortcutRegistry.registry.register(shortcut);
+    }
+  }
+
+  /**
+   * Uninstall these actions.
+   */
+  uninstall() {
+    ShortcutRegistry.registry.unregister(
+      Constants.SHORTCUT_NAMES.MOVE_WS_CURSOR_LEFT,
+    );
+    ShortcutRegistry.registry.unregister(
+      Constants.SHORTCUT_NAMES.MOVE_WS_CURSOR_RIGHT,
+    );
+    ShortcutRegistry.registry.unregister(
+      Constants.SHORTCUT_NAMES.MOVE_WS_CURSOR_UP,
+    );
+    ShortcutRegistry.registry.unregister(
+      Constants.SHORTCUT_NAMES.MOVE_WS_CURSOR_DOWN,
+    );
+  }
+
+  /**
+   * Moves the workspace cursor in the given direction.
+   *
+   * @param workspace The workspace the cursor is on.
+   * @param xDirection -1 to move cursor left. 1 to move cursor right.
+   * @param yDirection -1 to move cursor up. 1 to move cursor down.
+   * @returns True if the current node is a workspace, false
+   *     otherwise.
+   */
+  moveWSCursor(
+    workspace: WorkspaceSvg,
+    xDirection: number,
+    yDirection: number,
+  ): boolean {
+    const cursor = workspace.getCursor();
+    if (!cursor) {
+      return false;
+    }
+    const curNode = cursor.getCurNode();
+
+    if (curNode.getType() !== ASTNode.types.WORKSPACE) {
+      return false;
+    }
+
+    const wsCoord = curNode.getWsCoordinate();
+    const newX = xDirection * this.WS_MOVE_DISTANCE + wsCoord.x;
+    const newY = yDirection * this.WS_MOVE_DISTANCE + wsCoord.y;
+
+    cursor.setCurNode(
+      ASTNode.createWorkspaceNode(
+        workspace,
+        new blocklyUtils.Coordinate(newX, newY),
+      )!,
+    );
+    return true;
+  }
+}

--- a/src/actions/ws_movement.ts
+++ b/src/actions/ws_movement.ts
@@ -4,11 +4,11 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-import {ASTNode, ShortcutRegistry, utils as blocklyUtils} from 'blockly';
+import {ASTNode, ShortcutRegistry, utils as BlocklyUtils} from 'blockly';
 import * as Constants from '../constants';
 import type {WorkspaceSvg} from 'blockly';
 
-const KeyCodes = blocklyUtils.KeyCodes;
+const KeyCodes = BlocklyUtils.KeyCodes;
 const createSerializedKey = ShortcutRegistry.registry.createSerializedKey.bind(
   ShortcutRegistry.registry,
 );
@@ -125,7 +125,7 @@ export class WorkspaceMovement {
     cursor.setCurNode(
       ASTNode.createWorkspaceNode(
         workspace,
-        new blocklyUtils.Coordinate(newX, newY),
+        new BlocklyUtils.Coordinate(newX, newY),
       )!,
     );
     return true;

--- a/src/navigation.ts
+++ b/src/navigation.ts
@@ -30,11 +30,6 @@ export class Navigation {
   workspaceStates: {[index: string]: Constants.STATE} = {};
 
   /**
-   * The distance to move the cursor when the cursor is on the workspace.
-   */
-  WS_MOVE_DISTANCE = 40;
-
-  /**
    * The default coordinate to use when focusing on the workspace and no
    * blocks are present. In pixel coordinates, but will be converted to
    * workspace coordinates when used to position the cursor.
@@ -1171,43 +1166,6 @@ export class Navigation {
    */
   error(msg: string) {
     console.error(msg);
-  }
-
-  /**
-   * Moves the workspace cursor in the given direction.
-   *
-   * @param workspace The workspace the cursor is on.
-   * @param xDirection -1 to move cursor left. 1 to move cursor right.
-   * @param yDirection -1 to move cursor up. 1 to move cursor down.
-   * @returns True if the current node is a workspace, false
-   *     otherwise.
-   */
-  moveWSCursor(
-    workspace: Blockly.WorkspaceSvg,
-    xDirection: number,
-    yDirection: number,
-  ): boolean {
-    const cursor = workspace.getCursor();
-    if (!cursor) {
-      return false;
-    }
-    const curNode = cursor.getCurNode();
-
-    if (curNode.getType() !== Blockly.ASTNode.types.WORKSPACE) {
-      return false;
-    }
-
-    const wsCoord = curNode.getWsCoordinate();
-    const newX = xDirection * this.WS_MOVE_DISTANCE + wsCoord.x;
-    const newY = yDirection * this.WS_MOVE_DISTANCE + wsCoord.y;
-
-    cursor.setCurNode(
-      Blockly.ASTNode.createWorkspaceNode(
-        workspace,
-        new Blockly.utils.Coordinate(newX, newY),
-      )!,
-    );
-    return true;
   }
 
   /**

--- a/src/navigation_controller.ts
+++ b/src/navigation_controller.ts
@@ -29,6 +29,7 @@ import {ShortcutDialog} from './shortcut_dialog';
 import {DeleteAction} from './actions/delete';
 import {InsertAction} from './actions/insert';
 import {Clipboard} from './actions/clipboard';
+import {WorkspaceMovement} from './actions/ws_movement';
 
 const KeyCodes = BlocklyUtils.KeyCodes;
 const createSerializedKey = ShortcutRegistry.registry.createSerializedKey.bind(
@@ -57,6 +58,10 @@ export class NavigationController {
 
   clipboard: Clipboard = new Clipboard(
     this.navigation,
+    this.canCurrentlyEdit.bind(this),
+  );
+
+  workspaceMovement: WorkspaceMovement = new WorkspaceMovement(
     this.canCurrentlyEdit.bind(this),
   );
 
@@ -519,46 +524,6 @@ export class NavigationController {
       allowCollision: true,
     },
 
-    /** Move the cursor on the workspace to the left. */
-    wsMoveLeft: {
-      name: Constants.SHORTCUT_NAMES.MOVE_WS_CURSOR_LEFT,
-      preconditionFn: (workspace) => this.canCurrentlyEdit(workspace),
-      callback: (workspace) => {
-        return this.navigation.moveWSCursor(workspace, -1, 0);
-      },
-      keyCodes: [createSerializedKey(KeyCodes.A, [KeyCodes.SHIFT])],
-    },
-
-    /** Move the cursor on the workspace to the right. */
-    wsMoveRight: {
-      name: Constants.SHORTCUT_NAMES.MOVE_WS_CURSOR_RIGHT,
-      preconditionFn: (workspace) => this.canCurrentlyEdit(workspace),
-      callback: (workspace) => {
-        return this.navigation.moveWSCursor(workspace, 1, 0);
-      },
-      keyCodes: [createSerializedKey(KeyCodes.D, [KeyCodes.SHIFT])],
-    },
-
-    /** Move the cursor on the workspace up. */
-    wsMoveUp: {
-      name: Constants.SHORTCUT_NAMES.MOVE_WS_CURSOR_UP,
-      preconditionFn: (workspace) => this.canCurrentlyEdit(workspace),
-      callback: (workspace) => {
-        return this.navigation.moveWSCursor(workspace, 0, -1);
-      },
-      keyCodes: [createSerializedKey(KeyCodes.W, [KeyCodes.SHIFT])],
-    },
-
-    /** Move the cursor on the workspace down. */
-    wsMoveDown: {
-      name: Constants.SHORTCUT_NAMES.MOVE_WS_CURSOR_DOWN,
-      preconditionFn: (workspace) => this.canCurrentlyEdit(workspace),
-      callback: (workspace) => {
-        return this.navigation.moveWSCursor(workspace, 0, 1);
-      },
-      keyCodes: [createSerializedKey(KeyCodes.S, [KeyCodes.SHIFT])],
-    },
-
     /** List all of the currently registered shortcuts. */
     announceShortcuts: {
       name: Constants.SHORTCUT_NAMES.LIST_SHORTCUTS,
@@ -714,6 +679,7 @@ export class NavigationController {
     }
     this.deleteAction.install();
     this.insertAction.install();
+    this.workspaceMovement.install();
 
     this.clipboard.install();
 
@@ -734,6 +700,7 @@ export class NavigationController {
     this.deleteAction.uninstall();
     this.insertAction.uninstall();
     this.clipboard.uninstall();
+    this.workspaceMovement.uninstall();
 
     this.removeShortcutHandlers();
     this.navigation.dispose();


### PR DESCRIPTION
We don't know exactly what free movement on the workspace will look like yet, but we know we'll want some form of it.

This PR consolidates the existing code into a single action file, including implementation code that used to be in `navigation.ts`. As a side benefit, you can see from the result that there's no dependency on the `Navigation` class at this point: all of workspace navigation can be done by interacting directly with the workspace and its cursor.

Tested by modifying `Navigation.setCursorOnWorkspaceFocus` to force the cursor to go to the workspace, then using the relevant keyboard shortcuts.

This is pure cleanup with no behaviour changes.