### PR TITLE
fix: Disallow undo/redo during a keyboard-driven move.

### DIFF
--- a/src/actions/undo_redo.ts
+++ b/src/actions/undo_redo.ts
@@ -1,0 +1,77 @@
+/**
+ * @license
+ * Copyright 2025 Google LLC
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import {
+  ShortcutRegistry,
+  utils as BlocklyUtils,
+  ShortcutItems,
+  WorkspaceSvg,
+} from 'blockly/core';
+
+import * as Constants from '../constants';
+import type {Navigation} from '../navigation';
+
+const KeyCodes = BlocklyUtils.KeyCodes;
+
+/**
+ * Class for registering a shortcut for undo/redo actions.
+ */
+export class UndoRedoAction {
+  private originalUndo?: ShortcutRegistry.KeyboardShortcut;
+  private originalRedo?: ShortcutRegistry.KeyboardShortcut;
+  /**
+   * Patches the existing undo/redo shortcuts in the registry.
+   */
+  install() {
+    const undo =
+      ShortcutRegistry.registry.getRegistry()[ShortcutItems.names.UNDO];
+    if (undo) {
+      this.originalUndo = undo;
+      const patchedUndo = {
+        ...this.originalUndo,
+        preconditionFn: (workspace: WorkspaceSvg) => {
+          return !!(
+            !workspace.isDragging() && undo.preconditionFn?.(workspace)
+          );
+        },
+        allowCollision: true,
+      };
+
+      ShortcutRegistry.registry.register(patchedUndo, true);
+    }
+
+    const redo =
+      ShortcutRegistry.registry.getRegistry()[ShortcutItems.names.REDO];
+    if (redo) {
+      this.originalRedo = redo;
+      const patchedRedo = {
+        ...this.originalRedo,
+        preconditionFn: (workspace: WorkspaceSvg) => {
+          return !!(
+            !workspace.isDragging() && redo.preconditionFn?.(workspace)
+          );
+        },
+        allowCollision: true,
+      };
+
+      ShortcutRegistry.registry.register(patchedRedo, true);
+    }
+  }
+
+  /**
+   * Reverts the patched undo/redo shortcuts in the registry.
+   */
+  uninstall() {
+    if (this.originalUndo) {
+      ShortcutRegistry.registry.register(this.originalUndo, true);
+      this.originalUndo = undefined;
+    }
+    if (this.originalRedo) {
+      ShortcutRegistry.registry.register(this.originalRedo, true);
+      this.originalRedo = undefined;
+    }
+  }
+}

--- a/src/navigation_controller.ts
+++ b/src/navigation_controller.ts
@@ -36,6 +36,7 @@ import {DisconnectAction} from './actions/disconnect';
 import {ActionMenu} from './actions/action_menu';
 import {MoveActions} from './actions/move';
 import {Mover} from './actions/mover';
+import {UndoRedoAction} from './actions/undo_redo';
 
 const KeyCodes = BlocklyUtils.KeyCodes;
 
@@ -71,6 +72,8 @@ export class NavigationController {
   exitAction: ExitAction = new ExitAction(this.navigation);
 
   enterAction: EnterAction = new EnterAction(this.navigation);
+
+  undoRedoAction: UndoRedoAction = new UndoRedoAction();
 
   actionMenu: ActionMenu = new ActionMenu(this.navigation);
 
@@ -289,6 +292,7 @@ export class NavigationController {
     this.exitAction.install();
     this.enterAction.install();
     this.disconnectAction.install();
+    this.undoRedoAction.install();
     this.actionMenu.install();
 
     this.clipboard.install();
@@ -315,6 +319,7 @@ export class NavigationController {
     this.arrowNavigation.uninstall();
     this.exitAction.uninstall();
     this.enterAction.uninstall();
+    this.undoRedoAction.uninstall();
     this.actionMenu.uninstall();
     this.shortcutDialog.uninstall();
 


### PR DESCRIPTION
This PR fixes #394. It patches the undo and redo keyboard shortcuts to check whether the workspace is dragging, and do nothing in that case.