### PR TITLE
feat: add connection items without hacks

### DIFF
--- a/src/actions/clipboard.ts
+++ b/src/actions/clipboard.ts
@@ -17,8 +17,8 @@ import {
 import * as Constants from '../constants';
 import type {BlockSvg, WorkspaceSvg} from 'blockly';
 import {Navigation} from '../navigation';
-import {ScopeWithConnection} from './action_menu';
 import {getShortActionShortcut} from '../shortcut_formatting';
+import * as Blockly from 'blockly';
 
 const KeyCodes = blocklyUtils.KeyCodes;
 const createSerializedKey = ShortcutRegistry.registry.createSerializedKey.bind(
@@ -306,19 +306,28 @@ export class Clipboard {
   private registerPasteContextMenuAction() {
     const pasteAction: ContextMenuRegistry.RegistryItem = {
       displayText: (scope) => `Paste (${getShortActionShortcut('paste')})`,
-      preconditionFn: (scope: ScopeWithConnection) => {
-        const block = scope.block ?? scope.connection?.getSourceBlock();
+      preconditionFn: (scope: ContextMenuRegistry.Scope) => {
+        let block;
+        if (scope.focusedNode instanceof Blockly.Block) {
+          block = scope.focusedNode;
+        } else if (scope.focusedNode instanceof Blockly.Connection) {
+          block = scope.focusedNode.getSourceBlock();
+        }
         const ws = block?.workspace as WorkspaceSvg | null;
         if (!ws) return 'hidden';
         return this.pastePrecondition(ws) ? 'enabled' : 'disabled';
       },
-      callback: (scope: ScopeWithConnection) => {
-        const block = scope.block ?? scope.connection?.getSourceBlock();
+      callback: (scope: ContextMenuRegistry.Scope) => {
+        let block;
+        if (scope.focusedNode instanceof Blockly.Block) {
+          block = scope.focusedNode;
+        } else if (scope.focusedNode instanceof Blockly.Connection) {
+          block = scope.focusedNode.getSourceBlock();
+        }
         const ws = block?.workspace as WorkspaceSvg | null;
         if (!ws) return;
         return this.pasteCallback(ws);
       },
-      scopeType: ContextMenuRegistry.ScopeType.BLOCK,
       id: 'blockPasteFromContextMenu',
       weight: BASE_WEIGHT + 2,
     };

--- a/src/actions/insert.ts
+++ b/src/actions/insert.ts
@@ -12,7 +12,8 @@ import {
 import * as Constants from '../constants';
 import type {WorkspaceSvg} from 'blockly';
 import {Navigation} from '../navigation';
-import {ScopeWithConnection} from './action_menu';
+
+import * as Blockly from 'blockly/core';
 
 const KeyCodes = BlocklyUtils.KeyCodes;
 
@@ -70,21 +71,25 @@ export class InsertAction {
       displayText: () => {
         return 'Insert Block (I)';
       },
-      preconditionFn: (scope: ScopeWithConnection) => {
-        const block = scope.block ?? scope.connection?.getSourceBlock();
+      preconditionFn: (scope: ContextMenuRegistry.Scope) => {
+        let block;
+        if (scope.focusedNode instanceof Blockly.Block) {
+          block = scope.focusedNode;
+        } else if (scope.focusedNode instanceof Blockly.Connection) {
+          block = scope.focusedNode.getSourceBlock();
+        }
         const ws = block?.workspace as WorkspaceSvg | null;
         if (!ws) return 'hidden';
 
         return this.insertPrecondition(ws) ? 'enabled' : 'hidden';
       },
-      callback: (scope: ScopeWithConnection) => {
+      callback: (scope: ContextMenuRegistry.Scope) => {
         const ws =
-          scope.block?.workspace ??
-          (scope.connection?.getSourceBlock().workspace as WorkspaceSvg);
+          scope.focusedNode?.workspace ??
+          (scope.focusedNode?.getSourceBlock().workspace as WorkspaceSvg);
         if (!ws) return false;
         this.insertCallback(ws);
       },
-      scopeType: ContextMenuRegistry.ScopeType.BLOCK,
       id: 'insert',
       weight: 9,
     };

--- a/src/navigation.ts
+++ b/src/navigation.ts
@@ -404,8 +404,8 @@ export class Navigation {
       const passiveFocusNode = this.passiveFocusIndicator.getCurNode();
       this.passiveFocusIndicator.hide();
       const disposed = passiveFocusNode?.getSourceBlock()?.disposed;
-      // If there's a gesture then it will either set the node if it has not 
-      // been disposed (which can happen when blocks are reloaded) or be a click 
+      // If there's a gesture then it will either set the node if it has not
+      // been disposed (which can happen when blocks are reloaded) or be a click
       // that should not set one.
       if (!Blockly.Gesture.inProgress() && passiveFocusNode && !disposed) {
         cursor.setCurNode(passiveFocusNode);


### PR DESCRIPTION
Fixes #360 

Implements the Connection context menu items without the hacks. Depends on https://github.com/google/blockly/pull/8882, tests pass locally when they're linked.

Note that in core `Connection`s don't implement the `IContextMenu` interface yet, so we still call the `contextmenu.show` method manually. Fixing that is coming soon. But this removes the hacks around including the connection in the scope and manually checking the precondition functions.
