### PR TITLE
chore: fix lint errors and run lint in CI

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -1,0 +1,22 @@
+# Build workflow
+name: Build
+
+on: [pull_request, workflow_dispatch]
+
+permissions:
+  contents: read
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+      - name: Setup Node
+        uses: actions/setup-node@v4
+        with:
+          node-version: latest
+          cache: 'npm'
+      - run: npm ci
+      - run: npm run build
+      - run: npm run lint

--- a/eslint.config.js
+++ b/eslint.config.js
@@ -129,7 +129,7 @@ module.exports = [
     },
   },
   {
-    files: ['**/*.mocha.js'],
+    files: ['**/*.mocha.js', 'test/webdriverio/test/*_test.mjs'],
     languageOptions: {
       globals: {
         ...globals.mocha,

--- a/src/actions/action_menu.ts
+++ b/src/actions/action_menu.ts
@@ -219,7 +219,7 @@ export class ActionMenu {
    * @returns the action.
    */
   private getContextMenuAction(id: string) {
-    const item = ContextMenuRegistry.registry.getItem('insert');
+    const item = ContextMenuRegistry.registry.getItem(id);
     if (!item) {
       throw new Error(`can't find context menu item ${id}`);
     }

--- a/src/actions/arrow_navigation.ts
+++ b/src/actions/arrow_navigation.ts
@@ -57,7 +57,7 @@ export class ArrowNavigation {
       right: {
         name: Constants.SHORTCUT_NAMES.RIGHT,
         preconditionFn: (workspace) => this.canCurrentlyNavigate(workspace),
-        callback: (workspace, _, shortcut) => {
+        callback: (workspace, e, shortcut) => {
           const toolbox = workspace.getToolbox() as Toolbox;
           let isHandled = false;
           switch (this.navigation.getState(workspace)) {
@@ -94,7 +94,7 @@ export class ArrowNavigation {
       left: {
         name: Constants.SHORTCUT_NAMES.LEFT,
         preconditionFn: (workspace) => this.canCurrentlyNavigate(workspace),
-        callback: (workspace, _, shortcut) => {
+        callback: (workspace, e, shortcut) => {
           const toolbox = workspace.getToolbox() as Toolbox;
           let isHandled = false;
           switch (this.navigation.getState(workspace)) {
@@ -129,7 +129,7 @@ export class ArrowNavigation {
       down: {
         name: Constants.SHORTCUT_NAMES.DOWN,
         preconditionFn: (workspace) => this.canCurrentlyNavigate(workspace),
-        callback: (workspace, _, shortcut) => {
+        callback: (workspace, e, shortcut) => {
           const toolbox = workspace.getToolbox() as Toolbox;
           const flyout = workspace.getFlyout();
           let isHandled = false;
@@ -170,7 +170,7 @@ export class ArrowNavigation {
       up: {
         name: Constants.SHORTCUT_NAMES.UP,
         preconditionFn: (workspace) => this.canCurrentlyNavigate(workspace),
-        callback: (workspace, _, shortcut) => {
+        callback: (workspace, e, shortcut) => {
           const flyout = workspace.getFlyout();
           const toolbox = workspace.getToolbox() as Toolbox;
           let isHandled = false;

--- a/src/actions/clipboard.ts
+++ b/src/actions/clipboard.ts
@@ -379,6 +379,7 @@ export class Clipboard {
         this.navigation.tryToConnectNodes(
           pasteWorkspace,
           targetNode,
+          // eslint-disable-next-line @typescript-eslint/no-non-null-assertion
           ASTNode.createBlockNode(block)!,
         );
       }

--- a/src/actions/delete.ts
+++ b/src/actions/delete.ts
@@ -113,7 +113,7 @@ export class DeleteAction {
         // Run the original precondition code, from the context menu option.
         // If the item would be hidden or disabled, respect it.
         const originalPreconditionResult =
-          this.oldContextMenuItem!.preconditionFn?.(scope) ?? 'enabled';
+          this.oldContextMenuItem?.preconditionFn?.(scope) ?? 'enabled';
         if (!ws || originalPreconditionResult !== 'enabled') {
           return originalPreconditionResult;
         }

--- a/src/actions/disconnect.ts
+++ b/src/actions/disconnect.ts
@@ -145,6 +145,7 @@ export class DisconnectAction {
     rootBlock.bringToFront();
 
     if (wasVisitingConnection) {
+      // eslint-disable-next-line @typescript-eslint/no-non-null-assertion
       const connectionNode = ASTNode.createConnectionNode(superiorConnection)!;
       workspace.getCursor()?.setCurNode(connectionNode);
     }

--- a/src/actions/disconnect.ts
+++ b/src/actions/disconnect.ts
@@ -117,12 +117,17 @@ export class DisconnectAction {
     if (!curConnection.isConnected()) {
       return;
     }
+    const targetConnection = curConnection.targetConnection;
+    if (!targetConnection) {
+      throw new Error('Must have target if connected');
+    }
+
     const superiorConnection = curConnection.isSuperior()
       ? curConnection
-      : curConnection.targetConnection!;
+      : targetConnection;
 
     const inferiorConnection = curConnection.isSuperior()
-      ? curConnection.targetConnection!
+      ? targetConnection
       : curConnection;
 
     if (inferiorConnection.getSourceBlock().isShadow()) {
@@ -140,8 +145,8 @@ export class DisconnectAction {
     rootBlock.bringToFront();
 
     if (wasVisitingConnection) {
-      const connectionNode = ASTNode.createConnectionNode(superiorConnection);
-      workspace.getCursor()!.setCurNode(connectionNode!);
+      const connectionNode = ASTNode.createConnectionNode(superiorConnection)!;
+      workspace.getCursor()?.setCurNode(connectionNode);
     }
   }
 }

--- a/src/actions/disconnect.ts
+++ b/src/actions/disconnect.ts
@@ -145,8 +145,7 @@ export class DisconnectAction {
     rootBlock.bringToFront();
 
     if (wasVisitingConnection) {
-      // eslint-disable-next-line @typescript-eslint/no-non-null-assertion
-      const connectionNode = ASTNode.createConnectionNode(superiorConnection)!;
+      const connectionNode = ASTNode.createConnectionNode(superiorConnection);
       workspace.getCursor()?.setCurNode(connectionNode);
     }
   }

--- a/src/actions/edit.ts
+++ b/src/actions/edit.ts
@@ -4,19 +4,9 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-import {
-  Connection,
-  ContextMenuRegistry,
-  ShortcutRegistry,
-  comments,
-  utils as BlocklyUtils,
-} from 'blockly';
-import * as Constants from '../constants';
-import type {BlockSvg, WorkspaceSvg} from 'blockly';
+import {ContextMenuRegistry} from 'blockly';
+import type {WorkspaceSvg} from 'blockly';
 import {LineCursor} from '../line_cursor';
-import {NavigationController} from '../navigation_controller';
-
-const KeyCodes = BlocklyUtils.KeyCodes;
 
 /**
  * Action to edit a block.  This just moves the cursor to the first

--- a/src/actions/enter.ts
+++ b/src/actions/enter.ts
@@ -145,8 +145,7 @@ export class EnterAction {
     }
 
     this.navigation.focusWorkspace(workspace);
-    // eslint-disable-next-line @typescript-eslint/no-non-null-assertion
-    workspace.getCursor()?.setCurNode(ASTNode.createBlockNode(newBlock)!);
+    workspace.getCursor()?.setCurNode(ASTNode.createBlockNode(newBlock));
   }
 
   /**

--- a/src/actions/enter.ts
+++ b/src/actions/enter.ts
@@ -134,6 +134,7 @@ export class EnterAction {
         !this.navigation.tryToConnectNodes(
           workspace,
           stationaryNode,
+          // eslint-disable-next-line @typescript-eslint/no-non-null-assertion
           ASTNode.createBlockNode(newBlock)!,
         )
       ) {
@@ -144,6 +145,7 @@ export class EnterAction {
     }
 
     this.navigation.focusWorkspace(workspace);
+    // eslint-disable-next-line @typescript-eslint/no-non-null-assertion
     workspace.getCursor()?.setCurNode(ASTNode.createBlockNode(newBlock)!);
   }
 

--- a/src/actions/enter.ts
+++ b/src/actions/enter.ts
@@ -144,7 +144,7 @@ export class EnterAction {
     }
 
     this.navigation.focusWorkspace(workspace);
-    workspace.getCursor()!.setCurNode(ASTNode.createBlockNode(newBlock)!);
+    workspace.getCursor()?.setCurNode(ASTNode.createBlockNode(newBlock)!);
   }
 
   /**
@@ -155,17 +155,22 @@ export class EnterAction {
    */
   private triggerButtonCallback(workspace: WorkspaceSvg) {
     const button = this.navigation
-      .getFlyoutCursor(workspace)!
-      .getCurNode()
+      .getFlyoutCursor(workspace)
+      ?.getCurNode()
       ?.getLocation() as FlyoutButton | undefined;
     if (!button) return;
-    const buttonCallback = (workspace as any).flyoutButtonCallbacks.get(
-      (button as any).callbackKey,
-    );
-    if (typeof buttonCallback === 'function') {
+
+    const flyoutButtonCallbacks: Map<string, (p1: FlyoutButton) => void> =
+      // @ts-expect-error private field access
+      workspace.flyoutButtonCallbacks;
+
+    const info = button.info;
+    if ('callbackkey' in info) {
+      const buttonCallback = flyoutButtonCallbacks.get(info.callbackkey);
+      if (!buttonCallback) {
+        throw new Error('No callback function found for flyout button.');
+      }
       buttonCallback(button);
-    } else if (!button.isLabel()) {
-      throw new Error('No callback function found for flyout button.');
     }
   }
 
@@ -208,8 +213,8 @@ export class EnterAction {
     }
 
     const curBlock = this.navigation
-      .getFlyoutCursor(workspace)!
-      .getCurNode()
+      .getFlyoutCursor(workspace)
+      ?.getCurNode()
       ?.getLocation() as BlockSvg | undefined;
     if (!curBlock?.isEnabled()) {
       console.warn("Can't insert a disabled block.");

--- a/src/actions/insert.ts
+++ b/src/actions/insert.ts
@@ -5,16 +5,14 @@
  */
 
 import {
-  Connection,
   ContextMenuRegistry,
   ShortcutRegistry,
-  comments,
   utils as BlocklyUtils,
 } from 'blockly';
 import * as Constants from '../constants';
-import type {BlockSvg, WorkspaceSvg} from 'blockly';
+import type {WorkspaceSvg} from 'blockly';
 import {Navigation} from '../navigation';
-import {Scope} from './action_menu';
+import {ScopeWithConnection} from './action_menu';
 
 const KeyCodes = BlocklyUtils.KeyCodes;
 
@@ -87,15 +85,15 @@ export class InsertAction {
           return 'Insert Block (I)';
         }
       },
-      preconditionFn: (scope: Scope) => {
+      preconditionFn: (scope: ScopeWithConnection) => {
         const block = scope.block ?? scope.connection?.getSourceBlock();
         const ws = block?.workspace as WorkspaceSvg | null;
         if (!ws) return 'hidden';
 
         return this.insertPrecondition(ws) ? 'enabled' : 'hidden';
       },
-      callback: (scope: Scope) => {
-        let ws =
+      callback: (scope: ScopeWithConnection) => {
+        const ws =
           scope.block?.workspace ??
           (scope.connection?.getSourceBlock().workspace as WorkspaceSvg);
         if (!ws) return false;

--- a/src/actions/ws_movement.ts
+++ b/src/actions/ws_movement.ts
@@ -115,6 +115,7 @@ export class WorkspaceMovement {
     const newY = yDirection * WS_MOVE_DISTANCE + wsCoord.y;
 
     cursor.setCurNode(
+      // eslint-disable-next-line @typescript-eslint/no-non-null-assertion
       ASTNode.createWorkspaceNode(
         workspace,
         new BlocklyUtils.Coordinate(newX, newY),

--- a/src/actions/ws_movement.ts
+++ b/src/actions/ws_movement.ts
@@ -115,11 +115,10 @@ export class WorkspaceMovement {
     const newY = yDirection * WS_MOVE_DISTANCE + wsCoord.y;
 
     cursor.setCurNode(
-      // eslint-disable-next-line @typescript-eslint/no-non-null-assertion
       ASTNode.createWorkspaceNode(
         workspace,
         new BlocklyUtils.Coordinate(newX, newY),
-      )!,
+      ),
     );
     return true;
   }

--- a/src/actions/ws_movement.ts
+++ b/src/actions/ws_movement.ts
@@ -14,6 +14,11 @@ const createSerializedKey = ShortcutRegistry.registry.createSerializedKey.bind(
 );
 
 /**
+ * The distance to move the cursor when the cursor is on the workspace.
+ */
+const WS_MOVE_DISTANCE = 40;
+
+/**
  * Logic for free movement of the cursor on the workspace with keyboard
  * shortcuts.
  */
@@ -23,11 +28,6 @@ export class WorkspaceMovement {
    * is allowed.
    */
   private canCurrentlyEdit: (ws: WorkspaceSvg) => boolean;
-
-  /**
-   * The distance to move the cursor when the cursor is on the workspace.
-   */
-  WS_MOVE_DISTANCE = 40;
 
   constructor(canEdit: (ws: WorkspaceSvg) => boolean) {
     this.canCurrentlyEdit = canEdit;
@@ -111,8 +111,8 @@ export class WorkspaceMovement {
     if (!curNode || curNode.getType() !== ASTNode.types.WORKSPACE) return false;
 
     const wsCoord = curNode.getWsCoordinate();
-    const newX = xDirection * this.WS_MOVE_DISTANCE + wsCoord.x;
-    const newY = yDirection * this.WS_MOVE_DISTANCE + wsCoord.y;
+    const newX = xDirection * WS_MOVE_DISTANCE + wsCoord.x;
+    const newY = yDirection * WS_MOVE_DISTANCE + wsCoord.y;
 
     cursor.setCurNode(
       ASTNode.createWorkspaceNode(

--- a/src/constants.ts
+++ b/src/constants.ts
@@ -1,3 +1,6 @@
+/* eslint-disable @typescript-eslint/naming-convention */
+// The rules expect camel or pascal case enum members and record properties.
+
 /**
  * @license
  * Copyright 2021 Google LLC
@@ -38,13 +41,11 @@ export enum SHORTCUT_NAMES {
   CUT = 'keyboard_nav_cut',
   PASTE = 'keyboard_nav_paste',
   DELETE = 'keyboard_nav_delete',
-  /* eslint-disable @typescript-eslint/naming-convention */
   MOVE_WS_CURSOR_UP = 'workspace_up',
   MOVE_WS_CURSOR_DOWN = 'workspace_down',
   MOVE_WS_CURSOR_LEFT = 'workspace_left',
   MOVE_WS_CURSOR_RIGHT = 'workspace_right',
   CREATE_WS_CURSOR = 'to_workspace',
-  /* eslint-enable @typescript-eslint/naming-convention */
   LIST_SHORTCUTS = 'list_shortcuts',
   CLEAN_UP = 'clean_up_workspace',
 }

--- a/src/flyout_cursor.ts
+++ b/src/flyout_cursor.ts
@@ -83,12 +83,13 @@ export class FlyoutCursor extends Blockly.Cursor {
     return null;
   }
 
-  override setCurNode(node: Blockly.ASTNode) {
+  override setCurNode(node: Blockly.ASTNode | null) {
     super.setCurNode(node);
 
-    const location = node.getLocation();
+    const location = node?.getLocation();
     let bounds: Blockly.utils.Rect | undefined;
     if (
+      location &&
       'getBoundingRectangle' in location &&
       typeof location.getBoundingRectangle === 'function'
     ) {

--- a/src/flyout_cursor.ts
+++ b/src/flyout_cursor.ts
@@ -20,6 +20,8 @@ import {scrollBoundsIntoView} from './workspace_utilities';
 export class FlyoutCursor extends Blockly.Cursor {
   /**
    * The constructor for the FlyoutCursor.
+   *
+   * @param flyout The flyout this cursor is for.
    */
   constructor(private readonly flyout: Blockly.IFlyout) {
     super();

--- a/src/index.ts
+++ b/src/index.ts
@@ -10,9 +10,9 @@ import {CursorOptions, LineCursor} from './line_cursor';
 import {getFlyoutElement, getToolboxElement} from './workspace_utilities';
 
 /** Options object for KeyboardNavigation instances. */
-export type NavigationOptions = {
+export interface NavigationOptions {
   cursor: Partial<CursorOptions>;
-};
+}
 
 /** Default options for LineCursor instances. */
 const defaultOptions: NavigationOptions = {
@@ -73,6 +73,7 @@ export class KeyboardNavigation {
    *
    * @param workspace The workspace that the plugin will
    *     be added to.
+   * @param options Options.
    */
   constructor(
     workspace: Blockly.WorkspaceSvg,

--- a/src/keynames.ts
+++ b/src/keynames.ts
@@ -19,7 +19,8 @@
  *
  * Copied from goog.events.keynames
  */
-const keyNames = {
+const keyNames: Record<string, string> = {
+  /* eslint-disable @typescript-eslint/naming-convention */
   8: 'backspace',
   9: 'tab',
   13: 'enter',
@@ -118,6 +119,7 @@ const keyNames = {
   221: 'close-square-bracket',
   222: 'single-quote',
   224: 'win',
+  /* eslint-enable @typescript-eslint/naming-convention */
 };
 
 const modifierKeys = ['control', 'alt', 'meta'];
@@ -126,12 +128,20 @@ const modifierKeys = ['control', 'alt', 'meta'];
  * Assign the appropriate class names for the key.
  * Modifier keys are indicated so they can be switched to a platform specific
  * key.
+ *
+ * @param keyName The key name.
  */
-function getKeyClassName(keyName) {
+function getKeyClassName(keyName: string) {
   return modifierKeys.includes(keyName.toLowerCase()) ? 'key modifier' : 'key';
 }
 
-export function toTitleCase(str) {
+/**
+ * Naive title case conversion. Uppercases first and lowercases remainder.
+ *
+ * @param str String.
+ * @returns The string in title case.
+ */
+export function toTitleCase(str: string) {
   return str.charAt(0).toUpperCase() + str.substring(1).toLowerCase();
 }
 
@@ -139,11 +149,13 @@ export function toTitleCase(str) {
  * Convert from a serialized key code to a HTML string.
  * This should be the inverse of ShortcutRegistry.createSerializedKey, but
  * should also convert ascii characters to strings.
- * @param {string} keycode The key code as a string of characters separated
+ *
+ * @param keycode The key code as a string of characters separated
  *     by the + character.
- * @returns {string} A single string representing the key code.
+ * @param index Which key code this is in sequence.
+ * @returns A single string representing the key code.
  */
-function keyCodeToString(keycode, index) {
+function keyCodeToString(keycode: string, index: number) {
   let result = `<span class="shortcut-combo shortcut-combo-${index}">`;
   const pieces = keycode.split('+');
 
@@ -154,29 +166,23 @@ function keyCodeToString(keycode, index) {
     piece = pieces[i];
     strrep = keyNames[piece] ?? piece;
     const className = getKeyClassName(strrep);
-
-    if (i.length === 1) {
-      strrep = strrep.toUpperCase();
-    } else {
-      strrep = toTitleCase(strrep);
-    }
-
     if (i > 0) {
       result += '+';
     }
-    result += `<span class="${className}">${strrep}</span>`;
+    result += `<span class="${className}">${toTitleCase(strrep)}</span>`;
   }
   result += '</span>';
   return result;
 }
 
 /**
- * Convert an array of key codes into a comma-separated list of strings
- * @param {Array<string>} keycodeArr The array of key codes to convert.
- * @returns {string} The input array as a comma-separated list of
+ * Convert an array of key codes into a comma-separated list of strings.
+ *
+ * @param keycodeArr The array of key codes to convert.
+ * @returns The input array as a comma-separated list of
  *     human-readable strings wrapped in HTML.
  */
-export function keyCodeArrayToString(keycodeArr) {
+export function keyCodeArrayToString(keycodeArr: string[]): string {
   const stringified = keycodeArr.map((keycode, index) =>
     keyCodeToString(keycode, index),
   );

--- a/src/line_cursor.ts
+++ b/src/line_cursor.ts
@@ -744,8 +744,7 @@ export class LineCursor extends Marker {
         block = block.getParent();
       }
       if (block) {
-        // eslint-disable-next-line @typescript-eslint/no-non-null-assertion
-        this.setCurNode(Blockly.ASTNode.createBlockNode(block)!, true);
+        this.setCurNode(Blockly.ASTNode.createBlockNode(block), true);
       }
     }
   }

--- a/src/line_cursor.ts
+++ b/src/line_cursor.ts
@@ -744,6 +744,7 @@ export class LineCursor extends Marker {
         block = block.getParent();
       }
       if (block) {
+        // eslint-disable-next-line @typescript-eslint/no-non-null-assertion
         this.setCurNode(Blockly.ASTNode.createBlockNode(block)!, true);
       }
     }

--- a/src/navigation.ts
+++ b/src/navigation.ts
@@ -320,8 +320,7 @@ export class Navigation {
       const curNode = cursor.getCurNode();
       const block = curNode ? curNode.getSourceBlock() : null;
       if (block && block.id === mutatedBlockId) {
-        // eslint-disable-next-line @typescript-eslint/no-non-null-assertion
-        cursor.setCurNode(Blockly.ASTNode.createBlockNode(block)!);
+        cursor.setCurNode(Blockly.ASTNode.createBlockNode(block));
       }
     }
   }
@@ -348,11 +347,7 @@ export class Navigation {
 
     if (sourceBlock.id === deletedBlockId || ids.includes(sourceBlock.id)) {
       cursor.setCurNode(
-        // eslint-disable-next-line @typescript-eslint/no-non-null-assertion
-        Blockly.ASTNode.createWorkspaceNode(
-          workspace,
-          WS_COORDINATE_ON_DELETE,
-        )!,
+        Blockly.ASTNode.createWorkspaceNode(workspace, WS_COORDINATE_ON_DELETE),
       );
     }
   }
@@ -374,8 +369,7 @@ export class Navigation {
     const curNodeBlock = block.isShadow() ? block : block.getParent();
     if (curNodeBlock) {
       this.getFlyoutCursor(mainWorkspace)?.setCurNode(
-        // eslint-disable-next-line @typescript-eslint/no-non-null-assertion
-        Blockly.ASTNode.createStackNode(curNodeBlock)!,
+        Blockly.ASTNode.createStackNode(curNodeBlock),
       );
     }
     this.focusFlyout(mainWorkspace);
@@ -603,17 +597,15 @@ export class Navigation {
     if (!defaultFlyoutItem) return;
     const defaultFlyoutItemElement = defaultFlyoutItem.getElement();
     if (defaultFlyoutItemElement instanceof Blockly.FlyoutButton) {
-      // eslint-disable-next-line @typescript-eslint/no-non-null-assertion
       const astNode = Blockly.ASTNode.createButtonNode(
         defaultFlyoutItemElement as Blockly.FlyoutButton,
-      )!;
+      );
       flyoutCursor.setCurNode(astNode);
       return true;
     } else if (defaultFlyoutItemElement instanceof Blockly.BlockSvg) {
-      // eslint-disable-next-line @typescript-eslint/no-non-null-assertion
       const astNode = Blockly.ASTNode.createStackNode(
         defaultFlyoutItemElement as Blockly.BlockSvg,
-      )!;
+      );
       flyoutCursor.setCurNode(astNode);
       return true;
     }
@@ -652,17 +644,15 @@ export class Navigation {
     );
     if (topBlocks.length > 0) {
       cursor.setCurNode(
-        // eslint-disable-next-line @typescript-eslint/no-non-null-assertion
         Blockly.ASTNode.createTopNode(
           topBlocks[prefer === 'first' ? 0 : topBlocks.length - 1],
-        )!,
+        ),
       );
     } else {
-      // eslint-disable-next-line @typescript-eslint/no-non-null-assertion
       const wsNode = Blockly.ASTNode.createWorkspaceNode(
         workspace,
         wsCoordinates,
-      )!;
+      );
       cursor.setCurNode(wsNode);
     }
     return true;

--- a/src/navigation.ts
+++ b/src/navigation.ts
@@ -320,6 +320,7 @@ export class Navigation {
       const curNode = cursor.getCurNode();
       const block = curNode ? curNode.getSourceBlock() : null;
       if (block && block.id === mutatedBlockId) {
+        // eslint-disable-next-line @typescript-eslint/no-non-null-assertion
         cursor.setCurNode(Blockly.ASTNode.createBlockNode(block)!);
       }
     }
@@ -347,6 +348,7 @@ export class Navigation {
 
     if (sourceBlock.id === deletedBlockId || ids.includes(sourceBlock.id)) {
       cursor.setCurNode(
+        // eslint-disable-next-line @typescript-eslint/no-non-null-assertion
         Blockly.ASTNode.createWorkspaceNode(
           workspace,
           WS_COORDINATE_ON_DELETE,
@@ -372,6 +374,7 @@ export class Navigation {
     const curNodeBlock = block.isShadow() ? block : block.getParent();
     if (curNodeBlock) {
       this.getFlyoutCursor(mainWorkspace)?.setCurNode(
+        // eslint-disable-next-line @typescript-eslint/no-non-null-assertion
         Blockly.ASTNode.createStackNode(curNodeBlock)!,
       );
     }
@@ -600,12 +603,14 @@ export class Navigation {
     if (!defaultFlyoutItem) return;
     const defaultFlyoutItemElement = defaultFlyoutItem.getElement();
     if (defaultFlyoutItemElement instanceof Blockly.FlyoutButton) {
+      // eslint-disable-next-line @typescript-eslint/no-non-null-assertion
       const astNode = Blockly.ASTNode.createButtonNode(
         defaultFlyoutItemElement as Blockly.FlyoutButton,
       )!;
       flyoutCursor.setCurNode(astNode);
       return true;
     } else if (defaultFlyoutItemElement instanceof Blockly.BlockSvg) {
+      // eslint-disable-next-line @typescript-eslint/no-non-null-assertion
       const astNode = Blockly.ASTNode.createStackNode(
         defaultFlyoutItemElement as Blockly.BlockSvg,
       )!;
@@ -647,16 +652,18 @@ export class Navigation {
     );
     if (topBlocks.length > 0) {
       cursor.setCurNode(
+        // eslint-disable-next-line @typescript-eslint/no-non-null-assertion
         Blockly.ASTNode.createTopNode(
           topBlocks[prefer === 'first' ? 0 : topBlocks.length - 1],
         )!,
       );
     } else {
+      // eslint-disable-next-line @typescript-eslint/no-non-null-assertion
       const wsNode = Blockly.ASTNode.createWorkspaceNode(
         workspace,
         wsCoordinates,
-      );
-      cursor.setCurNode(wsNode!);
+      )!;
+      cursor.setCurNode(wsNode);
     }
     return true;
   }
@@ -1150,6 +1157,7 @@ export class Navigation {
         this.tryToConnectNodes(
           workspace,
           targetNode,
+          // eslint-disable-next-line @typescript-eslint/no-non-null-assertion
           Blockly.ASTNode.createBlockNode(block)!,
         );
       }

--- a/src/navigation_controller.ts
+++ b/src/navigation_controller.ts
@@ -149,13 +149,17 @@ export class NavigationController {
     }
     switch (shortcut.name) {
       case Constants.SHORTCUT_NAMES.UP:
-        return (this as any).selectPrevious();
+        // @ts-expect-error private method
+        return this.selectPrevious();
       case Constants.SHORTCUT_NAMES.LEFT:
-        return (this as any).selectParent();
+        // @ts-expect-error private method
+        return this.selectParent();
       case Constants.SHORTCUT_NAMES.DOWN:
-        return (this as any).selectNext();
+        // @ts-expect-error private method
+        return this.selectNext();
       case Constants.SHORTCUT_NAMES.RIGHT:
-        return (this as any).selectChild();
+        // @ts-expect-error private method
+        return this.selectChild();
       default:
         return false;
     }

--- a/src/passive_focus.ts
+++ b/src/passive_focus.ts
@@ -74,6 +74,8 @@ export class PassiveFocus {
   /**
    * Show the passive focus indicator at the specified location.
    * Implementation varies based on location type.
+   *
+   * @param node The node to show passive focus for.
    */
   show(node: ASTNode) {
     // Hide last shown.

--- a/src/shortcut_dialog.ts
+++ b/src/shortcut_dialog.ts
@@ -7,7 +7,6 @@
 import * as Blockly from 'blockly/core';
 import * as Constants from './constants';
 import {ShortcutRegistry} from 'blockly/core';
-// @ts-expect-error No types in js file
 import {keyCodeArrayToString, toTitleCase} from './keynames';
 
 /**
@@ -88,12 +87,13 @@ export class ShortcutDialog {
   }
 
   /**
-   * @param {string} shortcutName Shortcut name to convert.
-   * @returns {string}
+   * Munges a shortcut name into human readable text.
+   *
+   * @param shortcutName Shortcut name to convert.
+   * @returns A title case version of the name.
    */
   getReadableShortcutName(shortcutName: string) {
-    shortcutName = toTitleCase(shortcutName.replace(/_/gi, ' '));
-    return shortcutName;
+    return toTitleCase(shortcutName.replace(/_/gi, ' '));
   }
 
   /**
@@ -188,7 +188,7 @@ export class ShortcutDialog {
 /**
  * Register classes used by the shortcuts modal
  * Alt: plugin exports a register() function that updates the registry
- **/
+ */
 Blockly.Css.register(`
 :root {
   --divider-border-color: #eee;

--- a/test/blocks/p5_blocks.js
+++ b/test/blocks/p5_blocks.js
@@ -1,3 +1,4 @@
+/* eslint-disable camelcase */
 /**
  * @license
  * Copyright 2024 Google LLC

--- a/test/blocks/p5_generators.js
+++ b/test/blocks/p5_generators.js
@@ -1,3 +1,4 @@
+/* eslint-disable camelcase */
 /**
  * @license
  * Copyright 2023 Google LLC

--- a/test/index.ts
+++ b/test/index.ts
@@ -6,7 +6,7 @@
 
 import * as Blockly from 'blockly';
 // Import the default blocks.
-import * as libraryBlocks from 'blockly/blocks';
+import 'blockly/blocks';
 import {installAllBlocks as installColourBlocks} from '@blockly/field-colour';
 import {KeyboardNavigation} from '../src/index';
 // @ts-expect-error No types in js file
@@ -89,7 +89,10 @@ function createWorkspace(): Blockly.WorkspaceSvg {
     toolbox,
     renderer,
   };
-  const blocklyDiv = document.getElementById('blocklyDiv')!;
+  const blocklyDiv = document.getElementById('blocklyDiv');
+  if (!blocklyDiv) {
+    throw new Error('Missing blocklyDiv');
+  }
   const workspace = Blockly.inject(blocklyDiv, injectOptions);
 
   const navigationOptions = {

--- a/test/webdriverio/index.ts
+++ b/test/webdriverio/index.ts
@@ -6,7 +6,7 @@
 
 import * as Blockly from 'blockly';
 // Import the default blocks.
-import * as libraryBlocks from 'blockly/blocks';
+import 'blockly/blocks';
 import {installAllBlocks as installColourBlocks} from '@blockly/field-colour';
 import {KeyboardNavigation} from '../../src/index';
 // @ts-expect-error No types in js file
@@ -73,7 +73,10 @@ function createWorkspace(): Blockly.WorkspaceSvg {
     toolbox,
     renderer,
   };
-  const blocklyDiv = document.getElementById('blocklyDiv')!;
+  const blocklyDiv = document.getElementById('blocklyDiv');
+  if (!blocklyDiv) {
+    throw new Error('Missing blocklyDiv');
+  }
   const workspace = Blockly.inject(blocklyDiv, injectOptions);
 
   const navigationOptions = {
@@ -105,6 +108,7 @@ document.addEventListener('DOMContentLoaded', () => {
   createWorkspace();
   // Add Blockly to the global scope so that test code can access it to
   // verify state after keypresses.
-  // @ts-ignore
+  // eslint-disable-next-line @typescript-eslint/ban-ts-comment
+  // @ts-expect-error
   window.Blockly = Blockly;
 });

--- a/test/webdriverio/test/test_setup.mjs
+++ b/test/webdriverio/test/test_setup.mjs
@@ -40,7 +40,7 @@ export const PAUSE_TIME = 50;
 /**
  * Start up the test page. This should only be done once, to avoid
  * constantly popping browser windows open and closed.
- * @return A Promise that resolves to a webdriverIO browser that tests can manipulate.
+ * @returns {Promise<webdriverio.Browser>} A Promise that resolves to a webdriverIO browser that tests can manipulate.
  */
 export async function driverSetup() {
   const options = {
@@ -90,7 +90,7 @@ export async function driverTeardown() {
  * Navigate to the correct URL for the test, using the shared driver.
  * @param {string} playgroundUrl The URL to open for the test, which should be
  *     a Blockly playground with a workspace.
- * @return A Promsie that resolves to a webdriverIO browser that tests can manipulate.
+ * @returns {Promise<webdriverio.Browser>} A Promsie that resolves to a webdriverIO browser that tests can manipulate.
  */
 export async function testSetup(playgroundUrl) {
   if (!driver) {
@@ -106,11 +106,11 @@ export async function testSetup(playgroundUrl) {
 
 /**
  * Replaces OS-specific path with POSIX style path.
+ *
  * Simplified implementation based on
  * https://stackoverflow.com/a/63251716/4969945
- *
  * @param {string} target target path
- * @return {string} posix path
+ * @returns {string} posix path
  */
 function posixPath(target) {
   const result = target.split(path.sep).join(path.posix.sep);


### PR DESCRIPTION
Fixes #345 

This adds ignores for the non-null checks that relate to createXXXNode. It wasn't as bad as I expected as `setCurNode` permits null now. Raised https://github.com/google/blockly/issues/8827 in case there's interest in revisiting the signature or behaviour here.

It might also be nice to explore converting the tests to TypeScript before we make more of them. It didn't seem too hard to fix the current lint issues there so I've left lint enabled for them.
