### PR TITLE
feat: insert in move mode

### DIFF
--- a/src/actions/enter.ts
+++ b/src/actions/enter.ts
@@ -22,6 +22,7 @@ import type {
 
 import * as Constants from '../constants';
 import type {Navigation} from '../navigation';
+import {Mover} from './mover';
 
 const KeyCodes = BlocklyUtils.KeyCodes;
 
@@ -29,7 +30,10 @@ const KeyCodes = BlocklyUtils.KeyCodes;
  * Class for registering a shortcut for the enter action.
  */
 export class EnterAction {
-  constructor(private navigation: Navigation) {}
+  constructor(
+    private mover: Mover,
+    private navigation: Navigation,
+  ) {}
 
   /**
    * Adds the enter action shortcut to the registry.
@@ -149,6 +153,8 @@ export class EnterAction {
     this.navigation.focusWorkspace(workspace);
     // eslint-disable-next-line @typescript-eslint/no-non-null-assertion
     workspace.getCursor()?.setCurNode(ASTNode.createBlockNode(newBlock)!);
+
+    this.mover.startMove(workspace);
   }
 
   /**

--- a/src/navigation_controller.ts
+++ b/src/navigation_controller.ts
@@ -70,7 +70,7 @@ export class NavigationController {
 
   exitAction: ExitAction = new ExitAction(this.navigation);
 
-  enterAction: EnterAction = new EnterAction(this.navigation);
+  enterAction: EnterAction = new EnterAction(this.mover, this.navigation);
 
   actionMenu: ActionMenu = new ActionMenu(this.navigation);
 


### PR DESCRIPTION
This feels a bit rough while move mode disconnects from the connection you just inserted at.

@rachel-fenichel not ready to be merged but sharing in case it's useful for current work. Feel free to close.

An interesting issue is what to do with undo. At the moment the insert and the undo are separate but that feels wrong as the insert feels transient now until confirmed in position. Relatedly, undo during a move causes tragic errors (in common with most other non-move actions).

Demo: https://insert-move-mode.blockly-keyboard-experimentation.pages.dev/