### PR TITLE
refactor: split move actions from mover code

### DIFF
--- a/src/actions/move.ts
+++ b/src/actions/move.ts
@@ -1,0 +1,170 @@
+/**
+ * @license
+ * Copyright 2025 Google LLC
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import {
+  ContextMenuRegistry,
+  ShortcutRegistry,
+  utils,
+  WorkspaceSvg,
+} from 'blockly';
+import {Direction} from '../drag_direction';
+import {Mover} from './mover';
+
+const KeyCodes = utils.KeyCodes;
+const createSerializedKey = ShortcutRegistry.registry.createSerializedKey.bind(
+  ShortcutRegistry.registry,
+);
+
+/**
+ * Actions for moving blocks with keyboard shortcuts.
+ */
+export class MoveActions {
+  constructor(private mover: Mover) {}
+
+  private shortcuts: ShortcutRegistry.KeyboardShortcut[] = [
+    // Begin and end move.
+    {
+      name: 'Start move',
+      preconditionFn: (workspace) => this.mover.canMove(workspace),
+      callback: (workspace) => this.mover.startMove(workspace),
+      keyCodes: [KeyCodes.M],
+    },
+    {
+      name: 'Finish move',
+      preconditionFn: (workspace) => this.mover.isMoving(workspace),
+      callback: (workspace) => this.mover.finishMove(workspace),
+      keyCodes: [KeyCodes.ENTER],
+      allowCollision: true,
+    },
+    {
+      name: 'Abort move',
+      preconditionFn: (workspace) => this.mover.isMoving(workspace),
+      callback: (workspace) => this.mover.abortMove(workspace),
+      keyCodes: [KeyCodes.ESC],
+      allowCollision: true,
+    },
+
+    // Constrained moves.
+    {
+      name: 'Move left, constrained',
+      preconditionFn: (workspace) => this.mover.isMoving(workspace),
+      callback: (workspace) =>
+        this.mover.moveConstrained(workspace, Direction.Left),
+      keyCodes: [KeyCodes.LEFT],
+      allowCollision: true,
+    },
+    {
+      name: 'Move right constrained',
+      preconditionFn: (workspace) => this.mover.isMoving(workspace),
+      callback: (workspace) =>
+        this.mover.moveConstrained(workspace, Direction.Right),
+      keyCodes: [KeyCodes.RIGHT],
+      allowCollision: true,
+    },
+    {
+      name: 'Move up, constrained',
+      preconditionFn: (workspace) => this.mover.isMoving(workspace),
+      callback: (workspace) =>
+        this.mover.moveConstrained(workspace, Direction.Up),
+      keyCodes: [KeyCodes.UP],
+      allowCollision: true,
+    },
+    {
+      name: 'Move down constrained',
+      preconditionFn: (workspace) => this.mover.isMoving(workspace),
+      callback: (workspace) =>
+        this.mover.moveConstrained(workspace, Direction.Down),
+      keyCodes: [KeyCodes.DOWN],
+      allowCollision: true,
+    },
+
+    // Unconstrained moves.
+    {
+      name: 'Move left, unconstrained',
+      preconditionFn: (workspace) => this.mover.isMoving(workspace),
+      callback: (workspace) =>
+        this.mover.moveUnconstrained(workspace, Direction.Left),
+      keyCodes: [
+        createSerializedKey(KeyCodes.LEFT, [KeyCodes.ALT]),
+        createSerializedKey(KeyCodes.LEFT, [KeyCodes.CTRL]),
+      ],
+    },
+    {
+      name: 'Move right, unconstrained',
+      preconditionFn: (workspace) => this.mover.isMoving(workspace),
+      callback: (workspace) =>
+        this.mover.moveUnconstrained(workspace, Direction.Right),
+      keyCodes: [
+        createSerializedKey(KeyCodes.RIGHT, [KeyCodes.ALT]),
+        createSerializedKey(KeyCodes.RIGHT, [KeyCodes.CTRL]),
+      ],
+    },
+    {
+      name: 'Move up unconstrained',
+      preconditionFn: (workspace) => this.mover.isMoving(workspace),
+      callback: (workspace) =>
+        this.mover.moveUnconstrained(workspace, Direction.Up),
+      keyCodes: [
+        createSerializedKey(KeyCodes.UP, [KeyCodes.ALT]),
+        createSerializedKey(KeyCodes.UP, [KeyCodes.CTRL]),
+      ],
+    },
+    {
+      name: 'Move down, unconstrained',
+      preconditionFn: (workspace) => this.mover.isMoving(workspace),
+      callback: (workspace) =>
+        this.mover.moveUnconstrained(workspace, Direction.Down),
+      keyCodes: [
+        createSerializedKey(KeyCodes.DOWN, [KeyCodes.ALT]),
+        createSerializedKey(KeyCodes.DOWN, [KeyCodes.CTRL]),
+      ],
+    },
+  ];
+
+  menuItems: ContextMenuRegistry.RegistryItem[] = [
+    {
+      displayText: 'Move Block (M)',
+      preconditionFn: (scope) => {
+        const workspace = scope.block?.workspace as WorkspaceSvg | null;
+        if (!workspace) return 'hidden';
+        return this.mover.canMove(workspace) ? 'enabled' : 'disabled';
+      },
+      callback: (scope) => {
+        const workspace = scope.block?.workspace as WorkspaceSvg | null;
+        if (!workspace) return false;
+        this.mover.startMove(workspace);
+      },
+      scopeType: ContextMenuRegistry.ScopeType.BLOCK,
+      id: 'move',
+      weight: 8.5,
+    },
+  ];
+
+  /**
+   * Install the actions as both keyboard shortcuts and (where
+   * applicable) context menu items.
+   */
+  install() {
+    for (const shortcut of this.shortcuts) {
+      ShortcutRegistry.registry.register(shortcut);
+    }
+    for (const menuItem of this.menuItems) {
+      ContextMenuRegistry.registry.register(menuItem);
+    }
+  }
+
+  /**
+   * Uninstall these actions.
+   */
+  uninstall() {
+    for (const shortcut of this.shortcuts) {
+      ShortcutRegistry.registry.unregister(shortcut.name);
+    }
+    for (const menuItem of this.menuItems) {
+      ContextMenuRegistry.registry.unregister(menuItem.id);
+    }
+  }
+}

