### PR TITLE
feat: hide some context menu options when opening menu with mouse

### DIFF
--- a/src/actions/edit.ts
+++ b/src/actions/edit.ts
@@ -51,7 +51,8 @@ export class EditAction {
   private registerContextMenuAction() {
     const editAboveItem: ContextMenuRegistry.RegistryItem = {
       displayText: 'Edit Block contents (→︎)',
-      preconditionFn: (scope: ContextMenuRegistry.Scope) => {
+      preconditionFn: (scope: ContextMenuRegistry.Scope, menuOpenEvent) => {
+        if (menuOpenEvent instanceof PointerEvent) return 'hidden';
         const workspace = scope.block?.workspace;
         if (!workspace || !this.navigation.canCurrentlyNavigate(workspace)) {
           return 'disabled';

--- a/src/actions/insert.ts
+++ b/src/actions/insert.ts
@@ -71,7 +71,11 @@ export class InsertAction {
       displayText: () => {
         return 'Insert Block (I)';
       },
-      preconditionFn: (scope: ContextMenuRegistry.Scope) => {
+      preconditionFn: (
+        scope: ContextMenuRegistry.Scope,
+        menuOpenEvent: Event,
+      ) => {
+        if (menuOpenEvent instanceof PointerEvent) return 'hidden';
         let block;
         if (scope.focusedNode instanceof Blockly.Block) {
           block = scope.focusedNode;

--- a/src/actions/move.ts
+++ b/src/actions/move.ts
@@ -127,9 +127,10 @@ export class MoveActions {
   menuItems: ContextMenuRegistry.RegistryItem[] = [
     {
       displayText: 'Move Block (M)',
-      preconditionFn: (scope) => {
+      preconditionFn: (scope, menuOpenEvent) => {
         const workspace = scope.block?.workspace as WorkspaceSvg | null;
-        if (!workspace) return 'hidden';
+        if (!workspace || menuOpenEvent instanceof PointerEvent)
+          return 'hidden';
         return this.mover.canMove(workspace) ? 'enabled' : 'disabled';
       },
       callback: (scope) => {


### PR DESCRIPTION
I guess we don't have an issue for this, but we wanted the keyboard-specific context menu items to not be shown for mouse users.

This changes checks if the context menu was opened via mouse and if so hides the insert, move, and edit options. I left the copy/paste/cut options because I wasn't sure where we landed with showing those.
