### PR TITLE
chore: move paste implementation into clipboard.ts

### DIFF
--- a/src/actions/clipboard.ts
+++ b/src/actions/clipboard.ts
@@ -374,6 +374,7 @@ export class Clipboard {
         );
       }
       this.navigation.removeMark(pasteWorkspace);
+      Events.setGroup(false);
       return true;
     }
     Events.setGroup(false);

--- a/src/navigation.ts
+++ b/src/navigation.ts
@@ -1366,38 +1366,6 @@ export class Navigation {
   }
 
   /**
-   * Pastes the copied block to the marked location if possible or
-   * onto the workspace otherwise.
-   *
-   * @param copyData The data to paste into the workspace.
-   * @param workspace The workspace to paste the data into.
-   * @returns True if the paste was sucessful, false otherwise.
-   */
-  paste(copyData: Blockly.ICopyData, workspace: Blockly.WorkspaceSvg): boolean {
-    // Do this before clipoard.paste due to cursor/focus workaround in getCurNode.
-    const targetNode = workspace.getCursor()?.getCurNode();
-
-    Blockly.Events.setGroup(true);
-    const block = Blockly.clipboard.paste(
-      copyData,
-      workspace,
-    ) as Blockly.BlockSvg;
-    if (block) {
-      if (targetNode) {
-        this.tryToConnectNodes(
-          workspace,
-          targetNode,
-          Blockly.ASTNode.createBlockNode(block)!,
-        );
-      }
-      this.removeMark(workspace);
-      return true;
-    }
-    Blockly.Events.setGroup(false);
-    return false;
-  }
-
-  /**
    * Triggers a flyout button's callback.
    *
    * @param workspace The main workspace. The workspace


### PR DESCRIPTION
Sibling of https://github.com/google/blockly-keyboard-experimentation/pull/281

Moves the actual implementation of paste out of `navigation.ts` and into `clipboard.ts` along with the rest of the callback. It's only used in one place and there was not a good reason to have the callback split into two pieces like this.

The second commit closes the event group in the case where paste succeeds; this was previously omitted, which was a bug.

Tested by copying and pasting in various places and checking that behaviour is consistent with main.