### PR TITLE
fix: Disallow toolbox/insert during a keyboard-driven move

### DIFF
--- a/src/actions/insert.ts
+++ b/src/actions/insert.ts
@@ -53,8 +53,7 @@ export class InsertAction {
   private registerShortcut() {
     const insertShortcut: ShortcutRegistry.KeyboardShortcut = {
       name: this.insertShortcutName,
-      preconditionFn: (workspace: WorkspaceSvg) =>
-        !workspace.isDragging() && this.insertPrecondition(workspace),
+      preconditionFn: this.insertPrecondition.bind(this),
       callback: this.insertCallback.bind(this),
       keyCodes: [KeyCodes.I],
     };
@@ -102,7 +101,9 @@ export class InsertAction {
    * @returns True iff `insertCallback` function should be called.
    */
   private insertPrecondition(workspace: WorkspaceSvg): boolean {
-    return this.navigation.canCurrentlyEdit(workspace);
+    return (
+      !workspace.isDragging() && this.navigation.canCurrentlyEdit(workspace)
+    );
   }
 
   /**

--- a/src/actions/insert.ts
+++ b/src/actions/insert.ts
@@ -53,7 +53,8 @@ export class InsertAction {
   private registerShortcut() {
     const insertShortcut: ShortcutRegistry.KeyboardShortcut = {
       name: this.insertShortcutName,
-      preconditionFn: this.insertPrecondition.bind(this),
+      preconditionFn: (workspace: WorkspaceSvg) =>
+        !workspace.isDragging() && this.insertPrecondition(workspace),
       callback: this.insertCallback.bind(this),
       keyCodes: [KeyCodes.I],
     };

--- a/src/navigation_controller.ts
+++ b/src/navigation_controller.ts
@@ -244,7 +244,7 @@ export class NavigationController {
     focusToolbox: {
       name: Constants.SHORTCUT_NAMES.TOOLBOX,
       preconditionFn: (workspace) =>
-        this.navigation.canCurrentlyEdit(workspace),
+        !workspace.isDragging() && this.navigation.canCurrentlyEdit(workspace),
       callback: (workspace) => {
         switch (this.navigation.getState(workspace)) {
           case Constants.STATE.WORKSPACE:


### PR DESCRIPTION
This PR fixes https://github.com/google/blockly-keyboard-experimentation/issues/417

Demo: https://toolbox-dragging.blockly-keyboard-experimentation.pages.dev/
