### PR TITLE
feat: avoid insert then move; delete on abort

### DIFF
--- a/src/actions/enter.ts
+++ b/src/actions/enter.ts
@@ -132,8 +132,8 @@ export class EnterAction {
     const newBlock = this.createNewBlock(workspace);
     if (!newBlock) return;
 
-    const startConnection = stationaryNode
-      ? this.navigation.findBestInsertionConnection(stationaryNode, newBlock)
+    const insertStartPoint = stationaryNode
+      ? this.navigation.findInsertStartPoint(stationaryNode, newBlock)
       : null;
     if (workspace.getTopBlocks().includes(newBlock)) {
       this.positionNewTopLevelBlock(workspace, newBlock);
@@ -145,7 +145,7 @@ export class EnterAction {
     this.navigation.focusWorkspace(workspace);
     // eslint-disable-next-line @typescript-eslint/no-non-null-assertion
     workspace.getCursor()?.setCurNode(ASTNode.createBlockNode(newBlock)!);
-    this.mover.startMove(workspace, startConnection);
+    this.mover.startMove(workspace, insertStartPoint);
   }
 
   /**

--- a/src/actions/enter.ts
+++ b/src/actions/enter.ts
@@ -135,14 +135,10 @@ export class EnterAction {
     const stationaryNode = this.navigation.getStationaryNode(workspace);
     const newBlock = this.createNewBlock(workspace);
     if (!newBlock) return;
-    if (stationaryNode) {
-      if (!this.navigation.tryToConnectBlock(stationaryNode, newBlock)) {
-        console.warn(
-          'Something went wrong while inserting a block from the flyout.',
-        );
-      }
-    }
 
+    const startConnection = stationaryNode
+      ? this.navigation.findBestInsertionConnection(stationaryNode, newBlock)
+      : null;
     if (workspace.getTopBlocks().includes(newBlock)) {
       this.positionNewTopLevelBlock(workspace, newBlock);
     }
@@ -153,7 +149,7 @@ export class EnterAction {
     this.navigation.focusWorkspace(workspace);
     // eslint-disable-next-line @typescript-eslint/no-non-null-assertion
     workspace.getCursor()?.setCurNode(ASTNode.createBlockNode(newBlock)!);
-    this.mover.startMove(workspace);
+    this.mover.startMove(workspace, startConnection);
   }
 
   /**

--- a/src/actions/mover.ts
+++ b/src/actions/mover.ts
@@ -199,7 +199,6 @@ export class Mover {
     this.unpatchWorkspace(workspace);
     this.unpatchDragStrategy(info.block);
     this.moves.delete(workspace);
-
     return true;
   }
 

--- a/src/actions/mover.ts
+++ b/src/actions/mover.ts
@@ -177,11 +177,10 @@ export class Mover {
       info.block.getDragStrategy() as KeyboardDragStrategy;
     const {insertStartPoint} = keyboardDragStrategy;
 
-    if (insertStartPoint) {
-      // Monkey patch dragger to trigger delete.
-      // eslint-disable-next-line @typescript-eslint/no-explicit-any
-      (info.dragger as any).wouldDeleteDraggable = () => true;
-    } else {
+    // Monkey patch dragger to trigger delete.
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    (info.dragger as any).wouldDeleteDraggable = () => !!insertStartPoint;
+    if (!insertStartPoint) {
       // Monkey patch dragger to trigger call to draggable.revertDrag.
       // eslint-disable-next-line @typescript-eslint/no-explicit-any
       (info.dragger as any).shouldReturnToStart = () => true;
@@ -191,6 +190,10 @@ export class Mover {
     // Explicitly call `hidePreview` because it is not called in revertDrag.
     // @ts-expect-error Access to private property dragStrategy.
     blockSvg.dragStrategy.connectionPreviewer.hidePreview();
+    // Prevent the stragegy connecting the block so we just delete one block.
+    // @ts-expect-error Access to private property dragStrategy.
+    blockSvg.dragStrategy.connectionCandidate = null;
+
     info.dragger.onDragEnd(
       info.fakePointerEvent('pointerup'),
       info.startLocation,

--- a/src/actions/mover.ts
+++ b/src/actions/mover.ts
@@ -313,7 +313,8 @@ export class Mover {
    * Monkeypatch: replace the block's drag strategy and cache the old value.
    *
    * @param block The block to patch.
-   * @param insertStartPoint The starting connection.
+   * @param insertStartPoint The starting point for the move in the insert case,
+   *     when the block should be deleted if aborted rather than reverted.
    */
   private patchDragStrategy(
     block: BlockSvg,

--- a/src/actions/mover.ts
+++ b/src/actions/mover.ts
@@ -175,9 +175,9 @@ export class Mover {
     // If it's an insert-style move then we delete the block.
     const keyboardDragStrategy =
       info.block.getDragStrategy() as KeyboardDragStrategy;
-    const {insertStartPoint: startConnection} = keyboardDragStrategy;
+    const {insertStartPoint} = keyboardDragStrategy;
 
-    if (startConnection) {
+    if (insertStartPoint) {
       // Monkey patch dragger to trigger delete.
       // eslint-disable-next-line @typescript-eslint/no-explicit-any
       (info.dragger as any).wouldDeleteDraggable = () => true;

--- a/src/keyboard_drag_strategy.ts
+++ b/src/keyboard_drag_strategy.ts
@@ -37,7 +37,7 @@ export class KeyboardDragStrategy extends dragging.BlockDragStrategy {
 
   constructor(
     block: BlockSvg,
-    private startConnection: RenderedConnection | null,
+    public insertStartPoint: RenderedConnection | null,
   ) {
     super(block);
   }
@@ -269,7 +269,7 @@ export class KeyboardDragStrategy extends dragging.BlockDragStrategy {
    */
   private createInitialCandidate(): ConnectionCandidate | null {
     // @ts-expect-error startParentConn is private.
-    const neighbour = this.startConnection ?? this.startParentConn;
+    const neighbour = this.insertStartPoint ?? this.startParentConn;
     if (neighbour) {
       this.searchNode = ASTNode.createConnectionNode(neighbour);
       switch (neighbour.type) {

--- a/src/keyboard_drag_strategy.ts
+++ b/src/keyboard_drag_strategy.ts
@@ -35,6 +35,13 @@ export class KeyboardDragStrategy extends dragging.BlockDragStrategy {
   /** Where a constrained movement should start when traversing the tree. */
   private searchNode: ASTNode | null = null;
 
+  constructor(
+    block: BlockSvg,
+    private startConnection: RenderedConnection | null,
+  ) {
+    super(block);
+  }
+
   override startDrag(e?: PointerEvent) {
     super.startDrag(e);
     // Set position of the dragging block, so that it doesn't pop
@@ -263,7 +270,7 @@ export class KeyboardDragStrategy extends dragging.BlockDragStrategy {
    */
   private createInitialCandidate(): ConnectionCandidate | null {
     // @ts-expect-error startParentConn is private.
-    const neighbour = this.startParentConn;
+    const neighbour = this.startConnection ?? this.startParentConn;
     if (neighbour) {
       this.searchNode = ASTNode.createConnectionNode(neighbour);
       switch (neighbour.type) {

--- a/src/navigation.ts
+++ b/src/navigation.ts
@@ -749,9 +749,7 @@ export class Navigation {
         return stationaryBlock.outputConnection;
       }
     }
-    this.warn(
-      `Unexpected case in findBestInsertionConnection ${stationaryType}.`,
-    );
+    this.warn(`Unexpected case in findInsertStartPoint ${stationaryType}.`);
     return null;
   }
 

--- a/src/navigation.ts
+++ b/src/navigation.ts
@@ -404,8 +404,8 @@ export class Navigation {
       const passiveFocusNode = this.passiveFocusIndicator.getCurNode();
       this.passiveFocusIndicator.hide();
       const disposed = passiveFocusNode?.getSourceBlock()?.disposed;
-      // If there's a gesture then it will either set the node if it has not 
-      // been disposed (which can happen when blocks are reloaded) or be a click 
+      // If there's a gesture then it will either set the node if it has not
+      // been disposed (which can happen when blocks are reloaded) or be a click
       // that should not set one.
       if (!Blockly.Gesture.inProgress() && passiveFocusNode && !disposed) {
         cursor.setCurNode(passiveFocusNode);
@@ -662,15 +662,13 @@ export class Navigation {
   }
 
   /**
-   * Tries to intelligently connect the blocks or connections
-   * represented by the given nodes, based on node types and locations.
+   * Finds the starting point for an insert.
    *
-   * @param stationaryNode The first node to connect.
+   * @param stationaryNode The first node to find a connection for.
    * @param movingBlock The block we're moving.
-   * @returns True if the key was handled; false if something went
-   *     wrong.
+   * @returns The initial connection to use or begin move mode at.
    */
-  findBestInsertionConnection(
+  findInsertStartPoint(
     stationaryNode: Blockly.ASTNode,
     movingBlock: Blockly.BlockSvg,
   ): Blockly.RenderedConnection | null {
@@ -680,7 +678,7 @@ export class Navigation {
     if (stationaryNode.getType() === Blockly.ASTNode.types.FIELD) {
       const sourceBlock = stationaryNode.getSourceBlock();
       if (!sourceBlock) return null;
-      return this.findBestInsertionConnection(
+      return this.findInsertStartPoint(
         Blockly.ASTNode.createBlockNode(sourceBlock),
         movingBlock,
       );
@@ -696,7 +694,7 @@ export class Navigation {
       ) {
         const sourceBlock = stationaryNode.getSourceBlock();
         if (!sourceBlock) return null;
-        return this.findBestInsertionConnection(
+        return this.findInsertStartPoint(
           Blockly.ASTNode.createBlockNode(sourceBlock),
           movingBlock,
         );
@@ -743,7 +741,7 @@ export class Navigation {
         ) {
           const parent = stationaryNode.getSourceBlock()?.getParent();
           if (!parent) return null;
-          return this.findBestInsertionConnection(
+          return this.findInsertStartPoint(
             Blockly.ASTNode.createBlockNode(parent),
             movingBlock,
           );
@@ -770,7 +768,7 @@ export class Navigation {
     stationaryNode: Blockly.ASTNode,
     movingBlock: Blockly.BlockSvg,
   ): boolean {
-    const destConnection = this.findBestInsertionConnection(
+    const destConnection = this.findInsertStartPoint(
       stationaryNode,
       movingBlock,
     );


### PR DESCRIPTION
Fixes #421 

Demo: https://insert-connection.blockly-keyboard-experimentation.pages.dev/

Problems with this PR:
- [x] Select create canvas block, insert statement block, escape to abort. We delete more than we intend.
- [ ] Not doesn't wrap around true in test of `if` by default if on `if`

https://github.com/user-attachments/assets/812c993d-bc04-4fbc-b2e9-2a81d1f078ae

To raise as separate issues:
- Post-abort cursor position isn't great (like delete in general).
- Undo has too many steps.
