### PR TITLE
feat: W to move the cursor to the workspace

### DIFF
--- a/src/actions/ws_movement.ts
+++ b/src/actions/ws_movement.ts
@@ -55,13 +55,21 @@ export class WorkspaceMovement {
       callback: (workspace) => this.moveWSCursor(workspace, 0, -1),
       keyCodes: [createSerializedKey(KeyCodes.W, [KeyCodes.SHIFT])],
     },
-    
+
     /** Move the cursor on the workspace down. */
     {
       name: Constants.SHORTCUT_NAMES.MOVE_WS_CURSOR_DOWN,
       preconditionFn: (workspace) => this.canCurrentlyEdit(workspace),
       callback: (workspace) => this.moveWSCursor(workspace, 0, 1),
       keyCodes: [createSerializedKey(KeyCodes.S, [KeyCodes.SHIFT])],
+    },
+
+    /** Move the cursor to the workspace. */
+    {
+      name: Constants.SHORTCUT_NAMES.CREATE_WS_CURSOR,
+      preconditionFn: (workspace) => this.canCurrentlyEdit(workspace),
+      callback: (workspace) => this.createWSCursor(workspace),
+      keyCodes: [KeyCodes.W],
     },
   ];
 
@@ -112,6 +120,24 @@ export class WorkspaceMovement {
         new BlocklyUtils.Coordinate(newX, newY),
       )!,
     );
+    return true;
+  }
+
+  /**
+   * Moves the cursor to the workspace near the origin.
+   *
+   * @param workspace The workspace the cursor is on.
+   */
+  createWSCursor(workspace: WorkspaceSvg) {
+    const workspaceNode = ASTNode.createWorkspaceNode(
+      workspace,
+      new BlocklyUtils.Coordinate(10, 10),
+    );
+    const cursor = workspace.getCursor();
+
+    if (!cursor || !workspaceNode) return false;
+
+    cursor.setCurNode(workspaceNode);
     return true;
   }
 }

--- a/src/constants.ts
+++ b/src/constants.ts
@@ -43,6 +43,7 @@ export enum SHORTCUT_NAMES {
   MOVE_WS_CURSOR_DOWN = 'workspace_down',
   MOVE_WS_CURSOR_LEFT = 'workspace_left',
   MOVE_WS_CURSOR_RIGHT = 'workspace_right',
+  CREATE_WS_CURSOR = 'to_workspace',
   /* eslint-enable @typescript-eslint/naming-convention */
   LIST_SHORTCUTS = 'list_shortcuts',
   CLEAN_UP = 'clean_up_workspace',


### PR DESCRIPTION
In response to Christopher's concerns about testing here: https://github.com/google/blockly-keyboard-experimentation/pull/309#issuecomment-2722193511

