### PR TITLE
feat: add constrained movement

### DIFF
--- a/src/keyboard_drag_strategy.ts
+++ b/src/keyboard_drag_strategy.ts
@@ -4,11 +4,26 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-import {dragging, utils} from 'blockly';
+import {ASTNode, BlockSvg, RenderedConnection, dragging, utils} from 'blockly';
 import {Direction, getDirectionFromXY} from './drag_direction';
+import {LineCursor} from './line_cursor';
 
+// Copied in from core because it is not exported.
+interface ConnectionCandidate {
+  /** A connection on the dragging stack that is compatible with neighbour. */
+  local: RenderedConnection;
+
+  /** A nearby connection that is compatible with local. */
+  neighbour: RenderedConnection;
+
+  /** The distance between the local connection and the neighbour connection. */
+  distance: number;
+}
+
+// @ts-expect-error overrides a private function.
 export class KeyboardDragStrategy extends dragging.BlockDragStrategy {
   private currentDragDirection: Direction | null = null;
+  private searchNode: ASTNode | null = null;
 
   override startDrag(e?: PointerEvent) {
     super.startDrag(e);
@@ -16,12 +31,110 @@ export class KeyboardDragStrategy extends dragging.BlockDragStrategy {
     // to the top left of the workspace.
     // @ts-expect-error block and startLoc are private.
     this.block.moveDuringDrag(this.startLoc);
+    // @ts-expect-error startParentConn is private.
+    this.searchNode = ASTNode.createConnectionNode(this.startParentConn);
   }
 
   override drag(newLoc: utils.Coordinate, e?: PointerEvent): void {
     if (!e) return;
     this.currentDragDirection = getDirectionFromXY({x: e.tiltX, y: e.tiltY});
     super.drag(newLoc);
+
+    // Handle the case when an unconstrained drag found a connection candidate.
+    // The next constrained move will resume the search from the current candidate
+    // location.
+    // @ts-expect-error connectionCandidate is private.
+    if (this.connectionCandidate) {
+      this.searchNode = ASTNode.createConnectionNode(
+        // @ts-expect-error connectionCandidate is private.
+        (this.connectionCandidate as ConnectionCandidate).neighbour,
+      );
+    }
+  }
+
+  /**
+   * Returns the next compatible connection in keyboard navigation order,
+   * based on the input direction.
+   * Always resumes the search at the last
+   *
+   * @param draggingBlock The block where the drag started.
+   * @returns A valid connection candidate, or null if none was found.
+   */
+  private getConstrainedConnectionCandidate(
+    draggingBlock: BlockSvg,
+  ): ConnectionCandidate | null {
+    const cursor = draggingBlock.workspace.getCursor() as LineCursor;
+
+    const initialNode = this.searchNode;
+    if (!initialNode || !cursor) return null;
+
+    // @ts-expect-error getLocalConnections is private.
+    const localConns = this.getLocalConnections(draggingBlock);
+    const connectionChecker = draggingBlock.workspace.connectionChecker;
+
+    let candidateConnection: ConnectionCandidate | null = null;
+
+    let potential: ASTNode | null = initialNode;
+    while (potential && !candidateConnection) {
+      if (
+        this.currentDragDirection === Direction.Up ||
+        this.currentDragDirection === Direction.Left
+      ) {
+        potential = cursor.getPreviousNode(potential, (node) => {
+          // @ts-expect-error isConnectionType is private.
+          return node && ASTNode.isConnectionType(node.getType());
+        });
+      } else if (
+        this.currentDragDirection === Direction.Down ||
+        this.currentDragDirection === Direction.Right
+      ) {
+        potential = cursor.getNextNode(potential, (node) => {
+          // @ts-expect-error isConnectionType is private.
+          return node && ASTNode.isConnectionType(node.getType());
+        });
+      }
+
+      localConns.forEach((conn: RenderedConnection) => {
+        const potentialLocation =
+          potential?.getLocation() as RenderedConnection;
+        if (connectionChecker.canConnect(conn, potentialLocation, true, 5000)) {
+          candidateConnection = {
+            local: conn,
+            neighbour: potentialLocation,
+            distance: 0,
+          };
+        }
+      });
+    }
+    if (candidateConnection) {
+      this.searchNode = ASTNode.createConnectionNode(
+        (candidateConnection as ConnectionCandidate).neighbour,
+      );
+    }
+    return candidateConnection;
+  }
+
+  override currCandidateIsBetter(
+    currCandidate: ConnectionCandidate,
+    delta: utils.Coordinate,
+    newCandidate: ConnectionCandidate,
+  ): boolean {
+    if (this.isConstrainedMovement()) {
+      return false; // New connection is always better during a constrained drag.
+    }
+    // @ts-expect-error currCandidateIsBetter is private.
+    return super.currCandidateIsBetter(currCandidate, delta, newCandidate);
+  }
+
+  override getConnectionCandidate(
+    draggingBlock: BlockSvg,
+    delta: utils.Coordinate,
+  ): ConnectionCandidate | null {
+    if (this.isConstrainedMovement()) {
+      return this.getConstrainedConnectionCandidate(draggingBlock);
+    }
+    // @ts-expect-error getConnctionCandidate is private.
+    return super.getConnectionCandidate(draggingBlock, delta);
   }
 
   /**

--- a/src/keyboard_drag_strategy.ts
+++ b/src/keyboard_drag_strategy.ts
@@ -22,7 +22,10 @@ interface ConnectionCandidate {
 
 // @ts-expect-error overrides a private function.
 export class KeyboardDragStrategy extends dragging.BlockDragStrategy {
+  /** Which direction the current constrained drag is in, if any. */
   private currentDragDirection: Direction | null = null;
+
+  /** Where a constrained movement should start when traversing the tree. */
   private searchNode: ASTNode | null = null;
 
   override startDrag(e?: PointerEvent) {
@@ -55,7 +58,7 @@ export class KeyboardDragStrategy extends dragging.BlockDragStrategy {
   /**
    * Returns the next compatible connection in keyboard navigation order,
    * based on the input direction.
-   * Always resumes the search at the last
+   * Always resumes the search at the last valid connection that was tried.
    *
    * @param draggingBlock The block where the drag started.
    * @returns A valid connection candidate, or null if none was found.
@@ -63,6 +66,7 @@ export class KeyboardDragStrategy extends dragging.BlockDragStrategy {
   private getConstrainedConnectionCandidate(
     draggingBlock: BlockSvg,
   ): ConnectionCandidate | null {
+    // TODO(#385): Make sure this works for any cursor, not just LineCursor.
     const cursor = draggingBlock.workspace.getCursor() as LineCursor;
 
     const initialNode = this.searchNode;
@@ -97,7 +101,9 @@ export class KeyboardDragStrategy extends dragging.BlockDragStrategy {
       localConns.forEach((conn: RenderedConnection) => {
         const potentialLocation =
           potential?.getLocation() as RenderedConnection;
-        if (connectionChecker.canConnect(conn, potentialLocation, true, 5000)) {
+        if (
+          connectionChecker.canConnect(conn, potentialLocation, true, Infinity)
+        ) {
           candidateConnection = {
             local: conn,
             neighbour: potentialLocation,

--- a/src/line_cursor.ts
+++ b/src/line_cursor.ts
@@ -314,7 +314,7 @@ export class LineCursor extends Marker {
    *     should be traversed.
    * @returns The next node in the traversal.
    */
-  private getNextNode(
+  getNextNode(
     node: ASTNode | null,
     isValid: (p1: ASTNode | null) => boolean,
   ): ASTNode | null {
@@ -347,7 +347,7 @@ export class LineCursor extends Marker {
    * @returns The previous node in the traversal or null if no previous node
    *     exists.
    */
-  private getPreviousNode(
+  getPreviousNode(
     node: ASTNode | null,
     isValid: (p1: ASTNode | null) => boolean,
   ): ASTNode | null {


### PR DESCRIPTION
Fixes https://github.com/google/blockly-keyboard-experimentation/issues/364

This PR adds constrained movement by selectively extending and overriding parts of the drag strategy. In particular:
- Adds a `searchNode` property, which is where a constrained search should start traversing the tree.
- Overrides `currCandidateIsBetter` to always return false for a constrained drag. That is, the new candidate is always preferred.
- Overrides `getConnectionCandidate` to call `getConstrainedConnectionCandidate` if the movement was constrained.

`getConstrainedConnectionCandidate` implements the following algorithm:
- Start a traversal at the saved `searchNode`.
- Choose traversal direction (next or previous) based on input direction.
- In a loop, get the next (or previous) connection node in the tree.
- If the connection is compatible with any of the connections on the dragging block/stack:
  - Create an appropriate candidate connection.
  - Update the search node.
  - Break out of the loop.
- Otherwise, continue until no new nodes are found and return null.

### Additional information

This does _not_ position the dragging block near the connection (tracked in https://github.com/google/blockly-keyboard-experimentation/issues/370). I'm still figuring out how to do that without causing very weird jumps--I have to push information backwards through the dragging pipeline.

This does _not_ loop from the last block in the workspace to the first, or vice versa (tracked in #369).

When you switch from unconstrained to constrained dragging, the traversal will always resume at the last valid connection that was tried. This may lead to unexpected jumps.

If you use the arrow keys to constrained move off the edge of the workspace, it will not scroll to keep it in view (tracked in #371). The drag will continue and end appropriately on an escape or enter.

I'm accessing a lot of private properties. Every `@ts-expect-error` is a sign of an API problem we need to sort out.

