### PR TITLE
fix: right click menu issues

### DIFF
--- a/src/actions/action_menu.ts
+++ b/src/actions/action_menu.ts
@@ -111,7 +111,7 @@ export class ActionMenu {
     const cursor = workspace.getCursor();
     if (!cursor) throw new Error('workspace has no cursor');
     const node = cursor.getCurNode();
-    if (!node) throw new Error('No node is currently selected');
+    if (!node) return false;
     const nodeType = node.getType();
     switch (nodeType) {
       case ASTNode.types.BLOCK:

--- a/src/actions/delete.ts
+++ b/src/actions/delete.ts
@@ -150,7 +150,7 @@ export class DeleteAction {
   private deletePrecondition(workspace: WorkspaceSvg) {
     if (!this.canCurrentlyEdit(workspace)) return false;
 
-    const sourceBlock = workspace.getCursor()?.getCurNode().getSourceBlock();
+    const sourceBlock = workspace.getCursor()?.getCurNode()?.getSourceBlock();
     return !!sourceBlock?.isDeletable();
   }
 

--- a/src/index.ts
+++ b/src/index.ts
@@ -30,6 +30,9 @@ export class KeyboardNavigation {
   /** Event handler run when the workspace loses focus. */
   private blurListener: (e: Event) => void;
 
+  /** Event handler run when the widget or dropdown div loses focus. */
+  private widgetDropDownDivFocusOutListener: (e: Event) => void;
+
   /** Event handler run when the toolbox gains focus. */
   private toolboxFocusListener: () => void;
 
@@ -142,6 +145,22 @@ export class KeyboardNavigation {
     workspace.getSvgGroup().addEventListener('focus', this.focusListener);
     workspace.getSvgGroup().addEventListener('blur', this.blurListener);
 
+    this.widgetDropDownDivFocusOutListener = (e: Event) => {
+      this.navigationController.handleFocusOutWidgetDropdownDiv(
+        workspace,
+        (e as FocusEvent).relatedTarget,
+      );
+    };
+
+    Blockly.WidgetDiv.getDiv()?.addEventListener(
+      'focusout',
+      this.widgetDropDownDivFocusOutListener,
+    );
+    Blockly.DropDownDiv.getContentDiv()?.addEventListener(
+      'focusout',
+      this.widgetDropDownDivFocusOutListener,
+    );
+
     const toolboxElement = getToolboxElement(workspace);
     this.toolboxFocusListener = () => {
       this.navigationController.handleFocusToolbox(workspace);
@@ -196,6 +215,15 @@ export class KeyboardNavigation {
     this.workspace
       .getSvgGroup()
       .removeEventListener('focus', this.focusListener);
+
+    Blockly.WidgetDiv.getDiv()?.removeEventListener(
+      'focusout',
+      this.widgetDropDownDivFocusOutListener,
+    );
+    Blockly.DropDownDiv.getContentDiv()?.removeEventListener(
+      'focusout',
+      this.widgetDropDownDivFocusOutListener,
+    );
 
     const toolboxElement = getToolboxElement(this.workspace);
     toolboxElement?.removeEventListener('focus', this.toolboxFocusListener);

--- a/src/line_cursor.ts
+++ b/src/line_cursor.ts
@@ -15,7 +15,7 @@
 
 import * as Blockly from 'blockly/core';
 import {ASTNode, Marker} from 'blockly/core';
-import {getWorkspaceElement, scrollBoundsIntoView} from './workspace_utilities';
+import {scrollBoundsIntoView} from './workspace_utilities';
 
 /** Options object for LineCursor instances. */
 export type CursorOptions = {
@@ -61,7 +61,7 @@ export class LineCursor extends Marker {
   ) {
     super();
     // Bind selectListener to facilitate future install/uninstall.
-    this.selectListener = this.selectListener.bind(this);
+    this.changeListener = this.changeListener.bind(this);
     // Regularise options and apply defaults.
     this.options = {...defaultOptions, ...options};
 
@@ -81,7 +81,7 @@ export class LineCursor extends Marker {
     markerManager.setCursor(this);
     const oldCursorNode = this.oldCursor?.getCurNode();
     if (oldCursorNode) this.setCurNode(oldCursorNode);
-    this.workspace.addChangeListener(this.selectListener);
+    this.workspace.addChangeListener(this.changeListener);
     this.installed = true;
   }
 
@@ -92,7 +92,7 @@ export class LineCursor extends Marker {
    */
   uninstall() {
     if (!this.installed) throw new Error('LineCursor not yet installed');
-    this.workspace.removeChangeListener(this.selectListener.bind(this));
+    this.workspace.removeChangeListener(this.changeListener.bind(this));
     if (this.oldCursor) {
       this.workspace.getMarkerManager().setCursor(this.oldCursor);
     }
@@ -479,36 +479,14 @@ export class LineCursor extends Marker {
    * Get the current location of the cursor.
    *
    * Overrides normal Marker getCurNode to update the current node from the selected
-   * block. We typically update the node from the selection via a listener but
-   * that is not called immediately when `Gesture` calls `Blockly.common.setSelected`.
+   * block. This typically happens via the selection listener but that is not called
+   * immediately when `Gesture` calls `Blockly.common.setSelected`.
    * In particular the listener runs after showing the context menu.
    *
    * @returns The current field, connection, or block the cursor is on.
    */
-  override getCurNode(): ASTNode | null {
-    const curNode = super.getCurNode();
-    let selected = Blockly.common.getSelected();
-    if (
-      selected === null &&
-      curNode?.getType() === Blockly.ASTNode.types.BLOCK
-    ) {
-      // Selection says our curNode is not selected anymore.
-      // this.setCurNode(null as never, true);
-      return super.getCurNode();
-    }
-    if (selected?.workspace !== this.workspace) return curNode;
-    // Selection has a block in our workspace.
-    if (selected instanceof Blockly.BlockSvg) {
-      if (selected.isShadow()) {
-        // Although the shadow block is selected it's the parent that has the
-        // visual selection.
-        selected = selected.getParent();
-      }
-      if (selected) {
-        this.setCurNode(new ASTNode(ASTNode.types.BLOCK, selected), true);
-      }
-    }
-
+  override getCurNode(): Blockly.ASTNode | null {
+    this.updateCurNodeFromSelection();
     return super.getCurNode();
   }
 
@@ -555,25 +533,9 @@ export class LineCursor extends Marker {
    * @param newNode The new location of the cursor.
    * @param selectionUpToDate If false (the default) we'll update the selection too.
    */
-  override setCurNode(newNode: ASTNode, selectionUpToDate = false) {
+  override setCurNode(newNode: ASTNode | null, selectionUpToDate = false) {
     if (!selectionUpToDate) {
-      if (
-        newNode?.getType() === ASTNode.types.BLOCK &&
-        // For shadow blocks we need to clear the selection that's drawn on their parent.
-        !(newNode.getLocation() as Blockly.BlockSvg).isShadow()
-      ) {
-        if (Blockly.common.getSelected() !== newNode.getLocation()) {
-          Blockly.Events.disable();
-          Blockly.common.setSelected(newNode.getLocation() as Blockly.BlockSvg);
-          Blockly.Events.enable();
-        }
-      } else {
-        if (Blockly.common.getSelected()) {
-          Blockly.Events.disable();
-          Blockly.common.setSelected(null);
-          Blockly.Events.enable();
-        }
-      }
+      this.updateSelectionFromNode(newNode);
     }
 
     super.setCurNode(newNode);
@@ -652,6 +614,7 @@ export class LineCursor extends Marker {
         // Selection should already be in sync.
       } else {
         block.addSelect();
+        block.getParent()?.removeSelect();
       }
     }
 
@@ -707,18 +670,99 @@ export class LineCursor extends Marker {
   }
 
   /**
-   * Event listener that syncs the cursor location to the selected
-   * block on SELECTED events.
+   * Event listener that syncs the cursor location to the selected block on
+   * SELECTED events.
+   *
+   * This does not run early enough in all cases so `getCurNode()` also updates
+   * the node from the selection.
    *
    * @param event The `Selected` event.
    */
-  private selectListener(event: Blockly.Events.Abstract) {
-    if (event.type !== Blockly.Events.SELECTED) return;
-    const selectedEvent = event as Blockly.Events.Selected;
-    if (selectedEvent.workspaceId !== this.workspace.id) return;
-    // This runs too late so the logic to update the selection is in
-    // `getCurNode`.
-    this.getCurNode();
+  private changeListener(event: Blockly.Events.Abstract) {
+    switch (event.type) {
+      case Blockly.Events.SELECTED:
+        this.updateCurNodeFromSelection();
+        break;
+      case Blockly.Events.CLICK: {
+        const click = event as Blockly.Events.Click;
+        if (
+          click.workspaceId === this.workspace.id &&
+          click.targetType === Blockly.Events.ClickTarget.WORKSPACE
+        ) {
+          this.setCurNode(null);
+        }
+      }
+    }
+  }
+
+  /**
+   * Updates the current node to match the selection.
+   *
+   * Clears the current node if it's on a block but the selection is null.
+   * Sets the node to a block if selected for our workspace.
+   * For shadow blocks selections the parent is used by default (unless we're
+   * already on the shadow block via keyboard) as that's where the visual
+   * selection is.
+   */
+  private updateCurNodeFromSelection() {
+    const curNode = super.getCurNode();
+    const selected = Blockly.common.getSelected();
+
+    if (
+      selected === null &&
+      curNode?.getType() === Blockly.ASTNode.types.BLOCK
+    ) {
+      this.setCurNode(null, true);
+      return;
+    }
+    if (selected?.workspace !== this.workspace) {
+      return;
+    }
+    if (selected instanceof Blockly.BlockSvg) {
+      let block: Blockly.BlockSvg | null = selected;
+      if (selected.isShadow()) {
+        // OK if the current node is on the parent OR the shadow block.
+        // The former happens for clicks, the latter for keyboard nav.
+        if (
+          curNode &&
+          (curNode.getLocation() === block ||
+            curNode.getLocation() === block.getParent())
+        ) {
+          return;
+        }
+        block = block.getParent();
+      }
+      if (block) {
+        this.setCurNode(Blockly.ASTNode.createBlockNode(block)!, true);
+      }
+    }
+  }
+
+  /**
+   * Updates the selection from the node.
+   *
+   * Clears the selection for non-block nodes.
+   * Clears the selection for shadow blocks as the selection is drawn on
+   * the parent but the cursor will be drawn on the shadow block itself.
+   * We need to take care not to later clear the current node due to that null
+   * selection, so we track the latest selection we're in sync with.
+   *
+   * @param newNode The new node.
+   */
+  private updateSelectionFromNode(newNode: Blockly.ASTNode | null) {
+    if (newNode?.getType() === ASTNode.types.BLOCK) {
+      if (Blockly.common.getSelected() !== newNode.getLocation()) {
+        Blockly.Events.disable();
+        Blockly.common.setSelected(newNode.getLocation() as Blockly.BlockSvg);
+        Blockly.Events.enable();
+      }
+    } else {
+      if (Blockly.common.getSelected()) {
+        Blockly.Events.disable();
+        Blockly.common.setSelected(null);
+        Blockly.Events.enable();
+      }
+    }
   }
 }
 

--- a/src/navigation.ts
+++ b/src/navigation.ts
@@ -415,19 +415,55 @@ export class Navigation {
   }
 
   /**
-   * Clears the navigation state and switches to using the passive focus indicator.
+   * Clears navigation state and switches to using the passive focus indicator
+   * if it is not the context menu / field input that is causing blur.
    *
    * @param workspace The workspace that has lost focus.
+   * @param ignorePopUpDivs Whether to skip the focus indicator change when
+   *     the widget/dropdown divs are open.
    */
-  handleBlurWorkspace(workspace: Blockly.WorkspaceSvg) {
+  handleBlurWorkspace(
+    workspace: Blockly.WorkspaceSvg,
+    ignorePopUpDivs = false,
+  ) {
     this.setState(workspace, Constants.STATE.NOWHERE);
     const cursor = workspace.getCursor();
-    if (cursor) {
+    const popUpDivsShowing =
+      Blockly.WidgetDiv.isVisible() || Blockly.DropDownDiv.isVisible();
+    if (cursor && (ignorePopUpDivs || !popUpDivsShowing)) {
       if (cursor.getCurNode()) {
         this.passiveFocusIndicator.show(cursor.getCurNode());
       }
       // It's initially null so this is a valid state despite the types.
       cursor.setCurNode(null as never);
+    }
+  }
+
+  /**
+   * Handle the widget or dropdown div losing focus (via focusout).
+   *
+   * Because we skip the widget/dropdown div cases in `handleBlurWorkspace` we need
+   * to catch them here.
+   *
+   * @param workspace The workspace.
+   * @param relatedTarget The related target (newly focused element if any).
+   */
+  handleFocusOutWidgetDropdownDiv(
+    workspace: Blockly.WorkspaceSvg,
+    relatedTarget: EventTarget | null,
+  ) {
+    if (relatedTarget === null) {
+      // Workaround:
+      // Skip document.body/null case until these blur bugs are fixed to avoid
+      // flipping to passive focus as the user moves their mouse over the
+      // dropdown/widget at the cost of clicks on body showing the wrong focus
+      // style.
+      // https://github.com/google/blockly-samples/issues/2498
+      // https://github.com/google/blockly/issues/8819
+      return;
+    }
+    if (relatedTarget !== getWorkspaceElement(workspace)) {
+      this.handleBlurWorkspace(workspace, true);
     }
   }
 

--- a/src/navigation.ts
+++ b/src/navigation.ts
@@ -455,12 +455,10 @@ export class Navigation {
   ) {
     if (relatedTarget === null) {
       // Workaround:
-      // Skip document.body/null case until these blur bugs are fixed to avoid
+      // Skip document.body/null case until this blur bugs is fixed to avoid
       // flipping to passive focus as the user moves their mouse over the
-      // dropdown/widget at the cost of clicks on body showing the wrong focus
-      // style.
+      // colour picker.
       // https://github.com/google/blockly-samples/issues/2498
-      // https://github.com/google/blockly/issues/8819
       return;
     }
     if (relatedTarget !== getWorkspaceElement(workspace)) {

--- a/src/navigation.ts
+++ b/src/navigation.ts
@@ -455,7 +455,7 @@ export class Navigation {
   ) {
     if (relatedTarget === null) {
       // Workaround:
-      // Skip document.body/null case until this blur bugs is fixed to avoid
+      // Skip document.body/null case until this blur bug is fixed to avoid
       // flipping to passive focus as the user moves their mouse over the
       // colour picker.
       // https://github.com/google/blockly-samples/issues/2498

--- a/src/navigation_controller.ts
+++ b/src/navigation_controller.ts
@@ -196,6 +196,13 @@ export class NavigationController {
     this.navigation.handleBlurWorkspace(workspace);
   }
 
+  handleFocusOutWidgetDropdownDiv(
+    workspace: Blockly.WorkspaceSvg,
+    relatedTarget: EventTarget | null,
+  ) {
+    this.navigation.handleFocusOutWidgetDropdownDiv(workspace, relatedTarget);
+  }
+
   focusToolbox(workspace: Blockly.WorkspaceSvg) {
     this.navigation.focusToolbox(workspace);
   }


### PR DESCRIPTION
PR #326 introduced an issue with stale current node when showing the context menu by mouse. It's only possible to fix this by reinstating the updating of curNode from the selection in `getCurNode`.

We also attempt to avoid showing passive focus when using the context menu and widgets (via mouse and keyboard) for consistency with the normal Blockly experience.

You can now no longer get this scenario:

![image](https://github.com/user-attachments/assets/77cc02ae-98d8-41da-be41-95b91287660f)

Fixes an issue clicking on shadow blocks which could previously show an outline around the shadow and parent block. You can now no longer get these scenarios:

![image](https://github.com/user-attachments/assets/c010caf0-8495-491c-9ec6-6d530334d8b3)

![image](https://github.com/user-attachments/assets/12558cf4-978b-43ee-ae15-3f475aabd5b3)

Demo: https://fix-right-click-2.blockly-keyboard-experimentation.pages.dev/