### PR TITLE
feat: show drag preview immediately on start

### DIFF
--- a/src/actions/mover.ts
+++ b/src/actions/mover.ts
@@ -115,6 +115,7 @@ export class Mover {
     this.moves.set(workspace, info);
     // Begin drag.
     dragger.onDragStart(info.fakePointerEvent('pointerdown'));
+    info.dragger.onDrag(info.fakePointerEvent('pointermove'), info.totalDelta);
     return true;
   }
 


### PR DESCRIPTION
Prior to this change, the insertion marker was not shown at the initial position. This made it hard to see that a drag had actually started.

After this change, the insertion marker shows immediately.