### PR TITLE
fix: drag parent of shadow block

### DIFF
--- a/src/actions/mover.ts
+++ b/src/actions/mover.ts
@@ -218,15 +218,27 @@ export class Mover {
   /**
    * Get the source block for the cursor location, or undefined if no
    * source block can be found.
+   * If the cursor is on a shadow block, walks up the tree until it finds
+   * a non-shadow block to drag.
    *
    * @param workspace The workspace to inspect for a cursor.
    * @returns The source block, or undefined if no appropriate block
    *     could be found.
    */
   protected getCurrentBlock(workspace: WorkspaceSvg): BlockSvg | undefined {
-    const cursor = workspace?.getCursor();
-    const curNode = cursor?.getCurNode();
-    return (curNode?.getSourceBlock() as BlockSvg) ?? undefined;
+    const curNode = workspace?.getCursor()?.getCurNode();
+    let block = curNode?.getSourceBlock();
+    if (!block) return undefined;
+    while (block && block.isShadow()) {
+      block = block.getParent();
+      if (!block) {
+        throw new Error(
+          'Tried to drag a shadow block with no parent. ' +
+            'Shadow blocks should always have parents.',
+        );
+      }
+    }
+    return block as BlockSvg;
   }
 
   /**


### PR DESCRIPTION
Fixes #395 

When starting a drag, walk up the tree until the first non-shadow block and drag it. If there's no non-shadow block, throw because that's not supposed to happen.

This matches [related code](https://github.com/google/blockly/blob/develop/core/dragging/block_drag_strategy.ts#L94) in core.

The core code can't handle this case because the drag strategy of the moving block needs to be patched. We're doing that in `mover.ts`, and getting the correct block in `mover.ts` means that we don't have to track patching/unpatching the drag strategy on multiple blocks.