### PR TITLE
fix: Disallow delete during a keyboard-driven move

### DIFF
--- a/src/actions/delete.ts
+++ b/src/actions/delete.ts
@@ -29,6 +29,12 @@ export class DeleteAction {
   private oldContextMenuItem: ContextMenuRegistry.RegistryItem | null = null;
 
   /**
+   * Saved delete shortcut, which is re-registered when this action
+   * is uninstalled.
+   */
+  private oldDeleteShortcut: ShortcutRegistry.KeyboardShortcut | null = null;
+
+  /**
    * Registration name for the keyboard shortcut.
    */
   private deleteShortcutName = Constants.SHORTCUT_NAMES.DELETE;
@@ -53,12 +59,22 @@ export class DeleteAction {
       ContextMenuRegistry.registry.register(this.oldContextMenuItem);
     }
     ShortcutRegistry.registry.unregister(this.deleteShortcutName);
+    if (this.oldDeleteShortcut) {
+      ShortcutRegistry.registry.register(this.oldDeleteShortcut);
+    }
   }
 
   /**
    * Create and register the keyboard shortcut for this action.
    */
   private registerShortcut() {
+    this.oldDeleteShortcut = ShortcutRegistry.registry.getRegistry()['delete'];
+
+    if (!this.oldDeleteShortcut) return;
+
+    // Unregister the original shortcut.
+    ShortcutRegistry.registry.unregister(this.oldDeleteShortcut.name);
+
     const deleteShortcut: ShortcutRegistry.KeyboardShortcut = {
       name: this.deleteShortcutName,
       preconditionFn: this.deletePrecondition.bind(this),
@@ -66,6 +82,7 @@ export class DeleteAction {
       keyCodes: [KeyCodes.DELETE, KeyCodes.BACKSPACE],
       allowCollision: true,
     };
+
     ShortcutRegistry.registry.register(deleteShortcut);
   }
 
@@ -139,6 +156,7 @@ export class DeleteAction {
   private deletePrecondition(workspace: WorkspaceSvg) {
     const sourceBlock = workspace.getCursor()?.getCurNode()?.getSourceBlock();
     return (
+      !workspace.isDragging() &&
       this.navigation.canCurrentlyEdit(workspace) &&
       !!sourceBlock?.isDeletable()
     );


### PR DESCRIPTION
This PR fixes https://github.com/google/blockly-keyboard-experimentation/issues/413. The existing delete shortcut was never unregistered during the install of this action, so even with the new dragging check in place, the existing delete shortcut was still succeeding. This has been ammended by unregistering the existing delete shortcut in the same way as the existing context menu item.

Demo: https://delete-dragging.blockly-keyboard-experimentation.pages.dev/