### PR TITLE
chore: move disconnect action to its own file

### DIFF
--- a/src/actions/disconnect.ts
+++ b/src/actions/disconnect.ts
@@ -1,0 +1,133 @@
+/**
+ * @license
+ * Copyright 2025 Google LLC
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import {
+  ASTNode,
+  RenderedConnection,
+  ShortcutRegistry,
+  utils as BlocklyUtils,
+} from 'blockly';
+import * as Constants from '../constants';
+import type {WorkspaceSvg} from 'blockly';
+import {Navigation} from '../navigation';
+
+const KeyCodes = BlocklyUtils.KeyCodes;
+
+/**
+ * Action to insert a block into the workspace.
+ *
+ * This action registers itself as both a keyboard shortcut and a context menu
+ * item.
+ */
+export class DisconnectAction {
+  /**
+   * Function provided by the navigation controller to say whether editing
+   * is allowed.
+   */
+  private canCurrentlyEdit: (ws: WorkspaceSvg) => boolean;
+
+  /**
+   * Registration name for the keyboard shortcut.
+   */
+  private shortcutName = Constants.SHORTCUT_NAMES.DISCONNECT;
+
+  constructor(
+    private navigation: Navigation,
+    canEdit: (ws: WorkspaceSvg) => boolean,
+  ) {
+    this.canCurrentlyEdit = canEdit;
+  }
+
+  /**
+   * Install this action as both a keyboard shortcut and a context menu item.
+   */
+  install() {
+    this.registerShortcut();
+  }
+
+  /**
+   * Uninstall this action as both a keyboard shortcut and a context menu item.
+   * Reinstall the original context menu action if possible.
+   */
+  uninstall() {
+    ShortcutRegistry.registry.unregister(this.shortcutName);
+  }
+
+  /**
+   * Create and register the keyboard shortcut for this action.
+   */
+  private registerShortcut() {
+    const disconnectShortcut: ShortcutRegistry.KeyboardShortcut = {
+      name: this.shortcutName,
+      preconditionFn: (workspace) => this.canCurrentlyEdit(workspace),
+      callback: (workspace) => {
+        switch (this.navigation.getState(workspace)) {
+          case Constants.STATE.WORKSPACE:
+            this.disconnectBlocks(workspace);
+            return true;
+          default:
+            return false;
+        }
+      },
+      keyCodes: [KeyCodes.X],
+    };
+    ShortcutRegistry.registry.register(disconnectShortcut);
+  }
+
+  /**
+   * Disconnects the connection that the cursor is pointing to, and bump blocks.
+   * This is a no-op if the connection cannot be broken or if the cursor is not
+   * pointing to a connection.
+   *
+   * @param workspace The workspace.
+   */
+  disconnectBlocks(workspace: WorkspaceSvg) {
+    const cursor = workspace.getCursor();
+    if (!cursor) {
+      return;
+    }
+    let curNode: ASTNode | null = cursor.getCurNode();
+    let wasVisitingConnection = true;
+    while (curNode && !curNode.isConnection()) {
+      curNode = curNode.out();
+      wasVisitingConnection = false;
+    }
+    if (!curNode) {
+      console.log('Unable to find a connection to disconnect');
+      return;
+    }
+    const curConnection = curNode.getLocation() as RenderedConnection;
+    if (!curConnection.isConnected()) {
+      return;
+    }
+    const superiorConnection = curConnection.isSuperior()
+      ? curConnection
+      : curConnection.targetConnection!;
+
+    const inferiorConnection = curConnection.isSuperior()
+      ? curConnection.targetConnection!
+      : curConnection;
+
+    if (inferiorConnection.getSourceBlock().isShadow()) {
+      return;
+    }
+
+    if (!inferiorConnection.getSourceBlock().isMovable()) {
+      return;
+    }
+
+    superiorConnection.disconnect();
+    inferiorConnection.bumpAwayFrom(superiorConnection);
+
+    const rootBlock = superiorConnection.getSourceBlock().getRootBlock();
+    rootBlock.bringToFront();
+
+    if (wasVisitingConnection) {
+      const connectionNode = ASTNode.createConnectionNode(superiorConnection);
+      workspace.getCursor()!.setCurNode(connectionNode!);
+    }
+  }
+}

