### PR TITLE
feat: test page for webdriverio

### DIFF
--- a/package.json
+++ b/package.json
@@ -12,7 +12,9 @@
     "predeploy": "blockly-scripts predeploy",
     "prepublishOnly": "npm login --registry https://wombat-dressing-room.appspot.com",
     "start": "blockly-scripts start",
-    "test": "blockly-scripts test"
+    "test": "blockly-scripts test",
+    "wdio:build": "cd test/webdriverio && webpack",
+    "wdio:clean": "cd test/webdriverio && rm -rf build"
   },
   "main": "./dist/index.js",
   "module": "./src/index.js",

--- a/test/webdriverio/index.html
+++ b/test/webdriverio/index.html
@@ -3,13 +3,6 @@
   <head>
     <meta charset="utf-8" />
     <title>Keyboard-experimentation webdriverio page</title>
-    <link rel="preconnect" href="https://fonts.googleapis.com" />
-    <link
-      rel="stylesheet"
-      href="https://fonts.googleapis.com/css2?family=Roboto:wght@400;500&display=swap" />
-    <link
-      rel="stylesheet"
-      href="https://fonts.googleapis.com/css2?family=Material+Symbols+Outlined:opsz,wght,FILL,GRAD@20..48,100..700,0..1,-50..200" />
     <style>
       body {
         font-family: Roboto, sans-serif;

--- a/test/webdriverio/index.html
+++ b/test/webdriverio/index.html
@@ -1,0 +1,92 @@
+<!doctype html>
+<html>
+  <head>
+    <meta charset="utf-8" />
+    <title>Keyboard-experimentation webdriverio page</title>
+    <link rel="preconnect" href="https://fonts.googleapis.com" />
+    <link
+      rel="stylesheet"
+      href="https://fonts.googleapis.com/css2?family=Roboto:wght@400;500&display=swap" />
+    <link
+      rel="stylesheet"
+      href="https://fonts.googleapis.com/css2?family=Material+Symbols+Outlined:opsz,wght,FILL,GRAD@20..48,100..700,0..1,-50..200" />
+    <style>
+      body {
+        font-family: Roboto, sans-serif;
+        font-size: 15px;
+        margin: 0;
+        max-width: 100vw;
+      }
+
+      #root {
+        display: flex;
+        overflow: hidden;
+        height: 100vh;
+        width: 100vw;
+        background: rgb(228, 228, 228);
+      }
+
+      #blocklyDiv {
+        height: 100%;
+        width: 100%;
+        max-height: 100%;
+        position: relative;
+        --outline-width: 5px;
+      }
+
+      .blocklyWorkspace:focus .blocklyMainBackground {
+        outline: Highlight solid var(--outline-width);
+        outline-offset: -5px;
+      }
+
+      .blocklyFlyout {
+        top: var(--outline-width);
+        left: var(--outline-width);
+        height: calc(100% - calc(var(--outline-width) * 2));
+      }
+
+      .blocklyToolboxDiv ~ .blocklyFlyout:focus {
+        outline: none;
+      }
+
+      pre,
+      code {
+        overflow: auto;
+      }
+
+      #pageContainer {
+        display: flex;
+        width: 100%;
+        max-width: 100vw;
+        height: 100vh;
+      }
+
+      thead {
+        font-weight: bold;
+      }
+
+      .passiveBlockFocus.blocklyPath {
+        stroke-dasharray: 5 3;
+        stroke-width: 3;
+        stroke: #ffa200;
+      }
+
+      .passiveNextIndicator {
+        stroke: #ffa200;
+        fill: #ffa200;
+      }
+
+      .inputActiveFocus {
+        stroke-width: 3;
+        stroke: #ffa200;
+      }
+    </style>
+  </head>
+
+  <body>
+    <div id="root">
+      <div id="blocklyDiv"></div>
+      <div id="shortcuts"></div>
+    </div>
+  </body>
+</html>

