### PR TITLE
chore: Remove unnecessary cast.

### DIFF
--- a/src/keyboard_drag_strategy.ts
+++ b/src/keyboard_drag_strategy.ts
@@ -140,8 +140,7 @@ export class KeyboardDragStrategy extends dragging.BlockDragStrategy {
     draggingBlock: BlockSvg,
     localConns: RenderedConnection[],
   ): ConnectionCandidate | null {
-    // TODO(#385): Make sure this works for any cursor, not just LineCursor.
-    const cursor = draggingBlock.workspace.getCursor() as LineCursor;
+    const cursor = draggingBlock.workspace.getCursor();
     if (!cursor) return null;
 
     // Helper function for traversal.


### PR DESCRIPTION
This PR fixes #385 by removing a no-op cast to `LineCursor`. `LineCursor` is now the base class in core, so all cursors will inherit from it.