### PR TITLE
chore: Update dependency to Blockly v12 beta 4.

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -18,7 +18,7 @@
         "@types/p5": "^1.7.6",
         "@typescript-eslint/eslint-plugin": "^6.7.2",
         "@typescript-eslint/parser": "^6.7.2",
-        "blockly": "12.0.0-beta.3",
+        "blockly": "^12.0.0-beta.4",
         "chai": "^5.2.0",
         "eslint": "^8.49.0",
         "eslint-config-google": "^0.14.0",
@@ -34,7 +34,7 @@
         "webdriverio": "^9.12.1"
       },
       "peerDependencies": {
-        "blockly": "^12.0.0-beta.3"
+        "blockly": "^12.0.0-beta.4"
       }
     },
     "node_modules/@asamuzakjp/css-color": {
@@ -3062,9 +3062,9 @@
       }
     },
     "node_modules/blockly": {
-      "version": "12.0.0-beta.3",
-      "resolved": "https://registry.npmjs.org/blockly/-/blockly-12.0.0-beta.3.tgz",
-      "integrity": "sha512-qB4811omhieGkrDhgnW2fAFpPvr4zMzDN2bQ03YZzxfCnhVCDGLLtZb8xGUnws5YwHBrgW6LMYbE1qlzhB2yVw==",
+      "version": "12.0.0-beta.4",
+      "resolved": "https://registry.npmjs.org/blockly/-/blockly-12.0.0-beta.4.tgz",
+      "integrity": "sha512-KY26RP8GfJRTqX/EUWSwu7ilVwhdGU0qQTrgdUGl+frsgqlBqCtIWZJVCxMafCAUWyAlU9+5aQ7UBItcR2MVQQ==",
       "dev": true,
       "license": "Apache-2.0",
       "dependencies": {

--- a/package.json
+++ b/package.json
@@ -55,7 +55,7 @@
     "@types/p5": "^1.7.6",
     "@typescript-eslint/eslint-plugin": "^6.7.2",
     "@typescript-eslint/parser": "^6.7.2",
-    "blockly": "12.0.0-beta.3",
+    "blockly": "^12.0.0-beta.4",
     "chai": "^5.2.0",
     "eslint": "^8.49.0",
     "eslint-config-google": "^0.14.0",
@@ -71,11 +71,11 @@
     "webdriverio": "^9.12.1"
   },
   "peerDependencies": {
-    "blockly": "^12.0.0-beta.3"
+    "blockly": "^12.0.0-beta.4"
   },
   "overrides": {
     "@blockly/field-colour": {
-      "blockly": "^12.0.0-beta.3"
+      "blockly": "^12.0.0-beta.4"
     }
   },
   "publishConfig": {


### PR DESCRIPTION
This PR updates the repo to use the latest Blockly v12 beta 4 as a dependency.