--- a/src/navigation.ts
+++ b/src/navigation.ts
@@ -1020,64 +1020,6 @@ export class Navigation {
   }
 
   /**
-   * Disconnects the connection that the cursor is pointing to, and bump blocks.
-   * This is a no-op if the connection cannot be broken or if the cursor is not
-   * pointing to a connection.
-   *
-   * @param workspace The workspace.
-   */
-  disconnectBlocks(workspace: Blockly.WorkspaceSvg) {
-    const cursor = workspace.getCursor();
-    if (!cursor) {
-      return;
-    }
-    let curNode: Blockly.ASTNode | null = cursor.getCurNode();
-    let wasVisitingConnection = true;
-    while (curNode && !curNode.isConnection()) {
-      curNode = curNode.out();
-      wasVisitingConnection = false;
-    }
-    if (!curNode) {
-      this.log('Unable to find a connection to disconnect');
-      return;
-    }
-    const curConnection = curNode.getLocation() as Blockly.RenderedConnection;
-    if (!curConnection.isConnected()) {
-      this.log('Cannot disconnect unconnected connection');
-      return;
-    }
-    const superiorConnection = curConnection.isSuperior()
-      ? curConnection
-      : curConnection.targetConnection!;
-
-    const inferiorConnection = curConnection.isSuperior()
-      ? curConnection.targetConnection!
-      : curConnection;
-
-    if (inferiorConnection.getSourceBlock().isShadow()) {
-      this.log('Cannot disconnect a shadow block');
-      return;
-    }
-
-    if (!inferiorConnection.getSourceBlock().isMovable()) {
-      this.log('Cannot disconnect an immovable block');
-      return;
-    }
-
-    superiorConnection.disconnect();
-    inferiorConnection.bumpAwayFrom(superiorConnection);
-
-    const rootBlock = superiorConnection.getSourceBlock().getRootBlock();
-    rootBlock.bringToFront();
-
-    if (wasVisitingConnection) {
-      const connectionNode =
-        Blockly.ASTNode.createConnectionNode(superiorConnection);
-      workspace.getCursor()!.setCurNode(connectionNode!);
-    }
-  }
-
-  /**
    * Moves the passive focus indicator to the cursor's current location.
    *
    * @param workspace The workspace.

--- a/src/navigation_controller.ts
+++ b/src/navigation_controller.ts
@@ -30,6 +30,7 @@ import {DeleteAction} from './actions/delete';
 import {InsertAction} from './actions/insert';
 import {Clipboard} from './actions/clipboard';
 import {WorkspaceMovement} from './actions/ws_movement';
+import {DisconnectAction} from './actions/disconnect';
 
 const KeyCodes = BlocklyUtils.KeyCodes;
 const createSerializedKey = ShortcutRegistry.registry.createSerializedKey.bind(
@@ -52,6 +53,12 @@ export class NavigationController {
 
   /** Context menu and keyboard action for insertion. */
   insertAction: InsertAction = new InsertAction(
+    this.navigation,
+    this.canCurrentlyEdit.bind(this),
+  );
+
+  /** Keyboard shortcut for disconnection. */
+  disconnectAction: DisconnectAction = new DisconnectAction(
     this.navigation,
     this.canCurrentlyEdit.bind(this),
   );
@@ -468,22 +475,6 @@ export class NavigationController {
       ],
     },
 
-    /** Disconnect two blocks. */
-    disconnect: {
-      name: Constants.SHORTCUT_NAMES.DISCONNECT,
-      preconditionFn: (workspace) => this.canCurrentlyEdit(workspace),
-      callback: (workspace) => {
-        switch (this.navigation.getState(workspace)) {
-          case Constants.STATE.WORKSPACE:
-            this.navigation.disconnectBlocks(workspace);
-            return true;
-          default:
-            return false;
-        }
-      },
-      keyCodes: [KeyCodes.X],
-    },
-
     /** Move focus to or from the toolbox. */
     focusToolbox: {
       name: Constants.SHORTCUT_NAMES.TOOLBOX,
@@ -680,6 +671,7 @@ export class NavigationController {
     this.deleteAction.install();
     this.insertAction.install();
     this.workspaceMovement.install();
+    this.disconnectAction.install();
 
     this.clipboard.install();
 
@@ -699,6 +691,7 @@ export class NavigationController {
 
     this.deleteAction.uninstall();
     this.insertAction.uninstall();
+    this.disconnectAction.uninstall();
     this.clipboard.uninstall();
     this.workspaceMovement.uninstall();
 


### PR DESCRIPTION
Sibling of https://github.com/google/blockly-keyboard-experimentation/pull/283

Moves the disconnect shortcut definition and callback into a single file, `src/actions/disconnect.ts`.

Tested by running and disconnecting various things.

This is purely code cleanup and does not change behaviour. There is an existing bug with the disconnect behaviour (https://github.com/google/blockly-keyboard-experimentation/issues/311) that this does not address.