### PR TITLE
release: update version number to 0.0.7

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@blockly/keyboard-experiment",
-  "version": "0.0.6",
+  "version": "0.0.7",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@blockly/keyboard-experiment",
-      "version": "0.0.6",
+      "version": "0.0.7",
       "license": "Apache-2.0",
       "devDependencies": {
         "@blockly/dev-scripts": "^4.0.1",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@blockly/keyboard-experiment",
-  "version": "0.0.6",
+  "version": "0.0.7",
   "description": "A plugin for keyboard navigation.",
   "scripts": {
     "audit:fix": "blockly-scripts auditFix",


### PR DESCRIPTION
Note that this release was cut at this [commit](https://github.com/google/blockly-keyboard-experimentation/commit/f3d44ab2f0a06e5104b303ab26910d3bb5930048).
