### PR TITLE
feat: add tests for loading and selecting a block

### DIFF
--- a/package.json
+++ b/package.json
@@ -12,9 +12,10 @@
     "predeploy": "blockly-scripts predeploy",
     "prepublishOnly": "npm login --registry https://wombat-dressing-room.appspot.com",
     "start": "blockly-scripts start",
-    "test": "blockly-scripts test",
+    "test": "npm run wdio:clean && npm run wdio:build && npm run wdio:run",
     "wdio:build": "cd test/webdriverio && webpack",
-    "wdio:clean": "cd test/webdriverio && rm -rf build"
+    "wdio:clean": "cd test/webdriverio && rm -rf build",
+    "wdio:run": "cd test/webdriverio && npx mocha"
   },
   "main": "./dist/index.js",
   "module": "./src/index.js",

--- a/test/loadTestBlocks.js
+++ b/test/loadTestBlocks.js
@@ -228,7 +228,7 @@ const simpleCircle = {
           'STATEMENTS': {
             'block': {
               'type': 'simple_circle',
-              'id': '_}!@OHwjAb,2Gi8nT0}L',
+              'id': 'draw_circle_1',
               'inline': true,
               'inputs': {
                 'COLOR': {

--- a/test/webdriverio/index.ts
+++ b/test/webdriverio/index.ts
@@ -103,6 +103,8 @@ function addP5() {
 document.addEventListener('DOMContentLoaded', () => {
   addP5();
   createWorkspace();
+  // Add Blockly to the global scope so that test code can access it to
+  // verify state after keypresses.
   // @ts-ignore
-  window.getMainWorkspace = Blockly.getMainWorkspace;
+  window.Blockly = Blockly;
 });

--- a/test/webdriverio/index.ts
+++ b/test/webdriverio/index.ts
@@ -103,4 +103,6 @@ function addP5() {
 document.addEventListener('DOMContentLoaded', () => {
   addP5();
   createWorkspace();
+  // @ts-ignore
+  window.getMainWorkspace = Blockly.getMainWorkspace;
 });

--- a/test/webdriverio/test/basic_test.mjs
+++ b/test/webdriverio/test/basic_test.mjs
@@ -1,9 +1,15 @@
+/**
+ * @license
+ * Copyright 2025 Google LLC
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
 import * as chai from 'chai';
-import {testSetup, testFileLocations} from './test_setup.mjs';
+import {testSetup, testFileLocations, PAUSE_TIME} from './test_setup.mjs';
 import {Key} from 'webdriverio';
 
-suite('Testing testing', function () {
-  // Setting timeout to unlimited as the webdriver takes a longer time to run than most mocha test
+suite('Keyboard navigation', function () {
+  // Setting timeout to unlimited as these tests take a longer time to run than most mocha test
   this.timeout(0);
 
   // Setup Selenium for all of the tests
@@ -13,29 +19,27 @@ suite('Testing testing', function () {
 
   test('Default workspace', async function () {
     const blockCount = await this.browser.execute(() => {
-      return getMainWorkspace().getAllBlocks(false).length;
+      return Blockly.getMainWorkspace().getAllBlocks(false).length;
     });
 
     chai.assert.equal(blockCount, 7);
   });
 
-  test('Click on workspace', async function () {
+  test('Selected block', async function () {
     const workspace = await this.browser.$(
       '#blocklyDiv > div > svg.blocklySvg > g',
     );
     await workspace.click();
-    await this.browser.pause(50);
+    await this.browser.pause(PAUSE_TIME);
 
     for (let i = 0; i < 9; i++) {
       await this.browser.keys(Key.ArrowDown);
-      await this.browser.pause(50);
+      await this.browser.pause(PAUSE_TIME);
     }
 
-    await this.browser.pause(1000);
-
-    const blockCount = await this.browser.execute(() => {
-      return getMainWorkspace().getAllBlocks(false).length;
+    const selectedId = await this.browser.execute(() => {
+      return Blockly.common.getSelected().id;
     });
-    chai.assert.equal(blockCount, 7);
+    chai.assert.equal(selectedId, 'draw_circle_1');
   });
 });

--- a/test/webdriverio/test/basic_test.mjs
+++ b/test/webdriverio/test/basic_test.mjs
@@ -1,0 +1,41 @@
+import * as chai from 'chai';
+import {testSetup, testFileLocations} from './test_setup.mjs';
+import {Key} from 'webdriverio';
+
+suite('Testing testing', function () {
+  // Setting timeout to unlimited as the webdriver takes a longer time to run than most mocha test
+  this.timeout(0);
+
+  // Setup Selenium for all of the tests
+  suiteSetup(async function () {
+    this.browser = await testSetup(testFileLocations.BASE);
+  });
+
+  test('Default workspace', async function () {
+    const blockCount = await this.browser.execute(() => {
+      return getMainWorkspace().getAllBlocks(false).length;
+    });
+
+    chai.assert.equal(blockCount, 7);
+  });
+
+  test('Click on workspace', async function () {
+    const workspace = await this.browser.$(
+      '#blocklyDiv > div > svg.blocklySvg > g',
+    );
+    await workspace.click();
+    await this.browser.pause(50);
+
+    for (let i = 0; i < 9; i++) {
+      await this.browser.keys(Key.ArrowDown);
+      await this.browser.pause(50);
+    }
+
+    await this.browser.pause(1000);
+
+    const blockCount = await this.browser.execute(() => {
+      return getMainWorkspace().getAllBlocks(false).length;
+    });
+    chai.assert.equal(blockCount, 7);
+  });
+});

--- a/test/webdriverio/test/test_setup.mjs
+++ b/test/webdriverio/test/test_setup.mjs
@@ -17,7 +17,18 @@
  */
 
 import * as webdriverio from 'webdriverio';
+import * as path from 'path';
+import {fileURLToPath} from 'url';
 
+/**
+ * The directory where this code was run.
+ *
+ */
+const __dirname = path.dirname(fileURLToPath(import.meta.url));
+
+/**
+ * The webdriverio instance, which should only be initialized once.
+ */
 let driver = null;
 
 /**
@@ -86,6 +97,29 @@ export async function testSetup(playgroundUrl) {
   // Wait for the workspace to exist and be rendered.
   await driver
     .$('.blocklySvg .blocklyWorkspace > .blocklyBlockCanvas')
-    .waitForExist({timeout: 20000});
+    .waitForExist({timeout: 2000});
   return driver;
 }
+
+/**
+ * Replaces OS-specific path with POSIX style path.
+ * Simplified implementation based on
+ * https://stackoverflow.com/a/63251716/4969945
+ *
+ * @param {string} target target path
+ * @return {string} posix path
+ */
+function posixPath(target) {
+  const result = target.split(path.sep).join(path.posix.sep);
+  console.log(result);
+  return result;
+}
+
+export const testFileLocations = {
+  BASE:
+    'file://' + posixPath(path.join(__dirname, '..', 'build')) + '/index.html',
+  GERAS:
+    'file://' +
+    posixPath(path.join(__dirname, '..', 'build')) +
+    '/index.html?renderer=geras',
+};

--- a/test/webdriverio/test/test_setup.mjs
+++ b/test/webdriverio/test/test_setup.mjs
@@ -40,7 +40,7 @@ export const PAUSE_TIME = 50;
 /**
  * Start up the test page. This should only be done once, to avoid
  * constantly popping browser windows open and closed.
- * @return A Promsie that resolves to a webdriverIO browser that tests can manipulate.
+ * @return A Promise that resolves to a webdriverIO browser that tests can manipulate.
  */
 export async function driverSetup() {
   const options = {
@@ -50,6 +50,9 @@ export async function driverSetup() {
       'goog:chromeOptions': {
         args: ['--allow-file-access-from-files'],
       },
+      // We aren't (yet) using any BiDi features, and BiDi is sensitive to
+      // mismatches between Chrome version and Chromedriver version.
+      'wdio:enforceWebDriverClassic': 'true',
     },
     logLevel: 'warn',
   };


### PR DESCRIPTION
Fixes https://github.com/google/blockly-keyboard-experimentation/issues/339
- Adds a test file with tests to open the page and to click on the workspace and use arrow keys to move around.
- Demonstrates how to execute code in the browser context with [`await this.browser.execute`](https://webdriver.io/docs/api/browser/execute) to get values out of the page.
- Adds `Blockly` to the `window` object in the test page so that it can be accessed in a `browser.execute` call.
- Demonstrates how to find an element with selectors:
```
    const workspace = await this.browser.$(
      '#blocklyDiv > div > svg.blocklySvg > g',
    );
```
- Demonstrates [how to pass keyboard events](https://webdriver.io/docs/api/browser/keys) into the browser: `await this.browser.keys(Key.ArrowDown);`

Fixes https://github.com/google/blockly-keyboard-experimentation/issues/340 
- Adds a `wdio:run` script and updates the `test` script to clean, build, and run for wdio tests.

Fixes part of https://github.com/google/blockly-keyboard-experimentation/issues/341
- Adds a value to `testFileLocations` to load the page with geras. Could also be done by just tacking values directly onto the `BASE` value in the test setup; the only benefit of doing it this way is that the test-writer doesn't have to remember the parameters.
- The page doesn't currently have an RTL toggle so I did not add it as a URL.

### Additional notes
I added [`'wdio:enforceWebDriverClassic': 'true',`](https://webdriver.io/blog/2024/08/15/webdriverio-v9-release#new-features) to the list of capabilities because despite working just fine, I was getting this error in the console after my tests ran:
`2025-03-25T23:26:39.360Z ERROR webdriver: Could not connect to Bidi protocol of any candidate url in time: "ws://127.0.0.1:35297/session/3c5479a6a76e903be87e21495fe17387"`

We're not currently using BiDi features; [Webdriver BiDi](https://w3c.github.io/webdriver-bidi/) is a fairly new standard (still an editor's draft) so I don't want to rely on its stability.