### PR TITLE
feat: start a move when inserting a block from the flyout

### DIFF
--- a/src/actions/enter.ts
+++ b/src/actions/enter.ts
@@ -22,6 +22,7 @@ import type {
 
 import * as Constants from '../constants';
 import type {Navigation} from '../navigation';
+import {Mover} from './mover';
 
 const KeyCodes = BlocklyUtils.KeyCodes;
 
@@ -29,7 +30,10 @@ const KeyCodes = BlocklyUtils.KeyCodes;
  * Class for registering a shortcut for the enter action.
  */
 export class EnterAction {
-  constructor(private navigation: Navigation) {}
+  constructor(
+    private mover: Mover,
+    private navigation: Navigation,
+  ) {}
 
   /**
    * Adds the enter action shortcut to the registry.
@@ -149,6 +153,7 @@ export class EnterAction {
     this.navigation.focusWorkspace(workspace);
     // eslint-disable-next-line @typescript-eslint/no-non-null-assertion
     workspace.getCursor()?.setCurNode(ASTNode.createBlockNode(newBlock)!);
+    this.mover.startMove(workspace);
   }
 
   /**

--- a/src/actions/mover.ts
+++ b/src/actions/mover.ts
@@ -121,7 +121,6 @@ export class Mover {
     this.moves.set(workspace, info);
     // Begin drag.
     dragger.onDragStart(info.fakePointerEvent('pointerdown'));
-    //info.dragger.onDrag(info.fakePointerEvent('pointermove'), info.totalDelta);
     return true;
   }
 

--- a/src/actions/mover.ts
+++ b/src/actions/mover.ts
@@ -121,7 +121,7 @@ export class Mover {
     this.moves.set(workspace, info);
     // Begin drag.
     dragger.onDragStart(info.fakePointerEvent('pointerdown'));
-    info.dragger.onDrag(info.fakePointerEvent('pointermove'), info.totalDelta);
+    //info.dragger.onDrag(info.fakePointerEvent('pointermove'), info.totalDelta);
     return true;
   }
 

--- a/src/keyboard_drag_strategy.ts
+++ b/src/keyboard_drag_strategy.ts
@@ -41,13 +41,9 @@ export class KeyboardDragStrategy extends dragging.BlockDragStrategy {
     // to the top left of the workspace.
     // @ts-expect-error block and startLoc are private.
     this.block.moveDuringDrag(this.startLoc);
-    //// @ts-expect-error startParentConn is private.
-    //this.searchNode = ASTNode.createConnectionNode(this.startParentConn);
     // @ts-expect-error connectionCandidate is private.
     this.connectionCandidate = this.createInitialCandidate();
     this.forceShowPreview();
-    //// @ts-expect-error accessing private things.
-    //this.connectionPreviewer!.previewConnection(this.connectionCandidate.local, this.connectionCandidate.neighbour);
   }
 
   override drag(newLoc: utils.Coordinate, e?: PointerEvent): void {
@@ -212,51 +208,64 @@ export class KeyboardDragStrategy extends dragging.BlockDragStrategy {
     return !!this.currentDragDirection;
   }
 
-  // This is a direct copy of the second half of updateConnectionPreview in
-  // BlockDragStrategy.
+  /**
+   * Force the preview (replacement or insertion marker) to be shown
+   * immediately. Keyboard drags should always show a preview, even when
+   * the drag has just started; this forces it.
+   */
   private forceShowPreview() {
-    // @ts-expect-error connectionCandidate
-    const {local, neighbour} = this.connectionCandidate;
+    // @ts-expect-error connectionPreviewer is private
+    const previewer = this.connectionPreviewer;
+    // @ts-expect-error connectionCandidate is private
+    const candidate = this.connectionCandidate as ConnectionCandidate;
+    if (!candidate || !previewer) return;
+    // @ts-expect-error block is private
+    const block = this.block;
+
+    // This is essentially a copy of the second half of updateConnectionPreview
+    // in BlockDragStrategy. It adds a `moveDuringDrag` call at the end.
+    const {local, neighbour} = candidate;
     const localIsOutputOrPrevious =
       local.type === ConnectionType.OUTPUT_VALUE ||
       local.type === ConnectionType.PREVIOUS_STATEMENT;
+
+    const target = neighbour.targetBlock();
     const neighbourIsConnectedToRealBlock =
-      neighbour.isConnected() && !neighbour.targetBlock()!.isInsertionMarker();
+      target && !target.isInsertionMarker();
+
+    const orphanCanConnectAtEnd =
+      target &&
+      // @ts-expect-error orphanCanConnectAtEnd is private
+      this.orphanCanConnectAtEnd(block, target, local.type);
     if (
       localIsOutputOrPrevious &&
       neighbourIsConnectedToRealBlock &&
-      // @ts-expect-error orphanCanConnectAtEnd is private
-      !this.orphanCanConnectAtEnd(
-        // @ts-expect-error block is private
-        this.block,
-        neighbour.targetBlock()!,
-        local.type,
-      )
+      !orphanCanConnectAtEnd
     ) {
-      // @ts-expect-error connectionPreviewer is private
-      this.connectionPreviewer!.previewReplacement(
-        local,
-        neighbour,
-        neighbour.targetBlock()!,
-      );
-      return;
+      previewer.previewReplacement(local, neighbour, target);
+    } else {
+      previewer.previewConnection(local, neighbour);
     }
-    // @ts-expect-error connectionPreviewer is private
-    this.connectionPreviewer!.previewConnection(local, neighbour);
-
     // The moving block will be positioned slightly down and to the
     // right of the connection it found.
-    // @ts-expect-error block is private.
-    this.block.moveDuringDrag(
+    block.moveDuringDrag(
       new utils.Coordinate(neighbour.x + 10, neighbour.y + 10),
     );
   }
 
-  private createInitialCandidate() {
+  /**
+   * Create a candidate representing where the block was previously connected.
+   * Used to render the block position after picking up the block but before
+   * moving during a drag.
+   *
+   * @returns A connection candidate representing where the block was at the
+   *     start of the drag.
+   */
+  private createInitialCandidate(): ConnectionCandidate | null {
     // @ts-expect-error startParentConn is private.
     const neighbour = this.startParentConn;
-    this.searchNode = ASTNode.createConnectionNode(neighbour);
     if (neighbour) {
+      this.searchNode = ASTNode.createConnectionNode(neighbour);
       switch (neighbour.type) {
         case ConnectionType.INPUT_VALUE:
           return {

--- a/src/keyboard_drag_strategy.ts
+++ b/src/keyboard_drag_strategy.ts
@@ -285,4 +285,8 @@ export class KeyboardDragStrategy extends dragging.BlockDragStrategy {
     }
     return null;
   }
+
+  override shouldHealStack(e: PointerEvent | undefined): boolean {
+    return true;
+  }
 }

--- a/src/navigation_controller.ts
+++ b/src/navigation_controller.ts
@@ -70,7 +70,7 @@ export class NavigationController {
 
   exitAction: ExitAction = new ExitAction(this.navigation);
 
-  enterAction: EnterAction = new EnterAction(this.navigation);
+  enterAction: EnterAction = new EnterAction(this.mover, this.navigation);
 
   actionMenu: ActionMenu = new ActionMenu(this.navigation);
 


### PR DESCRIPTION
Works on https://github.com/google/blockly-keyboard-experimentation/issues/398 by switching to _always_ healing the stack (only dragging the selected block).

This is a better default while we wire up the actual behaviour.

Replaces https://github.com/google/blockly-keyboard-experimentation/pull/390

### Additional information

[Lines 225-248](https://github.com/google/blockly-keyboard-experimentation/compare/main...rachel-fenichel:blockly-keyboard-experimentation:insert_move?expand=1#diff-83090943936e3fd0aeacc7b73d1d244a2d87f974f8f6b649b9a3226033f04b0fR225-R248) in `keyboard_drag_strategy.ts` are essentially a copy of [code from `block_drag_strategy.ts`](https://github.com/google/blockly/blob/develop/core/dragging/block_drag_strategy.ts#L245-L267), but I had to rearrange the code to avoid non-null assertions.

Proposed followup: 
- Extract the logic out of `updateConnectionPreviewer` to a helper function in core.
- Restructure the code in core to avoid non-null assertions.
- Call the new helper in the subclass (instead of reimplementing).