### PR TITLE
fix: flyout mouse scrollbars and selection

### DIFF
--- a/src/actions/arrow_navigation.ts
+++ b/src/actions/arrow_navigation.ts
@@ -64,7 +64,11 @@ export class ArrowNavigation {
             case Constants.STATE.WORKSPACE:
               isHandled = this.fieldShortcutHandler(workspace, shortcut);
               if (!isHandled && workspace) {
-                if (!this.navigation.defaultCursorPositionIfNeeded(workspace)) {
+                if (
+                  !this.navigation.defaultWorkspaceCursorPositionIfNeeded(
+                    workspace,
+                  )
+                ) {
                   workspace.getCursor()?.in();
                 }
                 isHandled = true;
@@ -97,7 +101,11 @@ export class ArrowNavigation {
             case Constants.STATE.WORKSPACE:
               isHandled = this.fieldShortcutHandler(workspace, shortcut);
               if (!isHandled && workspace) {
-                if (!this.navigation.defaultCursorPositionIfNeeded(workspace)) {
+                if (
+                  !this.navigation.defaultWorkspaceCursorPositionIfNeeded(
+                    workspace,
+                  )
+                ) {
                   workspace.getCursor()?.out();
                 }
                 isHandled = true;
@@ -129,7 +137,11 @@ export class ArrowNavigation {
             case Constants.STATE.WORKSPACE:
               isHandled = this.fieldShortcutHandler(workspace, shortcut);
               if (!isHandled && workspace) {
-                if (!this.navigation.defaultCursorPositionIfNeeded(workspace)) {
+                if (
+                  !this.navigation.defaultWorkspaceCursorPositionIfNeeded(
+                    workspace,
+                  )
+                ) {
                   workspace.getCursor()?.next();
                 }
                 isHandled = true;
@@ -138,7 +150,9 @@ export class ArrowNavigation {
             case Constants.STATE.FLYOUT:
               isHandled = this.fieldShortcutHandler(workspace, shortcut);
               if (!isHandled && flyout) {
-                flyout.getWorkspace()?.getCursor()?.next();
+                if (!this.navigation.defaultFlyoutCursorIfNeeded(workspace)) {
+                  flyout.getWorkspace()?.getCursor()?.next();
+                }
                 isHandled = true;
               }
               return isHandled;
@@ -165,7 +179,7 @@ export class ArrowNavigation {
               isHandled = this.fieldShortcutHandler(workspace, shortcut);
               if (!isHandled) {
                 if (
-                  !this.navigation.defaultCursorPositionIfNeeded(
+                  !this.navigation.defaultWorkspaceCursorPositionIfNeeded(
                     workspace,
                     'last',
                   )
@@ -178,7 +192,14 @@ export class ArrowNavigation {
             case Constants.STATE.FLYOUT:
               isHandled = this.fieldShortcutHandler(workspace, shortcut);
               if (!isHandled && flyout) {
-                flyout.getWorkspace()?.getCursor()?.prev();
+                if (
+                  !this.navigation.defaultFlyoutCursorIfNeeded(
+                    workspace,
+                    'last',
+                  )
+                ) {
+                  flyout.getWorkspace()?.getCursor()?.prev();
+                }
                 isHandled = true;
               }
               return isHandled;

--- a/src/navigation.ts
+++ b/src/navigation.ts
@@ -503,6 +503,8 @@ export class Navigation {
     this.setState(workspace, Constants.STATE.FLYOUT);
     this.getFlyoutCursor(workspace)?.draw();
 
+    // This doesn't identify a click on the scrollbars which will unfortunately
+    // default the cursor if the flyout didn't already have focus.
     if (!Blockly.Gesture.inProgress()) {
       this.defaultFlyoutCursorIfNeeded(workspace);
     }


### PR DESCRIPTION
- Previously clicking the flyout scrollbars closed the flyout. Move focus logic
  to markFocused monkey patches rather than listeners so we can intercept the
  markFocused call in scrollbar.
- Previously clicking in a flyout made the cursor visible, instead default it
  on up/down similarly to the workspace.

Fixes #229 (remaining scrollbar part)

Compromises:
- Monkey patching markFocused, as there's no way to identify that the parent SVG of the main workspace getting focus is due to the flyout workspace `markFocused` call.