### PR TITLE
fix: patch WorkspaceSvg.getGesture to handle keyboard drags

### DIFF
--- a/src/actions/mover.ts
+++ b/src/actions/mover.ts
@@ -141,7 +141,7 @@ export class Mover {
       new utils.Coordinate(0, 0),
     );
 
-    this.upatchWorkspace(workspace);
+    this.unpatchWorkspace(workspace);
     this.unpatchDragStrategy(info.block);
     this.moves.delete(workspace);
     return true;
@@ -172,7 +172,7 @@ export class Mover {
       new utils.Coordinate(0, 0),
     );
 
-    this.upatchWorkspace(workspace);
+    this.unpatchWorkspace(workspace);
     this.unpatchDragStrategy(info.block);
     this.moves.delete(workspace);
     return true;
@@ -263,7 +263,7 @@ export class Mover {
    *
    * @param workspace The workspace to unpatch.
    */
-  private upatchWorkspace(workspace: WorkspaceSvg) {
+  private unpatchWorkspace(workspace: WorkspaceSvg) {
     if (this.oldIsDragging) {
       // eslint-disable-next-line @typescript-eslint/no-explicit-any
       (workspace as any).isDragging = this.oldIsDragging;

--- a/src/actions/mover.ts
+++ b/src/actions/mover.ts
@@ -4,7 +4,7 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-import type {BlockSvg, IDragger, IDragStrategy} from 'blockly';
+import type {BlockSvg, IDragger, IDragStrategy, Gesture} from 'blockly';
 import {
   ASTNode,
   common,
@@ -42,6 +42,12 @@ export class Mover {
    * of a keyboard drag and reset at the end of a keyboard drag.
    */
   oldIsDragging: (() => boolean) | null = null;
+
+  /**
+   * The stashed getGesture function, which is replaced at the beginning
+   * of a keyboard drag and reset at the end of a keyboard drag.
+   */
+  oldGetGesture: ((e: PointerEvent) => Gesture | null) | null = null;
 
   /**
    * The block's base drag strategy, which will be overridden during
@@ -100,7 +106,7 @@ export class Mover {
     common.setSelected(block);
     cursor.setCurNode(ASTNode.createBlockNode(block));
 
-    this.patchIsDragging(workspace);
+    this.patchWorkspace(workspace);
     this.patchDragStrategy(block);
     // Begin dragging block.
     const DraggerClass = registry.getClassFromOptions(
@@ -135,7 +141,7 @@ export class Mover {
       new utils.Coordinate(0, 0),
     );
 
-    this.unpatchIsDragging(workspace);
+    this.upatchWorkspace(workspace);
     this.unpatchDragStrategy(info.block);
     this.moves.delete(workspace);
     return true;
@@ -166,7 +172,7 @@ export class Mover {
       new utils.Coordinate(0, 0),
     );
 
-    this.unpatchIsDragging(workspace);
+    this.upatchWorkspace(workspace);
     this.unpatchDragStrategy(info.block);
     this.moves.delete(workspace);
     return true;
@@ -230,26 +236,41 @@ export class Mover {
   }
 
   /**
-   * Monkeypatch over workspace.isDragging to return whether a keyboard
-   * drag is in progress.
+   * Monkeypatch over workspace functions to consider keyboard drags as
+   * well as mouse/pointer drags.
    *
    * @param workspace The workspace to patch.
    */
-  private patchIsDragging(workspace: WorkspaceSvg) {
+  private patchWorkspace(workspace: WorkspaceSvg) {
+    // Keyboard drags are real drags.
     this.oldIsDragging = workspace.isDragging;
     // eslint-disable-next-line @typescript-eslint/no-explicit-any
     (workspace as any).isDragging = () => this.isMoving(workspace);
+
+    // Ignore mouse/pointer events during keyboard drags.
+    this.oldGetGesture = workspace.getGesture;
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    (workspace as any).getGesture = (e: PointerEvent) => {
+      // Normally these would be called from Gesture.doStart.
+      e.preventDefault();
+      e.stopPropagation();
+      return null;
+    };
   }
 
   /**
-   * Remove the monkeypatch on workspace.isDragging.
+   * Remove monkeypatches on the workspace.
    *
    * @param workspace The workspace to unpatch.
    */
-  private unpatchIsDragging(workspace: WorkspaceSvg) {
+  private upatchWorkspace(workspace: WorkspaceSvg) {
     if (this.oldIsDragging) {
       // eslint-disable-next-line @typescript-eslint/no-explicit-any
       (workspace as any).isDragging = this.oldIsDragging;
+    }
+    if (this.oldGetGesture) {
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+      (workspace as any).getGesture = this.oldGetGesture;
     }
   }
   /**


### PR DESCRIPTION
Fixes #393 

Adds an additional monkeypatch to the workspace. The current `Gesture` is always null during a keyboard drag, and trying to get a gesture also stops propagation and prevents default on the instigating event.

Without this patch, `WorkspaceSvg` automatically creates a new `Gesture` if none was found:

```
  getGesture(e: PointerEvent): Gesture | null {
    const isStart = e.type === 'pointerdown';

    const gesture = this.currentGesture_;
    if (gesture) {
      if (isStart && gesture.hasStarted()) {
        console.warn('Tried to start the same gesture twice.');
        // That's funny.  We must have missed a mouse up.
        // Cancel it, rather than try to retrieve all of the state we need.
        gesture.cancel();
        return null;
      }
      return gesture;
    }

    // No gesture existed on this workspace, but this looks like the start of a
    // new gesture.
    if (isStart) {
      this.currentGesture_ = new Gesture(e, this);
      return this.currentGesture_;
    }
    // No gesture existed and this event couldn't be the start of a new gesture.
    return null;
  }
```

The workspace then calls `handleWsStart` when the event propagates to the workspace, and `handleWsStart` calls `stopPropagation` and `preventDefault` on the event. 

Since `handlWsStart is not called in the new approach, directly cancel propagation in the getter.

### Additional information
As with anything marked as a monkeypatch, this will need formalization into core.