### PR TITLE
fix: show correct preview during unconstrained movement near a connection

### DIFF
--- a/src/actions/mover.ts
+++ b/src/actions/mover.ts
@@ -121,6 +121,7 @@ export class Mover {
     this.moves.set(workspace, info);
     // Begin drag.
     dragger.onDragStart(info.fakePointerEvent('pointerdown'));
+    info.updateTotalDelta();
     return true;
   }
 

--- a/src/keyboard_drag_strategy.ts
+++ b/src/keyboard_drag_strategy.ts
@@ -60,12 +60,14 @@ export class KeyboardDragStrategy extends dragging.BlockDragStrategy {
       // The next constrained move will resume the search from the current
       // candidate location.
       this.searchNode = ASTNode.createConnectionNode(neighbour);
-      // The moving block will be positioned slightly down and to the
-      // right of the connection it found.
-      // @ts-expect-error block is private.
-      this.block.moveDuringDrag(
-        new utils.Coordinate(neighbour.x + 10, neighbour.y + 10),
-      );
+      if (this.isConstrainedMovement()) {
+        // Position the moving block down and slightly to the right of the
+        // target connection.
+        // @ts-expect-error block is private.
+        this.block.moveDuringDrag(
+          new utils.Coordinate(neighbour.x + 10, neighbour.y + 10),
+        );
+      }
     } else {
       // Handle the case when unconstrained drag was far from any candidate.
       this.searchNode = null;


### PR DESCRIPTION
Proposed fix for https://github.com/google/blockly-keyboard-experimentation/issues/439

@microbit-robert @microbit-matt-hillsdon I'd appreciate your opinion on this.

Two parts to the change:

### Initial offset
In `mover.ts`, call `info.updateTotalDelta` immediately after `onDragStart`. 
If the drag immediately shows a preview, this will update the block's location accordingly. 
If a preview is shown, the block is moved down and to the right of the target connection. 
![image](https://github.com/user-attachments/assets/53d0cdef-c361-4c27-a561-157942b50808)

#### Rationale
Without this change, the block was wrong about its position until the first constrained movement occurred. I think this change is necessary no matter what.

### Offset during drag
In `keyboard_drag_strategy.ts`, only force the block's position offset if the most recent movement was constrained.
![image](https://github.com/user-attachments/assets/d2e3106c-b088-4a8f-b9f0-7fd13c794899)

If the movement was unconstrained, the insertion marker still shows or hides as appropriate, but the dragging block can translate relative to the insertion marker. All of these become legal:
![image](https://github.com/user-attachments/assets/5fc041dc-2183-4b6f-a9bb-cd244293a02d)
![image](https://github.com/user-attachments/assets/8442e3aa-1dd8-4ff0-b1bd-73bbf81f01a5)
![image](https://github.com/user-attachments/assets/1d8c5d61-0eff-4c26-9a58-1f7d637d9b01)
![image](https://github.com/user-attachments/assets/87fb8c0e-0ddf-44a8-80a1-84844df131db)

Moving away more causes the insertion marker to disappear: 
![image](https://github.com/user-attachments/assets/628c366a-8a32-4a56-ad66-01d9bade00cb)

And here's an example as a gif. All movements in this gif are unconstrained.
![582f55d7-5595-49db-a068-621fd105c8c7](https://github.com/user-attachments/assets/0f1529be-63f5-4ed8-8609-dd2d5a1c1bcc)

#### Rationale
In discussion with Robert and Matt I suggested making the drag step larger during keyboard drags, or making it larger only when showing a preview and trying to do an uncosntrained movement. But as the drag step size increases, so does the chance of missing a connection entirely. This is especially acute when working with value inputs, where the connections may be very close to each other in a row.

While investigating, I realized that part of the issue is that the user has no feedback: there is no visible change on the first unconstrained movement away from a connection (or, in MakeCode, the first four). In mouse mode the feedback is that the block moves along with the mouse pointer. The insertion marker sticks at the new position, but the dragging block moves around. In fact, this is half of the reason for using a separate insertion marker as a preview.

This change mimics mouse dragging by moving the dragging block around while still showing the preview. It may take multiple keypresses to move away from a connection, but users get feedback that a movement is happening.