### PR TITLE
feat: introduce `Mover` actions + experimental `DragMover` implementation

### DIFF
--- a/src/actions/drag_mover.ts
+++ b/src/actions/drag_mover.ts
@@ -49,8 +49,7 @@ export class DragMover extends Mover {
    */
   override startMove(workspace: WorkspaceSvg) {
     const cursor = workspace?.getCursor();
-    const curNode = cursor?.getCurNode();
-    const block = curNode?.getSourceBlock() as BlockSvg | null;
+    const block = this.getCurrentBlock(workspace);
     if (!cursor || !block) throw new Error('precondition failure');
 
     // Select and focus block.
@@ -81,7 +80,6 @@ export class DragMover extends Mover {
    * @returns True iff move successfully finished.
    */
   override finishMove(workspace: WorkspaceSvg) {
-    if (!workspace) return false;
     const info = this.moves.get(workspace);
     if (!info) throw new Error('no move info for workspace');
 
@@ -103,7 +101,6 @@ export class DragMover extends Mover {
    * @returns True iff move successfully aborted.
    */
   override abortMove(workspace: WorkspaceSvg) {
-    if (!workspace) return false;
     const info = this.moves.get(workspace);
     if (!info) throw new Error('no move info for workspace');
 

--- a/src/actions/drag_mover.ts
+++ b/src/actions/drag_mover.ts
@@ -129,7 +129,7 @@ export class DragMover extends Mover {
     // Not yet implemented.  Absorb keystroke to avoid moving cursor.
     alert(`Constrained movement not implemented.
 
-Use alt+arrow (option+arrow on macOS) for unconstrained move.
+Use ctrl+arrow or alt+arrow (option+arrow on macOS) for unconstrained move.
 Use enter to complete the move, or escape to abort.`);
     return true;
   }

--- a/src/actions/drag_mover.ts
+++ b/src/actions/drag_mover.ts
@@ -1,0 +1,179 @@
+/**
+ * @license
+ * Copyright 2025 Google LLC
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import * as Constants from '../constants';
+import {
+  ASTNode,
+  Connection,
+  ShortcutRegistry,
+  common,
+  registry,
+  utils,
+} from 'blockly';
+import type {Block, BlockSvg, IDragger, WorkspaceSvg} from 'blockly';
+import {Mover, MoveInfo} from './mover';
+import {Navigation} from '../navigation';
+
+/**
+ * An experimental implementation of Mover that uses a dragger to
+ * perform unconstraind movment.
+ */
+export class DragMover extends Mover {
+  /**
+   * The distance to move an item, in workspace coordinates, when
+   * making an unconstrained move.
+   */
+  UNCONSTRAINED_MOVE_DISTANCE = 20;
+
+  /**
+   * Map of moves in progress.
+   *
+   * An entry for a given workspace in this map means that the this
+   * Mover is moving a block on that workspace, and will disable
+   * normal cursor movement until the move is complete.
+   */
+  protected declare moves: Map<WorkspaceSvg, DragMoveInfo>;
+
+  /**
+   * Start moving the currently-focused item on workspace, if
+   * possible.
+   *
+   * Should only be called if canMove has returned true.
+   *
+   * @param workspace The workspace we might be moving on.
+   * @returns True iff a move has successfully begun.
+   */
+  override startMove(workspace: WorkspaceSvg) {
+    const cursor = workspace?.getCursor();
+    const curNode = cursor?.getCurNode();
+    const block = curNode?.getSourceBlock() as BlockSvg | null;
+    if (!cursor || !block) throw new Error('precondition failure');
+
+    // Select and focus block.
+    common.setSelected(block);
+    cursor.setCurNode(ASTNode.createBlockNode(block)!);
+    // Begin dragging block.
+    const DraggerClass = registry.getClassFromOptions(
+      registry.Type.BLOCK_DRAGGER,
+      workspace.options,
+      true,
+    );
+    if (!DraggerClass) throw new Error('no Dragger registered');
+    const dragger = new DraggerClass(block, workspace);
+    // Record that a move is in progress and start dragging.
+    this.moves.set(workspace, new DragMoveInfo(block, dragger));
+    dragger.onDragStart(new PointerEvent('pointerdown'));
+    return true;
+  }
+
+  /**
+   * Finish moving the currently-focused item on workspace.
+   *
+   * Should only be called if isMoving has returned true.
+   *
+   * @param workspace The workspace on which we are moving.
+   * @returns True iff move successfully finished.
+   */
+  override finishMove(workspace: WorkspaceSvg) {
+    if (!workspace) return false;
+    const info = this.moves.get(workspace);
+    if (!info) throw new Error('no move info for workspace');
+
+    info.dragger.onDragEnd(
+      new PointerEvent('pointerup'),
+      new utils.Coordinate(0, 0),
+    );
+
+    this.moves.delete(workspace);
+    return true;
+  }
+
+  /**
+   * Abort moving the currently-focused item on workspace.
+   *
+   * Should only be called if isMoving has returned true.
+   *
+   * @param workspace The workspace on which we are moving.
+   * @returns True iff move successfully aborted.
+   */
+  override abortMove(workspace: WorkspaceSvg) {
+    if (!workspace) return false;
+    const info = this.moves.get(workspace);
+    if (!info) throw new Error('no move info for workspace');
+
+    // Monkey patch dragger to trigger call to draggable.revertDrag.
+    (info.dragger as any).shouldReturnToStart = () => true;
+    info.dragger.onDragEnd(
+      new PointerEvent('pointerup'),
+      new utils.Coordinate(0, 0),
+    );
+
+    this.moves.delete(workspace);
+    return true;
+  }
+
+  /**
+   * Action to move the item being moved in the given direction,
+   * constrained to valid attachment points (if any).
+   *
+   * @param workspace The workspace to move on.
+   * @returns True iff this action applies and has been performed.
+   */
+  override moveConstrained(
+    workspace: WorkspaceSvg,
+    /* ... */
+  ) {
+    // Not yet implemented.  Absorb keystroke to avoid moving cursor.
+    alert(`Constrained movement not implemented.
+
+Use alt+arrow (option+arrow on macOS) for unconstrained move.
+Use enter to complete the move, or escape to abort.`);
+    return true;
+  }
+
+  /**
+   * Action to move the item being moved in the given direction,
+   * without constraint.
+   *
+   * @param workspace The workspace to move on.
+   * @param xDirection -1 to move left. 1 to move right.
+   * @param yDirection -1 to move up. 1 to move down.
+   * @returns True iff this action applies and has been performed.
+   */
+  override moveUnconstrained(
+    workspace: WorkspaceSvg,
+    xDirection: number,
+    yDirection: number,
+  ): boolean {
+    if (!workspace) return false;
+    const info = this.moves.get(workspace);
+    if (!info) throw new Error('no move info for workspace');
+
+    info.totalDelta.x +=
+      xDirection * this.UNCONSTRAINED_MOVE_DISTANCE * workspace.scale;
+    info.totalDelta.y +=
+      yDirection * this.UNCONSTRAINED_MOVE_DISTANCE * workspace.scale;
+
+    info.dragger.onDrag(new PointerEvent('pointermove'), info.totalDelta);
+    return true;
+  }
+}
+
+/**
+ * Information about the currently in-progress move for a given
+ * Workspace.
+ */
+class DragMoveInfo extends MoveInfo {
+  /** Total distance moved, in screen pixels */
+  totalDelta = new utils.Coordinate(0, 0);
+
+  constructor(
+    public readonly block: Block,
+    public readonly dragger: IDragger,
+  ) {
+    super(block);
+  }
+}

--- a/src/actions/drag_mover.ts
+++ b/src/actions/drag_mover.ts
@@ -4,7 +4,14 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-import {ASTNode, WorkspaceSvg, common, registry, utils} from 'blockly';
+import {
+  ASTNode,
+  BlockSvg,
+  WorkspaceSvg,
+  common,
+  registry,
+  utils,
+} from 'blockly';
 import type {Block, IDragger} from 'blockly';
 import {Mover, MoveInfo} from './mover';
 
@@ -97,6 +104,11 @@ export class DragMover extends Mover {
     // Monkey patch dragger to trigger call to draggable.revertDrag.
     // eslint-disable-next-line @typescript-eslint/no-explicit-any
     (info.dragger as any).shouldReturnToStart = () => true;
+    const blockSvg = info.block as BlockSvg;
+
+    // Explicitly call `hidePreview` because it is not called in revertDrag.
+    // @ts-expect-error Access to private property dragStrategy.
+    blockSvg.dragStrategy.connectionPreviewer.hidePreview();
     info.dragger.onDragEnd(
       info.fakePointerEvent('pointerup'),
       new utils.Coordinate(0, 0),

--- a/src/actions/drag_mover.ts
+++ b/src/actions/drag_mover.ts
@@ -23,7 +23,7 @@ const UNCONSTRAINED_MOVE_DISTANCE = 20;
 
 /**
  * An experimental implementation of Mover that uses a dragger to
- * perform unconstraind movement.
+ * perform unconstrained movement.
  */
 export class DragMover extends Mover {
   /**

--- a/src/actions/mover.ts
+++ b/src/actions/mover.ts
@@ -71,7 +71,7 @@ export class Mover {
       allowCollision: true,
     },
     {
-      name: 'Move right unconstraind',
+      name: 'Move right unconstrained',
       preconditionFn: (workspace) => this.isMoving(workspace),
       callback: (workspace) => this.moveConstrained(workspace /* , ... */),
       keyCodes: [KeyCodes.RIGHT],
@@ -103,7 +103,7 @@ export class Mover {
       ],
     },
     {
-      name: 'Move right, unconstraind',
+      name: 'Move right, unconstrained',
       preconditionFn: (workspace) => this.isMoving(workspace),
       callback: (workspace) => this.moveUnconstrained(workspace, 1, 0),
       keyCodes: [

--- a/src/actions/mover.ts
+++ b/src/actions/mover.ts
@@ -25,7 +25,6 @@ const createSerializedKey = ShortcutRegistry.registry.createSerializedKey.bind(
  * Actions for moving blocks with keyboard shortcuts.
  */
 export class Mover {
-
   /**
    * Map of moves in progress.
    *
@@ -324,11 +323,11 @@ export class Mover {
  * Workspace.
  */
 export class MoveInfo {
-  public readonly parentNext: Connection | null;
-  public readonly parentInput: Connection | null;
-  public readonly startLocation: utils.Coordinate;
+  readonly parentNext: Connection | null;
+  readonly parentInput: Connection | null;
+  readonly startLocation: utils.Coordinate;
 
-  constructor(public readonly block: Block) {
+  constructor(readonly block: Block) {
     this.parentNext = block.previousConnection?.targetConnection ?? null;
     this.parentInput = block.outputConnection?.targetConnection ?? null;
     this.startLocation = block.getRelativeToSurfaceXY();

--- a/src/actions/mover.ts
+++ b/src/actions/mover.ts
@@ -329,7 +329,7 @@ export class Mover {
 export class MoveInfo {
   public readonly parentNext: Connection | null;
   public readonly parentInput: Connection | null;
-  public readonly startLocation: utils.Coordinate | null;
+  public readonly startLocation: utils.Coordinate;
 
   constructor(public readonly block: Block) {
     this.parentNext = block.previousConnection?.targetConnection ?? null;

--- a/src/actions/mover.ts
+++ b/src/actions/mover.ts
@@ -106,25 +106,37 @@ export class Mover {
       name: 'Move left, unconstrained',
       preconditionFn: (workspace) => this.isMoving(workspace),
       callback: (workspace) => this.moveUnconstrained(workspace, -1, 0),
-      keyCodes: [createSerializedKey(KeyCodes.LEFT, [KeyCodes.ALT])],
+      keyCodes: [
+        createSerializedKey(KeyCodes.LEFT, [KeyCodes.ALT]),
+        createSerializedKey(KeyCodes.LEFT, [KeyCodes.CTRL]),
+      ],
     },
     {
       name: 'Move right, unconstraind',
       preconditionFn: (workspace) => this.isMoving(workspace),
       callback: (workspace) => this.moveUnconstrained(workspace, 1, 0),
-      keyCodes: [createSerializedKey(KeyCodes.RIGHT, [KeyCodes.ALT])],
+      keyCodes: [
+        createSerializedKey(KeyCodes.RIGHT, [KeyCodes.ALT]),
+        createSerializedKey(KeyCodes.RIGHT, [KeyCodes.CTRL]),
+      ],
     },
     {
       name: 'Move up unconstrained',
       preconditionFn: (workspace) => this.isMoving(workspace),
       callback: (workspace) => this.moveUnconstrained(workspace, 0, -1),
-      keyCodes: [createSerializedKey(KeyCodes.UP, [KeyCodes.ALT])],
+      keyCodes: [
+        createSerializedKey(KeyCodes.UP, [KeyCodes.ALT]),
+        createSerializedKey(KeyCodes.UP, [KeyCodes.CTRL]),
+      ],
     },
     {
       name: 'Move down, unconstrained',
       preconditionFn: (workspace) => this.isMoving(workspace),
       callback: (workspace) => this.moveUnconstrained(workspace, 0, 1),
-      keyCodes: [createSerializedKey(KeyCodes.DOWN, [KeyCodes.ALT])],
+      keyCodes: [
+        createSerializedKey(KeyCodes.DOWN, [KeyCodes.ALT]),
+        createSerializedKey(KeyCodes.DOWN, [KeyCodes.CTRL]),
+      ],
     },
   ];
 

--- a/src/actions/mover.ts
+++ b/src/actions/mover.ts
@@ -46,7 +46,6 @@ export class Mover {
       preconditionFn: (workspace) => this.canMove(workspace),
       callback: (workspace) => this.startMove(workspace),
       keyCodes: [KeyCodes.M],
-      allowCollision: true, // TODO: remove once #309 has been merged.
     },
     {
       name: 'Finish move',

--- a/src/actions/mover.ts
+++ b/src/actions/mover.ts
@@ -1,0 +1,265 @@
+/**
+ * @license
+ * Copyright 2025 Google LLC
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import * as Constants from '../constants';
+import {ASTNode, ShortcutRegistry, utils as BlocklyUtils} from 'blockly';
+import type {Block, WorkspaceSvg} from 'blockly';
+import {Navigation} from '../navigation';
+
+const KeyCodes = BlocklyUtils.KeyCodes;
+const createSerializedKey = ShortcutRegistry.registry.createSerializedKey.bind(
+  ShortcutRegistry.registry,
+);
+
+/**
+ * Actions for moving blocks with keyboard shortcuts.
+ */
+export class Mover {
+  /**
+   * Function provided by the navigation controller to say whether editing
+   * is allowed.
+   */
+  protected canCurrentlyEdit: (ws: WorkspaceSvg) => boolean;
+
+  /**
+   * Map of moves in progress.
+   *
+   * An entry for a given workspace in this map means that the this
+   * Mover is moving a block on that workspace, and will disable
+   * normal cursor movement until the move is complete.
+   */
+  protected moves: Map<WorkspaceSvg, MoveInfo> = new Map();
+
+  constructor(
+    protected navigation: Navigation,
+    canEdit: (ws: WorkspaceSvg) => boolean,
+  ) {
+    this.canCurrentlyEdit = canEdit;
+  }
+
+  private shortcuts: ShortcutRegistry.KeyboardShortcut[] = [
+    // Begin and end move.
+    {
+      name: 'Start move',
+      preconditionFn: (workspace) => this.canMove(workspace),
+      callback: (workspace) => this.startMove(workspace),
+      keyCodes: [KeyCodes.M],
+      allowCollision: true, // TODO: remove once #309 has been merged.
+    },
+    {
+      name: 'Finish move',
+      preconditionFn: (workspace) => this.isMoving(workspace),
+      callback: (workspace) => this.finishMove(workspace),
+      keyCodes: [KeyCodes.ENTER],
+      allowCollision: true,
+    },
+    {
+      name: 'Abort move',
+      preconditionFn: (workspace) => this.isMoving(workspace),
+      callback: (workspace) => this.abortMove(workspace),
+      keyCodes: [KeyCodes.ESC],
+      allowCollision: true,
+    },
+
+    // Constrained moves.
+    {
+      name: 'Move left, constrained',
+      preconditionFn: (workspace) => this.isMoving(workspace),
+      callback: (workspace) => this.moveConstrained(workspace /* , ...*/),
+      keyCodes: [KeyCodes.LEFT],
+      allowCollision: true,
+    },
+    {
+      name: 'Move right unconstraind',
+      preconditionFn: (workspace) => this.isMoving(workspace),
+      callback: (workspace) => this.moveConstrained(workspace /* , ... */),
+      keyCodes: [KeyCodes.RIGHT],
+      allowCollision: true,
+    },
+    {
+      name: 'Move up, constrained',
+      preconditionFn: (workspace) => this.isMoving(workspace),
+      callback: (workspace) => this.moveConstrained(workspace /* , ... */),
+      keyCodes: [KeyCodes.UP],
+      allowCollision: true,
+    },
+    {
+      name: 'Move down constrained',
+      preconditionFn: (workspace) => this.isMoving(workspace),
+      callback: (workspace) => this.moveConstrained(workspace /* , ... */),
+      keyCodes: [KeyCodes.DOWN],
+      allowCollision: true,
+    },
+
+    // Unconstrained moves.
+    {
+      name: 'Move left, unconstrained',
+      preconditionFn: (workspace) => this.isMoving(workspace),
+      callback: (workspace) => this.moveUnconstrained(workspace, -1, 0),
+      keyCodes: [createSerializedKey(KeyCodes.LEFT, [KeyCodes.ALT])],
+    },
+    {
+      name: 'Move right, unconstraind',
+      preconditionFn: (workspace) => this.isMoving(workspace),
+      callback: (workspace) => this.moveUnconstrained(workspace, 1, 0),
+      keyCodes: [createSerializedKey(KeyCodes.RIGHT, [KeyCodes.ALT])],
+    },
+    {
+      name: 'Move up unconstrained',
+      preconditionFn: (workspace) => this.isMoving(workspace),
+      callback: (workspace) => this.moveUnconstrained(workspace, 0, -1),
+      keyCodes: [createSerializedKey(KeyCodes.UP, [KeyCodes.ALT])],
+    },
+    {
+      name: 'Move down, unconstrained',
+      preconditionFn: (workspace) => this.isMoving(workspace),
+      callback: (workspace) => this.moveUnconstrained(workspace, 0, 1),
+      keyCodes: [createSerializedKey(KeyCodes.DOWN, [KeyCodes.ALT])],
+    },
+  ];
+
+  /**
+   * Install the actions as both keyboard shortcuts and (where
+   * applicable) context menu items.
+   */
+  install() {
+    for (const shortcut of this.shortcuts) {
+      ShortcutRegistry.registry.register(shortcut);
+    }
+  }
+
+  /**
+   * Uninstall these actions.
+   */
+  uninstall() {
+    for (const shortcut of this.shortcuts) {
+      ShortcutRegistry.registry.unregister(shortcut.name);
+    }
+  }
+
+  /**
+   * Returns true iff we are able to begin moving a block on the given
+   * workspace.
+   *
+   * @param workspace The workspace to move on.
+   * @returns True iff we can beign a move.
+   */
+  canMove(workspace: WorkspaceSvg) {
+    // TODO: also check if current block is movable.
+    return (
+      this.navigation.getState(workspace) === Constants.STATE.WORKSPACE &&
+      this.canCurrentlyEdit(workspace) &&
+      !this.moves.has(workspace)
+    );
+  }
+
+  /**
+   * Returns true iff we are currently moving a block on the given
+   * workspace.
+   *
+   * @param workspace The workspace we might be moving on.
+   * @returns True iff we are moving.
+   */
+  isMoving(workspace: WorkspaceSvg) {
+    return this.canCurrentlyEdit(workspace) && this.moves.has(workspace);
+  }
+
+  /**
+   * Start moving the currently-focused item on workspace, if
+   * possible.
+   *
+   * Should only be called if canMove has returned true.
+   *
+   * @param workspace The workspace we might be moving on.
+   * @returns True iff a move has successfully begun.
+   */
+  startMove(workspace: WorkspaceSvg) {
+    const cursor = workspace?.getCursor();
+    const curNode = cursor?.getCurNode();
+    const block = curNode?.getSourceBlock();
+    if (!block || !block.isMovable()) return false;
+
+    console.log('startMove');
+
+    this.moves.set(workspace, {});
+    return true;
+  }
+
+  /**
+   * Finish moving the currently-focused item on workspace.
+   *
+   * Should only be called if isMoving has returned true.
+   *
+   * @param workspace The workspace on which we are moving.
+   * @returns True iff move successfully finished.
+   */
+  finishMove(workspace: WorkspaceSvg) {
+    if (!workspace) return false;
+
+    console.log('finishMove');
+
+    this.moves.delete(workspace);
+    return true;
+  }
+
+  /**
+   * Abort moving the currently-focused item on workspace.
+   *
+   * Should only be called if isMoving has returned true.
+   *
+   * @param workspace The workspace on which we are moving.
+   * @returns True iff move successfully aborted.
+   */
+  abortMove(workspace: WorkspaceSvg) {
+    if (!workspace) return false;
+
+    console.log('abortMove');
+
+    this.moves.delete(workspace);
+    return true;
+  }
+
+  /**
+   * Action to move the item being moved in the given direction,
+   * constrained to valid attachment points (if any).
+   *
+   * @param workspace The workspace to move on.
+   * @returns True iff this action applies and has been performed.
+   */
+  moveConstrained(
+    workspace: WorkspaceSvg,
+    /* ... */
+  ) {
+    console.log('moveConstrained');
+    // Not yet implemented.  Absorb keystroke to avoid moving cursor.
+    return true;
+  }
+
+  /**
+   * Action to move the item being moved in the given direction,
+   * without constraint.
+   *
+   * @param workspace The workspace to move on.
+   * @param xDirection -1 to move left. 1 to move right.
+   * @param yDirection -1 to move up. 1 to move down.
+   * @returns True iff this action applies and has been performed.
+   */
+  moveUnconstrained(
+    workspace: WorkspaceSvg,
+    xDirection: number,
+    yDirection: number,
+  ): boolean {
+    console.log('moveUnconstrained');
+    // Not yet implemented.  Absorb keystroke to avoid moving cursor.
+    return true;
+  }
+}
+
+/**
+ * Information about the currently in-progress move for a given
+ * Workspace.
+ */
+type MoveInfo = {};

--- a/src/navigation_controller.ts
+++ b/src/navigation_controller.ts
@@ -34,6 +34,7 @@ import {ExitAction} from './actions/exit';
 import {EnterAction} from './actions/enter';
 import {DisconnectAction} from './actions/disconnect';
 import {ActionMenu} from './actions/action_menu';
+import {Mover} from './actions/mover';
 
 const KeyCodes = BlocklyUtils.KeyCodes;
 
@@ -95,6 +96,8 @@ export class NavigationController {
     this.navigation,
     this.canCurrentlyNavigate.bind(this),
   );
+
+  mover = new Mover(this.navigation, this.canCurrentlyEdit.bind(this));
 
   /**
    * Original Toolbox.prototype.onShortcut method, saved by
@@ -340,6 +343,7 @@ export class NavigationController {
     this.actionMenu.install();
 
     this.clipboard.install();
+    this.mover.install();
     this.shortcutDialog.install();
 
     // Initialize the shortcut modal with available shortcuts.  Needs
@@ -352,10 +356,7 @@ export class NavigationController {
    * Removes all the keyboard navigation shortcuts.
    */
   dispose() {
-    for (const shortcut of Object.values(this.shortcuts)) {
-      ShortcutRegistry.registry.unregister(shortcut.name);
-    }
-
+    this.mover.install();
     this.deleteAction.uninstall();
     this.editAction.uninstall();
     this.insertAction.uninstall();
@@ -368,6 +369,9 @@ export class NavigationController {
     this.actionMenu.uninstall();
     this.shortcutDialog.uninstall();
 
+    for (const shortcut of Object.values(this.shortcuts)) {
+      ShortcutRegistry.registry.unregister(shortcut.name);
+    }
     this.removeShortcutHandlers();
     this.navigation.dispose();
   }

--- a/src/navigation_controller.ts
+++ b/src/navigation_controller.ts
@@ -356,7 +356,7 @@ export class NavigationController {
    * Removes all the keyboard navigation shortcuts.
    */
   dispose() {
-    this.mover.install();
+    this.mover.uninstall();
     this.deleteAction.uninstall();
     this.editAction.uninstall();
     this.insertAction.uninstall();

--- a/src/navigation_controller.ts
+++ b/src/navigation_controller.ts
@@ -34,7 +34,7 @@ import {ExitAction} from './actions/exit';
 import {EnterAction} from './actions/enter';
 import {DisconnectAction} from './actions/disconnect';
 import {ActionMenu} from './actions/action_menu';
-import {Mover} from './actions/mover';
+import {DragMover as Mover} from './actions/drag_mover';
 
 const KeyCodes = BlocklyUtils.KeyCodes;
 


### PR DESCRIPTION
This is a rebuild/rebase of Christopher's https://github.com/google/blockly-keyboard-experimentation/pull/317.

I rebased it, tested that it worked, and then addressed Aaron's feedback in his review of #317.

I left alt in place because of Christopher's note about Mac users ("For now I will make both ctrl and alt usable (ctrl won't work for macOS users who use [Spaces](https://support.apple.com/en-gb/guide/mac-help/mh14112/mac) with default shortcut keys), and add a note to https://github.com/google/blockly-keyboard-experimentation/issues/106 that we need to figure out what to do instead.") but long-term I think we should actually move it to use shift+arrow for constrained and arrow for unconstrained. That matches what other dragging-related software does, generally.

I then fixed lint errors and formatted.

~I was not (yet) able to resolve the issue with aborting a drag when the insertion marker is shown.~ 