### PR TITLE
feat: consistent focus handling; remove markedNode

### DIFF
--- a/src/actions/arrow_navigation.ts
+++ b/src/actions/arrow_navigation.ts
@@ -64,7 +64,9 @@ export class ArrowNavigation {
             case Constants.STATE.WORKSPACE:
               isHandled = this.fieldShortcutHandler(workspace, shortcut);
               if (!isHandled && workspace) {
-                workspace.getCursor()?.in();
+                if (!this.navigation.defaultCursorPositionIfNeeded(workspace)) {
+                  workspace.getCursor()?.in();
+                }
                 isHandled = true;
               }
               return isHandled;
@@ -95,7 +97,9 @@ export class ArrowNavigation {
             case Constants.STATE.WORKSPACE:
               isHandled = this.fieldShortcutHandler(workspace, shortcut);
               if (!isHandled && workspace) {
-                workspace.getCursor()?.out();
+                if (!this.navigation.defaultCursorPositionIfNeeded(workspace)) {
+                  workspace.getCursor()?.out();
+                }
                 isHandled = true;
               }
               return isHandled;
@@ -125,7 +129,9 @@ export class ArrowNavigation {
             case Constants.STATE.WORKSPACE:
               isHandled = this.fieldShortcutHandler(workspace, shortcut);
               if (!isHandled && workspace) {
-                workspace.getCursor()?.next();
+                if (!this.navigation.defaultCursorPositionIfNeeded(workspace)) {
+                  workspace.getCursor()?.next();
+                }
                 isHandled = true;
               }
               return isHandled;
@@ -158,7 +164,14 @@ export class ArrowNavigation {
             case Constants.STATE.WORKSPACE:
               isHandled = this.fieldShortcutHandler(workspace, shortcut);
               if (!isHandled) {
-                workspace.getCursor()?.prev();
+                if (
+                  !this.navigation.defaultCursorPositionIfNeeded(
+                    workspace,
+                    'last',
+                  )
+                ) {
+                  workspace.getCursor()?.prev();
+                }
                 isHandled = true;
               }
               return isHandled;

--- a/src/actions/clipboard.ts
+++ b/src/actions/clipboard.ts
@@ -275,10 +275,13 @@ export class Clipboard {
       ?.getCursor()
       ?.getCurNode()
       .getSourceBlock() as BlockSvg;
-    workspace.hideChaff();
     this.copyData = sourceBlock.toCopyData();
     this.copyWorkspace = sourceBlock.workspace;
-    return !!this.copyData;
+    const copied = !!this.copyData;
+    if (copied && navigationState === Constants.STATE.FLYOUT) {
+      this.navigation.focusWorkspace(workspace);
+    }
+    return copied;
   }
 
   /**
@@ -373,7 +376,6 @@ export class Clipboard {
           ASTNode.createBlockNode(block)!,
         );
       }
-      this.navigation.removeMark(pasteWorkspace);
       Events.setGroup(false);
       return true;
     }

--- a/src/actions/clipboard.ts
+++ b/src/actions/clipboard.ts
@@ -363,8 +363,10 @@ export class Clipboard {
       ? workspace
       : this.copyWorkspace;
 
-    // Do this before clipoard.paste due to cursor/focus workaround in getCurNode.
     const targetNode = this.navigation.getStationaryNode(pasteWorkspace);
+    // If we're pasting in the flyout it still targets the workspace. Focus first
+    // so ensure correct selection handling.
+    this.navigation.focusWorkspace(workspace);
 
     Events.setGroup(true);
     const block = clipboard.paste(this.copyData, pasteWorkspace) as BlockSvg;
@@ -377,7 +379,6 @@ export class Clipboard {
         );
       }
       Events.setGroup(false);
-      this.navigation.focusWorkspace(workspace);
       return true;
     }
     Events.setGroup(false);

--- a/src/actions/clipboard.ts
+++ b/src/actions/clipboard.ts
@@ -364,7 +364,7 @@ export class Clipboard {
       : this.copyWorkspace;
 
     // Do this before clipoard.paste due to cursor/focus workaround in getCurNode.
-    const targetNode = pasteWorkspace.getCursor()?.getCurNode();
+    const targetNode = this.navigation.getStationaryNode(pasteWorkspace);
 
     Events.setGroup(true);
     const block = clipboard.paste(this.copyData, pasteWorkspace) as BlockSvg;
@@ -377,6 +377,7 @@ export class Clipboard {
         );
       }
       Events.setGroup(false);
+      this.navigation.focusWorkspace(workspace);
       return true;
     }
     Events.setGroup(false);

--- a/src/actions/enter.ts
+++ b/src/actions/enter.ts
@@ -93,6 +93,7 @@ export class EnterAction {
     const cursor = workspace.getCursor();
     if (!cursor) return;
     const curNode = cursor.getCurNode();
+    if (!curNode) return;
     const nodeType = curNode.getType();
     if (nodeType === ASTNode.types.FIELD) {
       (curNode.getLocation() as Field).showEditor();

--- a/src/actions/enter.ts
+++ b/src/actions/enter.ts
@@ -125,7 +125,7 @@ export class EnterAction {
    *     the block will be placed on.
    */
   private insertFromFlyout(workspace: WorkspaceSvg) {
-    const stationaryNode = workspace.getCursor()?.getCurNode();
+    const stationaryNode = this.navigation.getStationaryNode(workspace);
     const newBlock = this.createNewBlock(workspace);
     if (!newBlock) return;
     if (stationaryNode) {

--- a/src/actions/enter.ts
+++ b/src/actions/enter.ts
@@ -144,7 +144,6 @@ export class EnterAction {
 
     this.navigation.focusWorkspace(workspace);
     workspace.getCursor()!.setCurNode(ASTNode.createBlockNode(newBlock)!);
-    this.navigation.removeMark(workspace);
   }
 
   /**

--- a/src/gesture_monkey_patch.js
+++ b/src/gesture_monkey_patch.js
@@ -23,7 +23,8 @@ const oldDispose = Blockly.Gesture.prototype.dispose;
  */
 Blockly.Gesture.prototype.dispose = function () {
   // This is a bit of a cludge and focus management needs to be better
-  // integrated with Gesture. The intent is to move focus at the end of a drag.
+  // integrated with Gesture. The intent is to move focus at the end of
+  // a drag from a non-auto-closing flyout.
   if (this.isDragging()) {
     this.creatorWorkspace?.getSvgGroup().focus();
   }

--- a/src/index.ts
+++ b/src/index.ts
@@ -28,7 +28,7 @@ export class KeyboardNavigation {
   private focusListener: (e: Event) => void;
 
   /** Event handler run when the workspace loses focus. */
-  private blurListener: () => void;
+  private blurListener: (e: Event) => void;
 
   /** Event handler run when the toolbox gains focus. */
   private toolboxFocusListener: () => void;
@@ -129,8 +129,14 @@ export class KeyboardNavigation {
         this.navigationController.handleFocusWorkspace(workspace);
       }
     };
-    this.blurListener = () => {
-      this.navigationController.handleBlurWorkspace(workspace);
+    this.blurListener = (e: Event) => {
+      const relatedTarget = (e as FocusEvent).relatedTarget;
+      if (
+        relatedTarget !== this.workspace.getParentSvg() &&
+        relatedTarget !== this.workspace.getSvgGroup()
+      ) {
+        this.navigationController.handleBlurWorkspace(workspace);
+      }
     };
 
     workspace.getSvgGroup().addEventListener('focus', this.focusListener);

--- a/src/index.ts
+++ b/src/index.ts
@@ -7,6 +7,7 @@
 import * as Blockly from 'blockly/core';
 import {NavigationController} from './navigation_controller';
 import {CursorOptions, LineCursor} from './line_cursor';
+import {getFlyoutElement, getToolboxElement} from './workspace_utilities';
 
 /** Options object for KeyboardNavigation instances. */
 export type NavigationOptions = {
@@ -24,7 +25,7 @@ export class KeyboardNavigation {
   protected workspace: Blockly.WorkspaceSvg;
 
   /** Event handler run when the workspace gains focus. */
-  private focusListener: () => void;
+  private focusListener: (e: Event) => void;
 
   /** Event handler run when the workspace loses focus. */
   private blurListener: () => void;
@@ -33,7 +34,13 @@ export class KeyboardNavigation {
   private toolboxFocusListener: () => void;
 
   /** Event handler run when the toolbox loses focus. */
-  private toolboxBlurListener: () => void;
+  private toolboxBlurListener: (e: Event) => void;
+
+  /** Event handler run when the flyout gains focus. */
+  private flyoutFocusListener: () => void;
+
+  /** Event handler run when the flyout loses focus. */
+  private flyoutBlurListener: (e: Event) => void;
 
   /** Keyboard navigation controller instance for the workspace. */
   private navigationController: NavigationController;
@@ -86,31 +93,79 @@ export class KeyboardNavigation {
     // We add a focus listener below so use -1 so it doesn't become focusable.
     workspace.getParentSvg().setAttribute('tabindex', '-1');
 
-    this.focusListener = () => {
-      this.navigationController.updateWorkspaceFocus(workspace, true);
+    // Move the flyout for logical tab order.
+    const flyoutElement = getFlyoutElement(workspace);
+    flyoutElement?.parentElement?.insertBefore(
+      flyoutElement,
+      workspace.getParentSvg(),
+    );
+    // Allow tab to the flyout only when there's no toolbox.
+    if (workspace.getToolbox() && flyoutElement) {
+      flyoutElement.tabIndex = -1;
+    }
+
+    this.focusListener = (e: Event) => {
+      if (e.currentTarget === this.workspace.getParentSvg()) {
+        // Starting a gesture unconditionally calls markFocused on the parent SVG
+        // but we really don't want to move to the workspace (and close the
+        // flyout) if all you did was click in a flyout, potentially on a
+        // button. See also `gesture_monkey_patch.js`.
+        // eslint-disable-next-line @typescript-eslint/no-explicit-any
+        const gestureInternals = this.workspace.currentGesture_ as any;
+        const gestureFlyout = gestureInternals?.flyout;
+        const gestureFlyoutAutoClose = gestureFlyout?.autoClose;
+        const gestureOnBlock = gestureInternals?.startBlock;
+        if (
+          // When clicking on flyout that cannot close.
+          (gestureFlyout && !gestureFlyoutAutoClose) ||
+          // When clicking on a block in a flyout that can close.
+          (gestureFlyout && gestureFlyoutAutoClose && !gestureOnBlock)
+        ) {
+          this.navigationController.focusFlyout(workspace);
+        } else {
+          this.navigationController.focusWorkspace(workspace);
+        }
+      } else {
+        this.navigationController.handleFocusWorkspace(workspace);
+      }
     };
     this.blurListener = () => {
-      this.navigationController.updateWorkspaceFocus(workspace, false);
+      this.navigationController.handleBlurWorkspace(workspace);
     };
 
     workspace.getSvgGroup().addEventListener('focus', this.focusListener);
     workspace.getSvgGroup().addEventListener('blur', this.blurListener);
 
+    const toolboxElement = getToolboxElement(workspace);
     this.toolboxFocusListener = () => {
-      this.navigationController.updateToolboxFocus(workspace, true);
+      this.navigationController.handleFocusToolbox(workspace);
     };
-    this.toolboxBlurListener = () => {
-      this.navigationController.updateToolboxFocus(workspace, false);
-    };
-
-    const toolbox = workspace.getToolbox();
-    if (toolbox != null && toolbox instanceof Blockly.Toolbox) {
-      const contentsDiv = toolbox.HtmlDiv?.querySelector(
-        '.blocklyToolboxContents',
+    this.toolboxBlurListener = (e: Event) => {
+      this.navigationController.handleBlurToolbox(
+        workspace,
+        this.shouldCloseFlyoutOnBlur(
+          (e as FocusEvent).relatedTarget,
+          flyoutElement,
+        ),
       );
-      contentsDiv?.addEventListener('focus', this.toolboxFocusListener);
-      contentsDiv?.addEventListener('blur', this.toolboxBlurListener);
-    }
+    };
+    toolboxElement?.addEventListener('focus', this.toolboxFocusListener);
+    toolboxElement?.addEventListener('blur', this.toolboxBlurListener);
+
+    this.flyoutFocusListener = () => {
+      this.navigationController.handleFocusFlyout(workspace);
+    };
+    this.flyoutBlurListener = (e: Event) => {
+      this.navigationController.handleBlurFlyout(
+        workspace,
+        this.shouldCloseFlyoutOnBlur(
+          (e as FocusEvent).relatedTarget,
+          toolboxElement,
+        ),
+      );
+    };
+    flyoutElement?.addEventListener('focus', this.flyoutFocusListener);
+    flyoutElement?.addEventListener('blur', this.flyoutBlurListener);
 
     // Temporary workaround for #136.
     // TODO(#136): fix in core.
@@ -136,14 +191,13 @@ export class KeyboardNavigation {
       .getSvgGroup()
       .removeEventListener('focus', this.focusListener);
 
-    const toolbox = this.workspace.getToolbox();
-    if (toolbox != null && toolbox instanceof Blockly.Toolbox) {
-      const contentsDiv = toolbox.HtmlDiv?.querySelector(
-        '.blocklyToolboxContents',
-      );
-      contentsDiv?.removeEventListener('focus', this.toolboxFocusListener);
-      contentsDiv?.removeEventListener('blur', this.toolboxBlurListener);
-    }
+    const toolboxElement = getToolboxElement(this.workspace);
+    toolboxElement?.removeEventListener('focus', this.toolboxFocusListener);
+    toolboxElement?.removeEventListener('blur', this.toolboxBlurListener);
+
+    const flyoutElement = getFlyoutElement(this.workspace);
+    flyoutElement?.removeEventListener('focus', this.flyoutFocusListener);
+    flyoutElement?.removeEventListener('blur', this.flyoutBlurListener);
 
     if (this.workspaceParentTabIndex) {
       this.workspace
@@ -188,5 +242,33 @@ export class KeyboardNavigation {
       },
     });
     this.workspace.setTheme(newTheme);
+  }
+
+  /**
+   * Identify whether we should close the flyout when the toolbox or flyout
+   * blurs. If a gesture is in progerss or we're moving from one the other
+   * then we leave it open.
+   *
+   * @param relatedTarget The related target from the event on the flyout or toolbox.
+   * @param container The other element of flyout or toolbox (opposite to the event).
+   * @returns true if the flyout should be closed, false otherwise.
+   */
+  private shouldCloseFlyoutOnBlur(
+    relatedTarget: EventTarget | null,
+    container: Element | null,
+  ) {
+    if (Blockly.Gesture.inProgress()) {
+      return false;
+    }
+    if (!relatedTarget) {
+      return false;
+    }
+    if (
+      relatedTarget instanceof Node &&
+      container?.contains(relatedTarget as Node)
+    ) {
+      return false;
+    }
+    return true;
   }
 }

--- a/src/line_cursor.ts
+++ b/src/line_cursor.ts
@@ -492,11 +492,15 @@ export class LineCursor extends Marker {
         !(newNode.getLocation() as Blockly.BlockSvg).isShadow()
       ) {
         if (Blockly.common.getSelected() !== newNode.getLocation()) {
+          Blockly.Events.disable();
           Blockly.common.setSelected(newNode.getLocation() as Blockly.BlockSvg);
+          Blockly.Events.enable();
         }
       } else {
         if (Blockly.common.getSelected()) {
+          Blockly.Events.disable();
           Blockly.common.setSelected(null);
+          Blockly.Events.enable();
         }
       }
     }
@@ -668,12 +672,7 @@ export class LineCursor extends Marker {
           this.setCurNode(node, true);
         }
       }
-    } else if (
-      this.getCurNode()?.getType() === ASTNode.types.BLOCK &&
-      !(this.getCurNode().getLocation() as Blockly.BlockSvg).isShadow()
-    ) {
-      // This does mean other cursor types remain if you click on the workspace
-      // background. Ideally gesture would be handling this with more context.
+    } else {
       this.setCurNode(null as never, true);
     }
   }

--- a/src/line_cursor.ts
+++ b/src/line_cursor.ts
@@ -15,7 +15,7 @@
 
 import * as Blockly from 'blockly/core';
 import {ASTNode, Marker} from 'blockly/core';
-import {scrollBoundsIntoView} from './workspace_utilities';
+import {getWorkspaceElement, scrollBoundsIntoView} from './workspace_utilities';
 
 /** Options object for LineCursor instances. */
 export type CursorOptions = {
@@ -475,47 +475,6 @@ export class LineCursor extends Marker {
   }
 
   /**
-   * Get the current location of the cursor.
-   *
-   * Overrides superclass implementation to add a hack that attempts
-   * to detect if the user has moved focus by selecting a block and,
-   * if so, update the cursor location (and any highlighting) to
-   * match.
-   *
-   * Doing this only when getCurNode would naturally be called works
-   * reasonably well but has some glitches, most notably that if the
-   * cursor was not on a block (e.g. it was on a connection or the
-   * workspace) when the user selected a block then it will remain
-   * visible in its previous location until some keyboard navigation occurs.
-   *
-   * To ameliorate this, the LineCursor constructor adds an event
-   * listener that calls getCurNode in response to SELECTED events.
-   *
-   * Remove this hack once Blockly is modified to update the
-   * cursor/focus itself.
-   *
-   * @returns The current field, connection, or block the cursor is on.
-   */
-  override getCurNode(): ASTNode {
-    const curNode = super.getCurNode();
-    const selected = Blockly.common.getSelected();
-    if (selected?.workspace !== this.workspace) return curNode;
-
-    // Selected item is on workspace that this cursor belongs to.
-    const curLocation = curNode?.getLocation();
-    if (curLocation === selected) return curNode;
-
-    // Selected item is not where cursor is.  Try to move cursor.
-    if (!(selected instanceof Blockly.Block)) {
-      console.error('Selected item is not a block.  Ignoring');
-      return curNode;
-    }
-    const newNode = new ASTNode(ASTNode.types.BLOCK, selected);
-    this.setCurNode(newNode);
-    return newNode;
-  }
-
-  /**
    * Set the location of the cursor and draw it.
    *
    * Overrides normal Marker setCurNode logic to call
@@ -523,7 +482,25 @@ export class LineCursor extends Marker {
    *
    * @param newNode The new location of the cursor.
    */
-  override setCurNode(newNode: ASTNode) {
+  override setCurNode(newNode: ASTNode, selectionInSync = false) {
+    if (newNode?.getLocation() === this.getCurNode()?.getLocation()) {
+      return;
+    }
+    if (!selectionInSync) {
+      if (
+        newNode?.getType() === ASTNode.types.BLOCK &&
+        !(newNode.getLocation() as Blockly.BlockSvg).isShadow()
+      ) {
+        if (Blockly.common.getSelected() !== newNode.getLocation()) {
+          Blockly.common.setSelected(newNode.getLocation() as Blockly.BlockSvg);
+        }
+      } else {
+        if (Blockly.common.getSelected()) {
+          Blockly.common.setSelected(null);
+        }
+      }
+    }
+
     const oldNode = super.getCurNode();
     // Kludge: we can't set this.curNode directly, so we have to call
     // super.setCurNode(...) to do it for us - but that would call
@@ -533,6 +510,7 @@ export class LineCursor extends Marker {
     this.setDrawer(null as any); // Cast required since param is not nullable.
     super.setCurNode(newNode);
     this.setDrawer(drawer);
+
     // Draw this marker the way we want to.
     this.drawMarker(oldNode, newNode);
     // Try to scroll cursor into view.
@@ -542,22 +520,6 @@ export class LineCursor extends Marker {
         block.getBoundingRectangleWithoutChildren(),
         block.workspace,
       );
-    }
-  }
-
-  override hide(): void {
-    super.hide();
-
-    // If there's a block currently selected, remove the selection since the
-    // cursor should now be hidden.
-    const curNode = this.getCurNode();
-    if (curNode && curNode.getType() === ASTNode.types.BLOCK) {
-      const block = curNode.getLocation() as Blockly.BlockSvg;
-      if (!block.isShadow()) {
-        Blockly.common.setSelected(null);
-      } else {
-        block.removeSelect();
-      }
     }
   }
 
@@ -605,7 +567,7 @@ export class LineCursor extends Marker {
     if (oldNode?.getType() === ASTNode.types.BLOCK) {
       const block = oldNode.getLocation() as Blockly.BlockSvg;
       if (!block.isShadow()) {
-        Blockly.common.setSelected(null);
+        // Selection should already be in sync.
       } else {
         block.removeSelect();
       }
@@ -633,7 +595,7 @@ export class LineCursor extends Marker {
     } else if (curNodeType === ASTNode.types.BLOCK) {
       const block = curNode.getLocation() as Blockly.BlockSvg;
       if (!block.isShadow()) {
-        Blockly.common.setSelected(block);
+        // Selection should already be in sync.
       } else {
         block.addSelect();
       }
@@ -698,7 +660,22 @@ export class LineCursor extends Marker {
     if (event.type !== Blockly.Events.SELECTED) return;
     const selectedEvent = event as Blockly.Events.Selected;
     if (selectedEvent.workspaceId !== this.workspace.id) return;
-    this.getCurNode();
+    if (selectedEvent.newElementId) {
+      const block = this.workspace.getBlockById(selectedEvent.newElementId);
+      if (block) {
+        const node = ASTNode.createBlockNode(block);
+        if (node) {
+          this.setCurNode(node, true);
+        }
+      }
+    } else if (
+      this.getCurNode()?.getType() === ASTNode.types.BLOCK &&
+      !(this.getCurNode().getLocation() as Blockly.BlockSvg).isShadow()
+    ) {
+      // This does mean other cursor types remain if you click on the workspace
+      // background. Ideally gesture would be handling this with more context.
+      this.setCurNode(null as never, true);
+    }
   }
 }
 

--- a/src/passive_focus.ts
+++ b/src/passive_focus.ts
@@ -50,16 +50,16 @@ export class PassiveFocus {
     // If old node was a block, unselect it or remove fake selection.
     if (type === ASTNode.types.BLOCK) {
       this.hideAtBlock(this.curNode);
-      return;
     } else if (this.curNode.isConnection()) {
       const curNodeAsConnection = location as RenderedConnection;
       const connectionType = curNodeAsConnection.type;
       if (connectionType === ConnectionType.NEXT_STATEMENT) {
         this.hideAtNext(this.curNode);
-        return;
       }
+    } else {
+      console.log('Could not hide passive focus indicator');
     }
-    console.log('Could not hide passive focus indicator');
+    this.curNode = null;
   }
 
   /**
@@ -160,5 +160,9 @@ export class PassiveFocus {
       this.nextConnectionIndicator,
     );
     this.nextConnectionIndicator.style.display = 'none';
+  }
+
+  isVisible(): boolean {
+    return !!this.curNode;
   }
 }

--- a/src/passive_focus.ts
+++ b/src/passive_focus.ts
@@ -30,6 +30,15 @@ export class PassiveFocus {
     this.nextConnectionIndicator = this.createNextIndicator();
   }
 
+  /**
+   * Get the current passive focus node.
+   *
+   * @returns the node or null.
+   */
+  getCurNode(): ASTNode | null {
+    return this.curNode;
+  }
+
   /** Dispose of this indicator. Do any necessary cleanup. */
   dispose() {
     this.hide();
@@ -104,7 +113,11 @@ export class PassiveFocus {
    */
   hideAtBlock(node: ASTNode) {
     const block = node.getLocation() as BlockSvg;
-    utils.dom.removeClass(block.pathObject.svgPath, 'passiveBlockFocus');
+    // When a block is selected we can end up with a duplicate svgPath.
+    const svgPaths = block.getSvgRoot().querySelectorAll('.passiveBlockFocus');
+    svgPaths.forEach((svgPath) =>
+      utils.dom.removeClass(svgPath, 'passiveBlockFocus'),
+    );
   }
 
   /**

--- a/src/workspace_utilities.ts
+++ b/src/workspace_utilities.ts
@@ -68,3 +68,49 @@ export function scrollBoundsIntoView(
   deltaY *= scale;
   workspace.scroll(workspace.scrollX + deltaX, workspace.scrollY + deltaY);
 }
+
+/**
+ * Get the workspace SVG group which is the element that takes focus.
+ *
+ * @param workspace The workspace.
+ * @returns The element.
+ */
+export function getWorkspaceElement(workspace: Blockly.Workspace): SVGElement {
+  return (workspace as Blockly.WorkspaceSvg).getSvgGroup() as SVGElement;
+}
+
+/**
+ * Get the toolbox element that takes the focus (if any).
+ *
+ * @param workspace The workspace.
+ * @returns The element or null if a toolbox is not in use.
+ */
+export function getToolboxElement(
+  workspace: Blockly.WorkspaceSvg,
+): HTMLElement | null {
+  const toolbox = workspace.getToolbox();
+  if (toolbox instanceof Blockly.Toolbox) {
+    return toolbox.HtmlDiv?.querySelector(
+      '.blocklyToolboxContents',
+    ) as HTMLElement | null;
+  }
+  return null;
+}
+
+/**
+ * Get the flyout element we focus.
+ *
+ * @param workspace The workspace.
+ * @returns The element, or null if there is no flyout.
+ */
+export function getFlyoutElement(
+  workspace: Blockly.WorkspaceSvg,
+): SVGElement | null {
+  const flyout = workspace.getFlyout();
+  if (flyout != null && flyout instanceof Blockly.Flyout) {
+    // This relies on internals.
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    return ((flyout as any).svgGroup_ as SVGElement) ?? null;
+  }
+  return null;
+}

--- a/test/index.html
+++ b/test/index.html
@@ -45,6 +45,10 @@
         height: calc(100% - calc(var(--outline-width) * 2));
       }
 
+      .blocklyToolboxDiv ~ .blocklyFlyout:focus {
+        outline: none;
+      }
+
       pre,
       code {
         overflow: auto;


### PR DESCRIPTION
Ensure we always focus the same element when keyboard navigation works in that element. Previously the toolbox sometimes was and sometimes wasn't focused when it navigated, the workspace group or the workspace SVG could be focused and the flyout never took the focus.

With this approach the relevant container always takes focus and we explicitly move browser focus more often and let the focus/blur handlers do their work.

Manage the passive focus indicator based on focus rather than markedNode state. But we take care not to make a selection when focus returns due to a click as that can interrupt gestures.

Integrate with Gesture to determine how mouse behaviours relate to focus. This prevents issues where a gesture would cause a focus change which would close the flyout, interrupting a normal drag. In time hopefully this code can move to core where it will be more natural and less fragile.

Fixes #227
Fixes #200
Part of #229 (scrollbars still an issue)
Fixes #222
Fixes #287

Compromises:
- Knows about the flyout DOM for focus purposes (similar to toolbox before). I hope that focus changes in core can give API for this need.
- Uses more gesture internals. I think clean code with the same effect can be done in core.

Future steps:
- Make the flyout cursor and movement actions behave the same way, so clicking to create a variable (or on the flyout itself) doesn't move the cursor the first thing in the flyout.
- Always clear the current node when clicking on a workspace click. This happens for selection (which will clear the cursor via the listener) but not if you're e.g. at next/previous. The inconsistency feels weird.

**Demo**: https://rejig-focus.blockly-keyboard-experimentation.pages.dev/
