### PR TITLE
feat: allow for toolbox with multiple tab stops 

### DIFF
--- a/src/navigation.ts
+++ b/src/navigation.ts
@@ -503,12 +503,6 @@ export class Navigation {
     this.setState(workspace, Constants.STATE.FLYOUT);
     this.getFlyoutCursor(workspace)?.draw();
     this.resetFlyoutCursorPosition(workspace);
-
-    // Prevent shift-tab to the toolbox while the flyout has focus.
-    const toolboxElement = getToolboxElement(workspace);
-    if (toolboxElement) {
-      toolboxElement.tabIndex = -1;
-    }
   }
 
   /**
@@ -524,12 +518,6 @@ export class Navigation {
       workspace.hideChaff();
     }
     this.getFlyoutCursor(workspace)?.hide();
-
-    // Reinstate tab to toolbox.
-    const toolboxElement = getToolboxElement(workspace);
-    if (toolboxElement) {
-      toolboxElement.tabIndex = 0;
-    }
   }
 
   /**


### PR DESCRIPTION
- Switch to focusin/out for toolbox
    - This might make sense more widely in future if we get more fine-grained focus. What will start to matter is focus entering/leaving an area. The MakeCode toolbox has a search input field alongside the category tree that needs to take the focus.
- Drop the tab index fiddling as it's not practical to get it right in the face of more than one tab stop in the toolbox, especially if that toolbox has a DOM structure not known to the plugin.

Given that we're reinstating the ability to shift-tab flyout->toolbox it makes sense to allow tab to the flyout. Shift-tab to the flyout remains not possible in the auto-hide case but that's not unreasonable.

This version can be made to work with MakeCode. It might not be the ideal integration but it's a start.

I've structured this PR as commit based against the last v11 version then a merge of main as that v11 version is useful to me to test with MakeCode until we get Blockly 12 sorted.

Demo: https://toolbox-focus.blockly-keyboard-experimentation.pages.dev/