--- a/test/webdriverio/index.ts
+++ b/test/webdriverio/index.ts
@@ -1,0 +1,106 @@
+/**
+ * @license
+ * Copyright 2024 Google LLC
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import * as Blockly from 'blockly';
+// Import the default blocks.
+import * as libraryBlocks from 'blockly/blocks';
+import {installAllBlocks as installColourBlocks} from '@blockly/field-colour';
+import {KeyboardNavigation} from '../../src/index';
+// @ts-expect-error No types in js file
+import {blocks} from './../blocks/p5_blocks';
+// @ts-expect-error No types in js file
+import {toolbox as toolboxFlyout} from './../blocks/toolbox.js';
+// @ts-expect-error No types in js file
+import toolboxCategories from './../toolboxCategories.js';
+
+import {javascriptGenerator} from 'blockly/javascript';
+// @ts-expect-error No types in js file
+import {load} from './../loadTestBlocks';
+
+/**
+ * Parse query params for inject and navigation options and update
+ * the fields on the options form to match.
+ *
+ * @returns An options object with keys for each supported option.
+ */
+function getOptions() {
+  const params = new URLSearchParams(window.location.search);
+
+  const scenarioParam = params.get('scenario');
+  const scenario = scenarioParam ?? 'simpleCircle';
+
+  const rendererParam = params.get('renderer');
+  let renderer = 'zelos';
+  // For backwards compatibility with previous behaviour, support
+  // (e.g.) ?geras as well as ?renderer=geras:
+  if (rendererParam) {
+    renderer = rendererParam;
+  } else if (params.get('geras')) {
+    renderer = 'geras';
+  } else if (params.get('thrasos')) {
+    renderer = 'thrasos';
+  }
+
+  const noStackParam = params.get('noStack');
+  const stackConnections = !noStackParam;
+
+  const toolboxParam = params.get('toolbox');
+  const toolbox = toolboxParam ?? 'toolbox';
+  const toolboxObject =
+    toolbox === 'flyout' ? toolboxFlyout : toolboxCategories;
+
+  return {
+    scenario,
+    stackConnections,
+    renderer,
+    toolbox: toolboxObject,
+  };
+}
+
+/**
+ * Create the workspace, including installing keyboard navigation and
+ * change listeners.
+ *
+ * @returns The created workspace.
+ */
+function createWorkspace(): Blockly.WorkspaceSvg {
+  const {scenario, stackConnections, renderer, toolbox} = getOptions();
+
+  const injectOptions = {
+    toolbox,
+    renderer,
+  };
+  const blocklyDiv = document.getElementById('blocklyDiv')!;
+  const workspace = Blockly.inject(blocklyDiv, injectOptions);
+
+  const navigationOptions = {
+    cursor: {stackConnections},
+  };
+  new KeyboardNavigation(workspace, navigationOptions);
+
+  // Disable blocks that aren't inside the setup or draw loops.
+  workspace.addChangeListener(Blockly.Events.disableOrphans);
+
+  load(workspace, scenario);
+
+  return workspace;
+}
+
+/**
+ * Install p5.js blocks and generators.
+ */
+function addP5() {
+  // Installs all four blocks, the colour field, and all language generators.
+  installColourBlocks({
+    javascript: javascriptGenerator,
+  });
+  Blockly.common.defineBlocks(blocks);
+}
+
+document.addEventListener('DOMContentLoaded', () => {
+  addP5();
+  createWorkspace();
+});

--- a/test/webdriverio/webpack.config.js
+++ b/test/webdriverio/webpack.config.js
@@ -1,0 +1,72 @@
+/**
+ * @license
+ * Copyright 2024 Google LLC
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+// Build for webdriverio tests
+
+const path = require('path');
+const HtmlWebpackPlugin = require('html-webpack-plugin');
+const webpack = require('webpack');
+
+const fs = require('fs');
+const appDirectory = fs.realpathSync(process.cwd());
+const resolveApp = (relativePath) => path.resolve(appDirectory, relativePath);
+const packageJson = require(resolveApp('../../package.json'));
+
+const config = {
+  mode: 'development',
+  entry: './index.ts',
+  output: {
+    // Compile the source files into a bundle.
+    filename: 'bundle.js',
+    path: path.resolve(__dirname, 'build'),
+    clean: true,
+  },
+  // Enable webpack-dev-server to get hot refresh of the app.
+  devServer: {
+    static: './build',
+  },
+  module: {
+    rules: [
+      {
+        test: /\.tsx?$/,
+        use: 'ts-loader',
+        exclude: /node_modules/,
+      },
+      {
+        // Load CSS files. They can be imported into JS files.
+        test: /\.css$/i,
+        use: ['style-loader', 'css-loader'],
+      },
+    ],
+  },
+  resolve: {
+    extensions: ['.tsx', '.ts', '.js'],
+    fallback: {
+      'util': false,
+    },
+  },
+  plugins: [
+    // Generate the HTML index page based on our template.
+    // This will output the same index page with the bundle we
+    // created above added in a script tag.
+    new HtmlWebpackPlugin({
+      template: './index.html',
+    }),
+    // Use DefinePlugin (https://webpack.js.org/plugins/define-plugin/)
+    // to pass the name of the package being built to the dev-tools
+    // playground (via plugins/dev-tools/src/playground/id.js).  The
+    // "process.env."  prefix is arbitrary: the stringified value
+    // gets substituted directly into the source code of that file
+    // at build time.
+    new webpack.DefinePlugin({
+      'process.env.PACKAGE_NAME': JSON.stringify(packageJson.name),
+    }),
+  ],
+};
+
+module.exports = (env, argv) => {
+  return config;
+};


### PR DESCRIPTION
Fixes #335 and #336

- Adds a test page for webdriverio testing (`index.html` and `index.ts`) that looks similar to the standard test page but removes the ability to run code or set options through a form on the page. Setting options through the URL is still allowed.
- Adds a webpack config to build a static HTML page with all associated imports. This means we won't need to run a server to do these tests.
  - The output is in `test/webdriverio/build`
- Add scripts for `wdio:build` and `wdio:clean` to `package.json`