### PR TITLE
feat: monkeypatch the block's drag strategy during keyboard drags

### DIFF
--- a/src/actions/mover.ts
+++ b/src/actions/mover.ts
@@ -15,7 +15,7 @@ import {
   registry,
   utils,
 } from 'blockly';
-import type {Block, BlockSvg, IDragger, IDragStrategy} from 'blockly';
+import type {BlockSvg, IDragger, IDragStrategy} from 'blockly';
 import {Navigation} from '../navigation';
 import {KeyboardDragStrategy} from '../keyboard_drag_strategy';
 
@@ -279,7 +279,7 @@ export class Mover {
     );
 
     this.unpatchIsDragging(workspace);
-    this.unpatchDragStrategy(info.block as BlockSvg);
+    this.unpatchDragStrategy(info.block);
     this.moves.delete(workspace);
     return true;
   }
@@ -299,7 +299,7 @@ export class Mover {
     // Monkey patch dragger to trigger call to draggable.revertDrag.
     // eslint-disable-next-line @typescript-eslint/no-explicit-any
     (info.dragger as any).shouldReturnToStart = () => true;
-    const blockSvg = info.block as BlockSvg;
+    const blockSvg = info.block;
 
     // Explicitly call `hidePreview` because it is not called in revertDrag.
     // @ts-expect-error Access to private property dragStrategy.
@@ -310,7 +310,7 @@ export class Mover {
     );
 
     this.unpatchIsDragging(workspace);
-    this.unpatchDragStrategy(info.block as BlockSvg);
+    this.unpatchDragStrategy(info.block);
     this.moves.delete(workspace);
     return true;
   }
@@ -434,7 +434,7 @@ export class MoveInfo {
   readonly startLocation: utils.Coordinate;
 
   constructor(
-    readonly block: Block,
+    readonly block: BlockSvg,
     readonly dragger: IDragger,
   ) {
     this.parentNext = block.previousConnection?.targetConnection ?? null;

--- a/src/actions/mover.ts
+++ b/src/actions/mover.ts
@@ -15,8 +15,9 @@ import {
   registry,
   utils,
 } from 'blockly';
-import type {Block, BlockSvg, IDragger} from 'blockly';
+import type {Block, BlockSvg, IDragger, IDragStrategy} from 'blockly';
 import {Navigation} from '../navigation';
+import {KeyboardDragStrategy} from '../keyboard_drag_strategy';
 
 const KeyCodes = utils.KeyCodes;
 const createSerializedKey = ShortcutRegistry.registry.createSerializedKey.bind(
@@ -47,6 +48,12 @@ export class Mover {
    * of a keyboard drag and reset at the end of a keyboard drag.
    */
   oldIsDragging: (() => boolean) | null = null;
+
+  /**
+   * The block's base drag strategy, which will be overridden during
+   * keyboard drags and reset at the end of the drag.
+   */
+  private oldDragStrategy: IDragStrategy | null = null;
 
   constructor(
     protected navigation: Navigation,
@@ -237,6 +244,7 @@ export class Mover {
     cursor.setCurNode(ASTNode.createBlockNode(block));
 
     this.patchIsDragging(workspace);
+    this.patchDragStrategy(block);
     // Begin dragging block.
     const DraggerClass = registry.getClassFromOptions(
       registry.Type.BLOCK_DRAGGER,
@@ -271,6 +279,7 @@ export class Mover {
     );
 
     this.unpatchIsDragging(workspace);
+    this.unpatchDragStrategy(info.block as BlockSvg);
     this.moves.delete(workspace);
     return true;
   }
@@ -301,6 +310,7 @@ export class Mover {
     );
 
     this.unpatchIsDragging(workspace);
+    this.unpatchDragStrategy(info.block as BlockSvg);
     this.moves.delete(workspace);
     return true;
   }
@@ -386,6 +396,28 @@ Use enter to complete the move, or escape to abort.`);
     if (this.oldIsDragging) {
       // eslint-disable-next-line @typescript-eslint/no-explicit-any
       (workspace as any).isDragging = this.oldIsDragging;
+    }
+  }
+  /**
+   * Monkeypatch: replace the block's drag strategy and cache the old value.
+   *
+   * @param block The block to patch.
+   */
+  private patchDragStrategy(block: BlockSvg) {
+    // @ts-expect-error block.dragStrategy is private.
+    this.oldDragStrategy = block.dragStrategy;
+    block.setDragStrategy(new KeyboardDragStrategy(block));
+  }
+
+  /**
+   * Undo the monkeypatching of the block's drag strategy.
+   *
+   * @param block The block to patch.
+   */
+  private unpatchDragStrategy(block: BlockSvg) {
+    if (this.oldDragStrategy) {
+      block.setDragStrategy(this.oldDragStrategy);
+      this.oldDragStrategy = null;
     }
   }
 }

--- a/src/keyboard_drag_strategy.ts
+++ b/src/keyboard_drag_strategy.ts
@@ -1,0 +1,9 @@
+/**
+ * @license
+ * Copyright 2025 Google LLC
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import {dragging} from 'blockly';
+
+export class KeyboardDragStrategy extends dragging.BlockDragStrategy {}


### PR DESCRIPTION
Fixes #373.

Adds a drag strategy class and the appropriate patching and unpatching at beginning and end of drag.

The new class extends core's `BlockDragStrategy`. Populating it with useful functions is tracked in https://github.com/google/blockly-keyboard-experimentation/issues/364.

Part of #363

Tested by:

Doing keyboard drags that end in an Esc
Doing keyboard drags that end in an Enter
Doing mouse drags after the fact to confirm that mouse dragging still works