### PR TITLE
feat: support external toolbox (e.g. MakeCode)

### DIFF
--- a/src/navigation.ts
+++ b/src/navigation.ts
@@ -17,6 +17,7 @@ import {
   registrationType as cursorRegistrationType,
   FlyoutCursor,
 } from './flyout_cursor';
+import {NavigationOptions} from './index';
 import {PassiveFocus} from './passive_focus';
 
 /**
@@ -81,8 +82,9 @@ export class Navigation {
 
   /**
    * Constructor for keyboard navigation.
+   * @param options Options.
    */
-  constructor() {
+  constructor(private options: NavigationOptions) {
     this.wsChangeWrapper = this.workspaceChangeListener.bind(this);
     this.flyoutChangeWrapper = this.flyoutChangeListener.bind(this);
   }
@@ -424,7 +426,9 @@ export class Navigation {
     this.setState(workspace, Constants.STATE.TOOLBOX);
     this.resetFlyout(workspace, false /* shouldHide */);
 
-    if (!toolbox.getSelectedItem()) {
+    if (this.options.externalToolbox) {
+      this.options.externalToolbox.focus();
+    } else if (!toolbox.getSelectedItem()) {
       // Find the first item that is selectable.
       const toolboxItems = (toolbox as any).getToolboxItems();
       for (let i = 0, toolboxItem; (toolboxItem = toolboxItems[i]); i++) {

--- a/src/navigation_controller.ts
+++ b/src/navigation_controller.ts
@@ -29,6 +29,7 @@ import {ShortcutDialog} from './shortcut_dialog';
 import {DeleteAction} from './actions/delete';
 import {InsertAction} from './actions/insert';
 import {Clipboard} from './actions/clipboard';
+import {NavigationOptions} from './index';
 
 const KeyCodes = BlocklyUtils.KeyCodes;
 const createSerializedKey = ShortcutRegistry.registry.createSerializedKey.bind(
@@ -39,26 +40,17 @@ const createSerializedKey = ShortcutRegistry.registry.createSerializedKey.bind(
  * Class for registering shortcuts for keyboard navigation.
  */
 export class NavigationController {
-  navigation: Navigation = new Navigation();
+  navigation: Navigation;
   announcer: Announcer = new Announcer();
   shortcutDialog: ShortcutDialog = new ShortcutDialog();
 
   /** Context menu and keyboard action for deletion. */
-  deleteAction: DeleteAction = new DeleteAction(
-    this.navigation,
-    this.canCurrentlyEdit.bind(this),
-  );
+  deleteAction: DeleteAction;
 
   /** Context menu and keyboard action for insertion. */
-  insertAction: InsertAction = new InsertAction(
-    this.navigation,
-    this.canCurrentlyEdit.bind(this),
-  );
+  insertAction: InsertAction;
 
-  clipboard: Clipboard = new Clipboard(
-    this.navigation,
-    this.canCurrentlyEdit.bind(this),
-  );
+  clipboard: Clipboard;
 
   hasNavigationFocus: boolean = false;
 
@@ -69,6 +61,25 @@ export class NavigationController {
   private origToolboxOnShortcut:
     | typeof Blockly.Toolbox.prototype.onShortcut
     | null = null;
+
+  constructor(options: NavigationOptions) {
+    this.navigation = new Navigation(options);
+
+    this.deleteAction = new DeleteAction(
+      this.navigation,
+      this.canCurrentlyEdit.bind(this),
+    );
+
+    this.insertAction = new InsertAction(
+      this.navigation,
+      this.canCurrentlyEdit.bind(this),
+    );
+
+    this.clipboard = new Clipboard(
+      this.navigation,
+      this.canCurrentlyEdit.bind(this),
+    );
+  }
 
   /**
    * Registers the default keyboard shortcuts for keyboard navigation.
@@ -157,10 +168,15 @@ export class NavigationController {
    *
    * @param workspace the workspace that now has input focus.
    * @param isFocused whether the environment has browser focus.
+   * @param isFocusedForFlyoutKeyboardNavigation avoid workspace modifications.
    */
-  setHasFocus(workspace: WorkspaceSvg, isFocused: boolean) {
+  setHasFocus(
+    workspace: WorkspaceSvg,
+    isFocused: boolean,
+    isFocusedForFlyoutKeyboardNavigation = false,
+  ) {
     this.hasNavigationFocus = isFocused;
-    if (isFocused) {
+    if (isFocused && !isFocusedForFlyoutKeyboardNavigation) {
       this.navigation.focusWorkspace(workspace, true);
     }
   }


### PR DESCRIPTION
MakeCode's toolbox is a separate UI component (the toolbox Blockly sees is empty).  Add just enough glue to get keyboard navigation working in its flyout and be able to close the flyout when we leave the toolbox.

This is analogous to the monkey patching that was done for the original keyboard navigation plugin (which isn't viable anymore due to better encapsulation).

One to discuss next week, but it would be really helpful to merge something like this even if we aspire to do it differently in the long term.

I've tried to clarify this a little based on a past chat discussion and it's got simpler as the plugin has evolved.