### PR TITLE
chore: bump version to 0.0.5

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@blockly/keyboard-experiment",
-  "version": "0.0.3",
+  "version": "0.0.4",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@blockly/keyboard-experiment",
-      "version": "0.0.3",
+      "version": "0.0.4",
       "license": "Apache-2.0",
       "devDependencies": {
         "@blockly/dev-scripts": "^4.0.1",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@blockly/keyboard-experiment",
-  "version": "0.0.4",
+  "version": "0.0.5",
   "description": "A plugin for keyboard navigation.",
   "scripts": {
     "audit:fix": "blockly-scripts auditFix",


### PR DESCRIPTION
Bump for another beta release. I will release manually once this is approved.

Fixes https://github.com/google/blockly-keyboard-experimentation/issues/324