### PR TITLE
fix: position of block at the start of a drag

### DIFF
--- a/src/actions/clipboard.ts
+++ b/src/actions/clipboard.ts
@@ -5,7 +5,6 @@
  */
 
 import {
-  ASTNode,
   ContextMenuRegistry,
   Gesture,
   ShortcutRegistry,

--- a/src/keyboard_drag_strategy.ts
+++ b/src/keyboard_drag_strategy.ts
@@ -6,4 +6,12 @@
 
 import {dragging} from 'blockly';
 
-export class KeyboardDragStrategy extends dragging.BlockDragStrategy {}
+export class KeyboardDragStrategy extends dragging.BlockDragStrategy {
+  override startDrag(e?: PointerEvent) {
+    super.startDrag(e);
+    // Set position of the dragging block, so that it doesn't pop
+    // to the top left of the workspace.
+    // @ts-expect-error block and startLoc are private.
+    this.block.moveDuringDrag(this.startLoc);
+  }
+}


### PR DESCRIPTION
Fixes an issue where the block is moved to 0,0 on the workspace at the start of a drag.

Before:
![image](https://github.com/user-attachments/assets/71e58463-58a8-4268-a8be-513cb31ca3ea)


After:
![image](https://github.com/user-attachments/assets/b8b03542-33bf-4e86-b952-939ddb286619)
(The focus is passive because of the screenshot system).

Also fixes one last lint warning.