--- a/src/actions/mover.ts
+++ b/src/actions/mover.ts
@@ -4,26 +4,19 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-import * as Constants from '../constants';
+import type {BlockSvg, IDragger, IDragStrategy} from 'blockly';
 import {
   ASTNode,
-  Connection,
-  ContextMenuRegistry,
-  ShortcutRegistry,
-  WorkspaceSvg,
   common,
+  Connection,
   registry,
   utils,
+  WorkspaceSvg,
 } from 'blockly';
-import type {BlockSvg, IDragger, IDragStrategy} from 'blockly';
-import {Navigation} from '../navigation';
-import {KeyboardDragStrategy} from '../keyboard_drag_strategy';
+import * as Constants from '../constants';
 import {Direction, getXYFromDirection} from '../drag_direction';
-
-const KeyCodes = utils.KeyCodes;
-const createSerializedKey = ShortcutRegistry.registry.createSerializedKey.bind(
-  ShortcutRegistry.registry,
-);
+import {KeyboardDragStrategy} from '../keyboard_drag_strategy';
+import {Navigation} from '../navigation';
 
 /**
  * The distance to move an item, in workspace coordinates, when
@@ -32,7 +25,7 @@ const createSerializedKey = ShortcutRegistry.registry.createSerializedKey.bind(
 const UNCONSTRAINED_MOVE_DISTANCE = 20;
 
 /**
- * Actions for moving blocks with keyboard shortcuts.
+ * Low-level code for moving blocks with keyboard shortcuts.
  */
 export class Mover {
   /**
@@ -57,145 +50,6 @@ export class Mover {
   private oldDragStrategy: IDragStrategy | null = null;
 
   constructor(protected navigation: Navigation) {}
-
-  private shortcuts: ShortcutRegistry.KeyboardShortcut[] = [
-    // Begin and end move.
-    {
-      name: 'Start move',
-      preconditionFn: (workspace) => this.canMove(workspace),
-      callback: (workspace) => this.startMove(workspace),
-      keyCodes: [KeyCodes.M],
-    },
-    {
-      name: 'Finish move',
-      preconditionFn: (workspace) => this.isMoving(workspace),
-      callback: (workspace) => this.finishMove(workspace),
-      keyCodes: [KeyCodes.ENTER],
-      allowCollision: true,
-    },
-    {
-      name: 'Abort move',
-      preconditionFn: (workspace) => this.isMoving(workspace),
-      callback: (workspace) => this.abortMove(workspace),
-      keyCodes: [KeyCodes.ESC],
-      allowCollision: true,
-    },
-
-    // Constrained moves.
-    {
-      name: 'Move left, constrained',
-      preconditionFn: (workspace) => this.isMoving(workspace),
-      callback: (workspace) => this.moveConstrained(workspace, Direction.Left),
-      keyCodes: [KeyCodes.LEFT],
-      allowCollision: true,
-    },
-    {
-      name: 'Move right unconstrained',
-      preconditionFn: (workspace) => this.isMoving(workspace),
-      callback: (workspace) => this.moveConstrained(workspace, Direction.Right),
-      keyCodes: [KeyCodes.RIGHT],
-      allowCollision: true,
-    },
-    {
-      name: 'Move up, constrained',
-      preconditionFn: (workspace) => this.isMoving(workspace),
-      callback: (workspace) => this.moveConstrained(workspace, Direction.Up),
-      keyCodes: [KeyCodes.UP],
-      allowCollision: true,
-    },
-    {
-      name: 'Move down constrained',
-      preconditionFn: (workspace) => this.isMoving(workspace),
-      callback: (workspace) => this.moveConstrained(workspace, Direction.Down),
-      keyCodes: [KeyCodes.DOWN],
-      allowCollision: true,
-    },
-
-    // Unconstrained moves.
-    {
-      name: 'Move left, unconstrained',
-      preconditionFn: (workspace) => this.isMoving(workspace),
-      callback: (workspace) =>
-        this.moveUnconstrained(workspace, Direction.Left),
-      keyCodes: [
-        createSerializedKey(KeyCodes.LEFT, [KeyCodes.ALT]),
-        createSerializedKey(KeyCodes.LEFT, [KeyCodes.CTRL]),
-      ],
-    },
-    {
-      name: 'Move right, unconstrained',
-      preconditionFn: (workspace) => this.isMoving(workspace),
-      callback: (workspace) =>
-        this.moveUnconstrained(workspace, Direction.Right),
-      keyCodes: [
-        createSerializedKey(KeyCodes.RIGHT, [KeyCodes.ALT]),
-        createSerializedKey(KeyCodes.RIGHT, [KeyCodes.CTRL]),
-      ],
-    },
-    {
-      name: 'Move up unconstrained',
-      preconditionFn: (workspace) => this.isMoving(workspace),
-      callback: (workspace) => this.moveUnconstrained(workspace, Direction.Up),
-      keyCodes: [
-        createSerializedKey(KeyCodes.UP, [KeyCodes.ALT]),
-        createSerializedKey(KeyCodes.UP, [KeyCodes.CTRL]),
-      ],
-    },
-    {
-      name: 'Move down, unconstrained',
-      preconditionFn: (workspace) => this.isMoving(workspace),
-      callback: (workspace) =>
-        this.moveUnconstrained(workspace, Direction.Down),
-      keyCodes: [
-        createSerializedKey(KeyCodes.DOWN, [KeyCodes.ALT]),
-        createSerializedKey(KeyCodes.DOWN, [KeyCodes.CTRL]),
-      ],
-    },
-  ];
-
-  menuItems: ContextMenuRegistry.RegistryItem[] = [
-    {
-      displayText: 'Move Block (M)',
-      preconditionFn: (scope) => {
-        const workspace = scope.block?.workspace as WorkspaceSvg | null;
-        if (!workspace) return 'hidden';
-        return this.canMove(workspace) ? 'enabled' : 'disabled';
-      },
-      callback: (scope) => {
-        const workspace = scope.block?.workspace as WorkspaceSvg | null;
-        if (!workspace) return false;
-        this.startMove(workspace);
-      },
-      scopeType: ContextMenuRegistry.ScopeType.BLOCK,
-      id: 'move',
-      weight: 8.5,
-    },
-  ];
-
-  /**
-   * Install the actions as both keyboard shortcuts and (where
-   * applicable) context menu items.
-   */
-  install() {
-    for (const shortcut of this.shortcuts) {
-      ShortcutRegistry.registry.register(shortcut);
-    }
-    for (const menuItem of this.menuItems) {
-      ContextMenuRegistry.registry.register(menuItem);
-    }
-  }
-
-  /**
-   * Uninstall these actions.
-   */
-  uninstall() {
-    for (const shortcut of this.shortcuts) {
-      ShortcutRegistry.registry.unregister(shortcut.name);
-    }
-    for (const menuItem of this.menuItems) {
-      ContextMenuRegistry.registry.unregister(menuItem.id);
-    }
-  }
 
   /**
    * Returns true iff we are able to begin moving the block which

--- a/src/navigation_controller.ts
+++ b/src/navigation_controller.ts
@@ -34,6 +34,7 @@ import {ExitAction} from './actions/exit';
 import {EnterAction} from './actions/enter';
 import {DisconnectAction} from './actions/disconnect';
 import {ActionMenu} from './actions/action_menu';
+import {MoveActions} from './actions/move';
 import {Mover} from './actions/mover';
 
 const KeyCodes = BlocklyUtils.KeyCodes;
@@ -43,6 +44,8 @@ const KeyCodes = BlocklyUtils.KeyCodes;
  */
 export class NavigationController {
   private navigation: Navigation = new Navigation();
+
+  private mover = new Mover(this.navigation);
 
   shortcutDialog: ShortcutDialog = new ShortcutDialog();
 
@@ -71,7 +74,7 @@ export class NavigationController {
 
   actionMenu: ActionMenu = new ActionMenu(this.navigation);
 
-  mover = new Mover(this.navigation);
+  moveActions = new MoveActions(this.mover);
 
   /**
    * Original Toolbox.prototype.onShortcut method, saved by
@@ -289,7 +292,7 @@ export class NavigationController {
     this.actionMenu.install();
 
     this.clipboard.install();
-    this.mover.install();
+    this.moveActions.install();
     this.shortcutDialog.install();
 
     // Initialize the shortcut modal with available shortcuts.  Needs
@@ -302,7 +305,7 @@ export class NavigationController {
    * Removes all the keyboard navigation shortcuts.
    */
   dispose() {
-    this.mover.uninstall();
+    this.moveActions.uninstall();
     this.deleteAction.uninstall();
     this.editAction.uninstall();
     this.insertAction.uninstall();


### PR DESCRIPTION
This opens up the possibility of triggering movement from other actions in future, e.g. insert.

Split from #390 at @rachel-fenichel's request; I'll rebase that soon.

Demo: https://split-move-actions.blockly-keyboard-experimentation.pages.dev/ (no behaviour change)
