### PR TITLE
fix: heuristic insert for statment block when value block is selected

### DIFF
--- a/src/navigation.ts
+++ b/src/navigation.ts
@@ -715,7 +715,26 @@ export class Navigation {
 
       // 3. Output connection. This will wrap around or displace.
       if (stationaryBlock.outputConnection) {
-        return this.insertBlock(movingBlock, stationaryBlock.outputConnection);
+        const handled = this.insertBlock(
+          movingBlock,
+          stationaryBlock.outputConnection,
+        );
+        if (handled) {
+          return true;
+        }
+      }
+
+      // 4. Connect statement blocks to the next connection of the moving block's parent.
+      const stationaryBlockParent = stationaryBlock.getParent();
+      if (
+        stationaryBlockParent &&
+        stationaryBlockParent.nextConnection &&
+        !movingBlock.outputConnection
+      ) {
+        return this.insertBlock(
+          movingBlock,
+          stationaryBlockParent.nextConnection,
+        );
       }
     }
     this.warn(`Unexpected case in tryToConnectBlock ${stationaryType}.`);


### PR DESCRIPTION
Potential fix for https://github.com/google/blockly-keyboard-experimentation/issues/418.  I'm not at all convinced that this is the right approach as the first warning message we get is `This block can not be inserted at the marked location` from inside the `insertBlock` method. However, the behaviour demonstrated here is what I think we're after.

Please feel free to close this in favour of a better approach or more reasoned approach.

Demo: https://insert-at-value.blockly-keyboard-experimentation.pages.dev/