### PR TITLE
feat: allow applications to trigger the shortcut help dialog

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -138,6 +138,13 @@ export class KeyboardNavigation {
   }
 
   /**
+   * Toggle visibility of a help dialog for the keyboard shortcuts.
+   */
+  toggleShortcutDialog(): void {
+    this.navigationController.shortcutDialog.toggle();
+  }
+
+  /**
    * Update the theme to match the selected glow colour to the cursor
    * colour.
    */


### PR DESCRIPTION
This will be be used on an interm basis in MakeCode, likely replaced later with a more MakeCode-wide dialog.

Even if we don't plan to use this long term it would be useful not to have to maintain this in a fork and perhaps useful for others.

Currently used like this in our MakeCode integration:
![image](https://github.com/user-attachments/assets/48d4c9ef-7d68-4f8d-a04c-cda611c967f5)
