### PR TITLE
feat: improved insertion flow

### DIFF
--- a/src/actions/enter.ts
+++ b/src/actions/enter.ts
@@ -133,14 +133,9 @@ export class EnterAction {
     const stationaryNode = this.navigation.getStationaryNode(workspace);
     const newBlock = this.createNewBlock(workspace);
     if (!newBlock) return;
-    if (stationaryNode) {
-      if (!this.navigation.tryToConnectBlock(stationaryNode, newBlock)) {
-        console.warn(
-          'Something went wrong while inserting a block from the flyout.',
-        );
-      }
-    }
-
+    const insertStartPoint = stationaryNode
+      ? this.navigation.findInsertStartPoint(stationaryNode, newBlock)
+      : null;
     if (workspace.getTopBlocks().includes(newBlock)) {
       this.positionNewTopLevelBlock(workspace, newBlock);
     }
@@ -151,7 +146,7 @@ export class EnterAction {
     this.navigation.focusWorkspace(workspace);
     // eslint-disable-next-line @typescript-eslint/no-non-null-assertion
     workspace.getCursor()?.setCurNode(ASTNode.createBlockNode(newBlock)!);
-    this.mover.startMove(workspace, newBlock, true);
+    this.mover.startMove(workspace, newBlock, insertStartPoint);
 
     const isStartBlock =
       !newBlock.outputConnection &&

--- a/src/actions/enter.ts
+++ b/src/actions/enter.ts
@@ -151,7 +151,7 @@ export class EnterAction {
     this.navigation.focusWorkspace(workspace);
     // eslint-disable-next-line @typescript-eslint/no-non-null-assertion
     workspace.getCursor()?.setCurNode(ASTNode.createBlockNode(newBlock)!);
-    this.mover.startMove(workspace, newBlock);
+    this.mover.startMove(workspace, newBlock, true);
 
     const isStartBlock =
       !newBlock.outputConnection &&

--- a/src/actions/enter.ts
+++ b/src/actions/enter.ts
@@ -128,6 +128,7 @@ export class EnterAction {
    */
   private insertFromFlyout(workspace: WorkspaceSvg) {
     workspace.setResizesEnabled(false);
+    // Create a new event group or append to the existing group.
     const existingGroup = Events.getGroup();
     if (!existingGroup) {
       Events.setGroup(true);

--- a/src/actions/enter.ts
+++ b/src/actions/enter.ts
@@ -128,7 +128,10 @@ export class EnterAction {
    */
   private insertFromFlyout(workspace: WorkspaceSvg) {
     workspace.setResizesEnabled(false);
-    Events.setGroup(true);
+    const existingGroup = Events.getGroup();
+    if (!existingGroup) {
+      Events.setGroup(true);
+    }
 
     const stationaryNode = this.navigation.getStationaryNode(workspace);
     const newBlock = this.createNewBlock(workspace);
@@ -140,7 +143,6 @@ export class EnterAction {
       this.positionNewTopLevelBlock(workspace, newBlock);
     }
 
-    Events.setGroup(false);
     workspace.setResizesEnabled(true);
 
     this.navigation.focusWorkspace(workspace);

--- a/src/actions/enter.ts
+++ b/src/actions/enter.ts
@@ -151,7 +151,7 @@ export class EnterAction {
     this.navigation.focusWorkspace(workspace);
     // eslint-disable-next-line @typescript-eslint/no-non-null-assertion
     workspace.getCursor()?.setCurNode(ASTNode.createBlockNode(newBlock)!);
-    this.mover.startMove(workspace);
+    this.mover.startMove(workspace, newBlock);
 
     const isStartBlock =
       !newBlock.outputConnection &&

--- a/src/actions/move.ts
+++ b/src/actions/move.ts
@@ -199,7 +199,7 @@ export class MoveActions {
     const curNode = workspace?.getCursor()?.getCurNode();
     let block = curNode?.getSourceBlock();
     if (!block) return undefined;
-    while (block && block.isShadow()) {
+    while (block?.isShadow()) {
       block = block.getParent();
       if (!block) {
         throw new Error(

--- a/src/actions/move.ts
+++ b/src/actions/move.ts
@@ -35,7 +35,9 @@ export class MoveActions {
       },
       callback: (workspace) => {
         const startBlock = this.getCurrentBlock(workspace);
-        return !!startBlock && this.mover.startMove(workspace, startBlock);
+        return (
+          !!startBlock && this.mover.startMove(workspace, startBlock, false)
+        );
       },
       keyCodes: [KeyCodes.M],
     },
@@ -148,7 +150,9 @@ export class MoveActions {
         const workspace = scope.block?.workspace as WorkspaceSvg | null;
         if (!workspace) return false;
         const startBlock = this.getCurrentBlock(workspace);
-        return !!startBlock && this.mover.startMove(workspace, startBlock);
+        return (
+          !!startBlock && this.mover.startMove(workspace, startBlock, false)
+        );
       },
       scopeType: ContextMenuRegistry.ScopeType.BLOCK,
       id: 'move',

--- a/src/actions/move.ts
+++ b/src/actions/move.ts
@@ -36,7 +36,7 @@ export class MoveActions {
       callback: (workspace) => {
         const startBlock = this.getCurrentBlock(workspace);
         return (
-          !!startBlock && this.mover.startMove(workspace, startBlock, false)
+          !!startBlock && this.mover.startMove(workspace, startBlock, null)
         );
       },
       keyCodes: [KeyCodes.M],
@@ -151,7 +151,7 @@ export class MoveActions {
         if (!workspace) return false;
         const startBlock = this.getCurrentBlock(workspace);
         return (
-          !!startBlock && this.mover.startMove(workspace, startBlock, false)
+          !!startBlock && this.mover.startMove(workspace, startBlock, null)
         );
       },
       scopeType: ContextMenuRegistry.ScopeType.BLOCK,

--- a/src/actions/mover.ts
+++ b/src/actions/mover.ts
@@ -340,7 +340,7 @@ export class Mover {
    *     the workspace's viewport.
    */
   private scrollCurrentBlockIntoView(workspace: WorkspaceSvg, padding = 10) {
-    const blockToView = this.getCurrentBlock(workspace);
+    const blockToView = this.moves.get(workspace)?.block;
     if (blockToView) {
       workspace.scrollBoundsIntoView(
         blockToView.getBoundingRectangleWithoutChildren(),

--- a/src/actions/mover.ts
+++ b/src/actions/mover.ts
@@ -4,7 +4,13 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-import type {BlockSvg, IDragger, IDragStrategy, Gesture} from 'blockly';
+import type {
+  BlockSvg,
+  IDragger,
+  IDragStrategy,
+  Gesture,
+  RenderedConnection,
+} from 'blockly';
 import {
   ASTNode,
   Connection,
@@ -108,12 +114,17 @@ export class Mover {
    *
    * @param workspace The workspace we might be moving on.
    * @param block The block to start dragging.
-   * @param isNewBlock Whether the moving block was created for this action.
+   * @param insertStartPoint Where to insert the block, or null if the block
+   *     already existed.
    * @returns True iff a move has successfully begun.
    */
-  startMove(workspace: WorkspaceSvg, block: BlockSvg, isNewBlock: boolean) {
+  startMove(
+    workspace: WorkspaceSvg,
+    block: BlockSvg,
+    insertStartPoint: RenderedConnection | null,
+  ) {
     this.patchWorkspace(workspace);
-    this.patchDragStrategy(block, isNewBlock);
+    this.patchDragStrategy(block, insertStartPoint);
     // Begin dragging block.
     const DraggerClass = registry.getClassFromOptions(
       registry.Type.BLOCK_DRAGGER,
@@ -297,14 +308,16 @@ export class Mover {
    * Monkeypatch: replace the block's drag strategy and cache the old value.
    *
    * @param block The block to patch.
-   * @param isNewBlock Whether the moving block was created for this action.
+   * @param insertStartPoint Where to insert the block, or null if the block
+   *     already existed.
    */
-  private patchDragStrategy(block: BlockSvg, isNewBlock: boolean) {
+  private patchDragStrategy(
+    block: BlockSvg,
+    insertStartPoint: RenderedConnection | null,
+  ) {
     // @ts-expect-error block.dragStrategy is private.
     this.oldDragStrategy = block.dragStrategy;
-    block.setDragStrategy(
-      new KeyboardDragStrategy(block, this.navigation, isNewBlock),
-    );
+    block.setDragStrategy(new KeyboardDragStrategy(block, insertStartPoint));
   }
 
   /**

--- a/src/actions/mover.ts
+++ b/src/actions/mover.ts
@@ -305,7 +305,7 @@ export class Mover {
   private patchDragStrategy(block: BlockSvg) {
     // @ts-expect-error block.dragStrategy is private.
     this.oldDragStrategy = block.dragStrategy;
-    block.setDragStrategy(new KeyboardDragStrategy(block));
+    block.setDragStrategy(new KeyboardDragStrategy(block, this.navigation));
   }
 
   /**

--- a/src/actions/mover.ts
+++ b/src/actions/mover.ts
@@ -57,18 +57,6 @@ export class Mover {
   oldGetGesture: ((e: PointerEvent) => Gesture | null) | null = null;
 
   /**
-   * The stashed wouldDeleteDraggable function, which is sometimes replaced
-   * during a keyboard drag and is reset at the end of a keyboard drag.
-   */
-  oldWouldDeleteDraggable: (() => boolean) | null = null;
-
-  /**
-   * The stashed shouldReturnToStart function, which is sometimes replaced
-   * during a keyboard drag and is reset at the end of a keyboard drag.
-   */
-  oldShouldReturnToStart: (() => boolean) | null = null;
-
-  /**
    * The block's base drag strategy, which will be overridden during
    * keyboard drags and reset at the end of the drag.
    */
@@ -213,7 +201,6 @@ export class Mover {
 
     this.unpatchWorkspace(workspace);
     this.unpatchDragStrategy(info.block);
-    this.unpatchDragger(info.dragger as dragging.Dragger);
     this.moves.delete(workspace);
     // Delay scroll until after block has finished moving.
     setTimeout(() => this.scrollCurrentBlockIntoView(workspace), 0);
@@ -359,35 +346,13 @@ export class Mover {
    */
   private patchDragger(dragger: dragging.Dragger, isNewBlock: boolean) {
     if (isNewBlock) {
-      // @ts-expect-error dragger.wouldDeleteDraggable is private.
-      this.oldWouldDeleteDraggable = dragger.wouldDeleteDraggable;
       // Monkey patch dragger to trigger delete.
       // eslint-disable-next-line @typescript-eslint/no-explicit-any
       (dragger as any).wouldDeleteDraggable = () => true;
     } else {
-      // @ts-expect-error dragger.shouldReturnToStart is private.
-      this.oldShouldReturnToStart = dragger.shouldReturnToStart;
       // Monkey patch dragger to trigger call to draggable.revertDrag.
       // eslint-disable-next-line @typescript-eslint/no-explicit-any
       (dragger as any).shouldReturnToStart = () => true;
-    }
-  }
-
-  /**
-   * Undo the monkeypatching of the block dragger.
-   *
-   * @param dragger The dragger to patch.
-   */
-  private unpatchDragger(dragger: dragging.Dragger) {
-    if (this.oldWouldDeleteDraggable) {
-      // @ts-expect-error dragger.wouldDeleteDraggable is private.
-      dragger.wouldDeleteDraggable = this.oldWouldDeleteDraggable;
-      this.oldWouldDeleteDraggable = null;
-    }
-    if (this.oldShouldReturnToStart) {
-      // @ts-expect-error dragger.shouldReturnToStart is private.
-      dragger.shouldReturnToStart = this.oldShouldReturnToStart;
-      this.oldShouldReturnToStart = null;
     }
   }
 }

--- a/src/actions/mover.ts
+++ b/src/actions/mover.ts
@@ -63,11 +63,10 @@ export class Mover {
    * currently has focus on the given workspace.
    *
    * @param workspace The workspace to move on.
+   * @param block The block to try to drag.
    * @returns True iff we can begin a move.
    */
-  canMove(workspace: WorkspaceSvg) {
-    const block = this.getCurrentBlock(workspace);
-
+  canMove(workspace: WorkspaceSvg, block: BlockSvg) {
     return !!(
       this.navigation.getState(workspace) === Constants.STATE.WORKSPACE &&
       this.navigation.canCurrentlyEdit(workspace) &&
@@ -96,12 +95,12 @@ export class Mover {
    * Should only be called if canMove has returned true.
    *
    * @param workspace The workspace we might be moving on.
+   * @param block The block to start dragging.
    * @returns True iff a move has successfully begun.
    */
-  startMove(workspace: WorkspaceSvg) {
+  startMove(workspace: WorkspaceSvg, block: BlockSvg) {
     const cursor = workspace?.getCursor();
-    const block = this.getCurrentBlock(workspace);
-    if (!cursor || !block) throw new Error('precondition failure');
+    if (!cursor) throw new Error('precondition failure');
 
     // Select and focus block.
     common.setSelected(block);
@@ -231,32 +230,6 @@ export class Mover {
     info.dragger.onDrag(info.fakePointerEvent('pointermove'), info.totalDelta);
     this.scrollCurrentBlockIntoView(workspace);
     return true;
-  }
-
-  /**
-   * Get the source block for the cursor location, or undefined if no
-   * source block can be found.
-   * If the cursor is on a shadow block, walks up the tree until it finds
-   * a non-shadow block to drag.
-   *
-   * @param workspace The workspace to inspect for a cursor.
-   * @returns The source block, or undefined if no appropriate block
-   *     could be found.
-   */
-  protected getCurrentBlock(workspace: WorkspaceSvg): BlockSvg | undefined {
-    const curNode = workspace?.getCursor()?.getCurNode();
-    let block = curNode?.getSourceBlock();
-    if (!block) return undefined;
-    while (block && block.isShadow()) {
-      block = block.getParent();
-      if (!block) {
-        throw new Error(
-          'Tried to drag a shadow block with no parent. ' +
-            'Shadow blocks should always have parents.',
-        );
-      }
-    }
-    return block as BlockSvg;
   }
 
   /**

--- a/src/actions/mover.ts
+++ b/src/actions/mover.ts
@@ -6,8 +6,6 @@
 
 import type {BlockSvg, IDragger, IDragStrategy, Gesture} from 'blockly';
 import {
-  ASTNode,
-  common,
   Connection,
   registry,
   utils,
@@ -101,10 +99,6 @@ export class Mover {
   startMove(workspace: WorkspaceSvg, block: BlockSvg) {
     const cursor = workspace?.getCursor();
     if (!cursor) throw new Error('precondition failure');
-
-    // Select and focus block.
-    common.setSelected(block);
-    cursor.setCurNode(ASTNode.createBlockNode(block));
 
     this.patchWorkspace(workspace);
     this.patchDragStrategy(block);

--- a/src/actions/mover.ts
+++ b/src/actions/mover.ts
@@ -206,7 +206,7 @@ export class Mover {
       info.startLocation,
     );
 
-    if (target) {
+    if (dragStrategy.isNewBlock && target) {
       const newNode = ASTNode.createConnectionNode(target);
       if (newNode) workspace.getCursor()?.setCurNode(newNode);
     }

--- a/src/actions/mover.ts
+++ b/src/actions/mover.ts
@@ -5,12 +5,7 @@
  */
 
 import type {BlockSvg, IDragger, IDragStrategy, Gesture} from 'blockly';
-import {
-  Connection,
-  registry,
-  utils,
-  WorkspaceSvg,
-} from 'blockly';
+import {Connection, registry, utils, WorkspaceSvg} from 'blockly';
 import * as Constants from '../constants';
 import {Direction, getXYFromDirection} from '../drag_direction';
 import {KeyboardDragStrategy} from '../keyboard_drag_strategy';
@@ -94,14 +89,12 @@ export class Mover {
    *
    * @param workspace The workspace we might be moving on.
    * @param block The block to start dragging.
+   * @param isNewBlock Whether the moving block was created for this action.
    * @returns True iff a move has successfully begun.
    */
-  startMove(workspace: WorkspaceSvg, block: BlockSvg) {
-    const cursor = workspace?.getCursor();
-    if (!cursor) throw new Error('precondition failure');
-
+  startMove(workspace: WorkspaceSvg, block: BlockSvg, isNewBlock: boolean) {
     this.patchWorkspace(workspace);
-    this.patchDragStrategy(block);
+    this.patchDragStrategy(block, isNewBlock);
     // Begin dragging block.
     const DraggerClass = registry.getClassFromOptions(
       registry.Type.BLOCK_DRAGGER,
@@ -268,11 +261,14 @@ export class Mover {
    * Monkeypatch: replace the block's drag strategy and cache the old value.
    *
    * @param block The block to patch.
+   * @param isNewBlock Whether the moving block was created for this action.
    */
-  private patchDragStrategy(block: BlockSvg) {
+  private patchDragStrategy(block: BlockSvg, isNewBlock: boolean) {
     // @ts-expect-error block.dragStrategy is private.
     this.oldDragStrategy = block.dragStrategy;
-    block.setDragStrategy(new KeyboardDragStrategy(block, this.navigation));
+    block.setDragStrategy(
+      new KeyboardDragStrategy(block, this.navigation, isNewBlock),
+    );
   }
 
   /**

--- a/src/keyboard_drag_strategy.ts
+++ b/src/keyboard_drag_strategy.ts
@@ -16,7 +16,6 @@ import {
 } from 'blockly';
 import {Direction, getDirectionFromXY} from './drag_direction';
 import {showUnconstrainedMoveHint} from './hints';
-import {Navigation} from './navigation';
 
 // Copied in from core because it is not exported.
 interface ConnectionCandidate {
@@ -40,12 +39,14 @@ export class KeyboardDragStrategy extends dragging.BlockDragStrategy {
 
   private cursor: LineCursor | null;
 
+  isNewBlock: boolean;
+
   constructor(
     private block: BlockSvg,
-    private navigation: Navigation,
-    readonly isNewBlock: boolean,
+    private insertStartPoint: RenderedConnection | null,
   ) {
     super(block);
+    this.isNewBlock = !!this.insertStartPoint;
     this.cursor = block.workspace.getCursor();
   }
 
@@ -286,7 +287,7 @@ export class KeyboardDragStrategy extends dragging.BlockDragStrategy {
    */
   private createInitialCandidate(): ConnectionCandidate | null {
     // @ts-expect-error startParentConn is private.
-    const neighbour = this.startParentConn;
+    const neighbour = this.insertStartPoint ?? this.startParentConn;
     if (neighbour) {
       this.searchNode = ASTNode.createConnectionNode(neighbour);
       switch (neighbour.type) {

--- a/src/keyboard_drag_strategy.ts
+++ b/src/keyboard_drag_strategy.ts
@@ -43,6 +43,7 @@ export class KeyboardDragStrategy extends dragging.BlockDragStrategy {
   constructor(
     private block: BlockSvg,
     private navigation: Navigation,
+    private isNewBlock: boolean,
   ) {
     super(block);
     this.cursor = block.workspace.getCursor();

--- a/src/keyboard_drag_strategy.ts
+++ b/src/keyboard_drag_strategy.ts
@@ -14,6 +14,7 @@ import {
 } from 'blockly';
 import {Direction, getDirectionFromXY} from './drag_direction';
 import {showUnconstrainedMoveHint} from './hints';
+import {Navigation} from './navigation';
 
 // Copied in from core because it is not exported.
 interface ConnectionCandidate {
@@ -34,6 +35,13 @@ export class KeyboardDragStrategy extends dragging.BlockDragStrategy {
 
   /** Where a constrained movement should start when traversing the tree. */
   private searchNode: ASTNode | null = null;
+
+  constructor(
+    private block: BlockSvg,
+    private navigation: Navigation,
+  ) {
+    super(block);
+  }
 
   override startDrag(e?: PointerEvent) {
     super.startDrag(e);
@@ -63,7 +71,6 @@ export class KeyboardDragStrategy extends dragging.BlockDragStrategy {
       if (this.isConstrainedMovement()) {
         // Position the moving block down and slightly to the right of the
         // target connection.
-        // @ts-expect-error block is private.
         this.block.moveDuringDrag(
           new utils.Coordinate(neighbour.x + 10, neighbour.y + 10),
         );
@@ -225,7 +232,6 @@ export class KeyboardDragStrategy extends dragging.BlockDragStrategy {
     // @ts-expect-error connectionCandidate is private
     const candidate = this.connectionCandidate as ConnectionCandidate;
     if (!candidate || !previewer) return;
-    // @ts-expect-error block is private
     const block = this.block;
 
     // This is essentially a copy of the second half of updateConnectionPreview
@@ -276,14 +282,12 @@ export class KeyboardDragStrategy extends dragging.BlockDragStrategy {
         case ConnectionType.INPUT_VALUE:
           return {
             neighbour: neighbour,
-            // @ts-expect-error block is private.
             local: this.block.outputConnection,
             distance: 0,
           };
         case ConnectionType.NEXT_STATEMENT:
           return {
             neighbour: neighbour,
-            // @ts-expect-error block is private.
             local: this.block.previousConnection,
             distance: 0,
           };

--- a/src/keyboard_drag_strategy.ts
+++ b/src/keyboard_drag_strategy.ts
@@ -5,7 +5,6 @@
  */
 
 import {
-  common,
   ASTNode,
   BlockSvg,
   ConnectionType,
@@ -52,8 +51,6 @@ export class KeyboardDragStrategy extends dragging.BlockDragStrategy {
 
   override startDrag(e?: PointerEvent) {
     if (!this.cursor) throw new Error('precondition failure');
-    // Select and focus block.
-    common.setSelected(this.block);
     this.cursor.setCurNode(ASTNode.createBlockNode(this.block));
     super.startDrag(e);
     // Set position of the dragging block, so that it doesn't pop
@@ -166,8 +163,6 @@ export class KeyboardDragStrategy extends dragging.BlockDragStrategy {
     draggingBlock: BlockSvg,
     localConns: RenderedConnection[],
   ): ConnectionCandidate | null {
-    // TODO: Handle the case where the cursor is null, or never return null
-    // from workspace.getCursor()
     if (!this.cursor) throw new Error('precondition failure');
 
     // Helper function for traversal.

--- a/src/keyboard_drag_strategy.ts
+++ b/src/keyboard_drag_strategy.ts
@@ -43,7 +43,7 @@ export class KeyboardDragStrategy extends dragging.BlockDragStrategy {
   constructor(
     private block: BlockSvg,
     private navigation: Navigation,
-    private isNewBlock: boolean,
+    readonly isNewBlock: boolean,
   ) {
     super(block);
     this.cursor = block.workspace.getCursor();

--- a/src/navigation.ts
+++ b/src/navigation.ts
@@ -670,17 +670,17 @@ export class Navigation {
    * @returns True if the key was handled; false if something went
    *     wrong.
    */
-  tryToConnectBlock(
+  findInsertStartPoint(
     stationaryNode: Blockly.ASTNode,
     movingBlock: Blockly.BlockSvg,
-  ): boolean {
+  ): Blockly.RenderedConnection | null {
     const stationaryType = stationaryNode.getType();
     const stationaryLoc = stationaryNode.getLocation();
 
     if (stationaryNode.getType() === Blockly.ASTNode.types.FIELD) {
       const sourceBlock = stationaryNode.getSourceBlock();
-      if (!sourceBlock) return false;
-      return this.tryToConnectBlock(
+      if (!sourceBlock) return null;
+      return this.findInsertStartPoint(
         Blockly.ASTNode.createBlockNode(sourceBlock),
         movingBlock,
       );
@@ -695,8 +695,8 @@ export class Navigation {
         stationaryAsConnection.type === Blockly.ConnectionType.INPUT_VALUE
       ) {
         const sourceBlock = stationaryNode.getSourceBlock();
-        if (!sourceBlock) return false;
-        return this.tryToConnectBlock(
+        if (!sourceBlock) return null;
+        return this.findInsertStartPoint(
           Blockly.ASTNode.createBlockNode(sourceBlock),
           movingBlock,
         );
@@ -704,9 +704,9 @@ export class Navigation {
 
       // Connect the moving block to the stationary connection using
       // the most plausible connection on the moving block.
-      return this.insertBlock(movingBlock, stationaryAsConnection);
+      return stationaryAsConnection;
     } else if (stationaryType === Blockly.ASTNode.types.WORKSPACE) {
-      return this.moveBlockToWorkspace(movingBlock, stationaryNode);
+      return null;
     } else if (stationaryType === Blockly.ASTNode.types.BLOCK) {
       const stationaryBlock = stationaryLoc as Blockly.BlockSvg;
 
@@ -726,15 +726,12 @@ export class Navigation {
             connection = connection.targetBlock()!.nextConnection!;
           }
         }
-        return this.insertBlock(
-          movingBlock,
-          connection as Blockly.RenderedConnection,
-        );
+        return connection as Blockly.RenderedConnection;
       }
 
       // 2. Connect statement blocks to next connection.
       if (stationaryBlock.nextConnection && !movingBlock.outputConnection) {
-        return this.insertBlock(movingBlock, stationaryBlock.nextConnection);
+        return stationaryBlock.nextConnection;
       }
 
       // 3. Output connection. This will wrap around or displace.
@@ -745,19 +742,39 @@ export class Navigation {
           stationaryNode.getType() === Blockly.ASTNode.types.BLOCK
         ) {
           const parent = stationaryNode.getSourceBlock()?.getParent();
-          if (!parent) return false;
-          return this.tryToConnectBlock(
+          if (!parent) return null;
+          return this.findInsertStartPoint(
             Blockly.ASTNode.createBlockNode(parent),
             movingBlock,
           );
         }
-        return this.insertBlock(movingBlock, stationaryBlock.outputConnection);
+        return stationaryBlock.outputConnection;
       }
     }
-    this.warn(`Unexpected case in tryToConnectBlock ${stationaryType}.`);
-    return false;
+    this.warn(`Unexpected case in findInsertStartPoint ${stationaryType}.`);
+    return null;
   }
 
+  /**
+   * Tries to intelligently connect the blocks or connections
+   * represented by the given nodes, based on node types and locations.
+   *
+   * @param stationaryNode The first node to connect.
+   * @param movingBlock The block we're moving.
+   * @returns True if the key was handled; false if something went
+   *     wrong.
+   */
+  tryToConnectBlock(
+    stationaryNode: Blockly.ASTNode,
+    movingBlock: Blockly.BlockSvg,
+  ): boolean {
+    const destConnection = this.findInsertStartPoint(
+      stationaryNode,
+      movingBlock,
+    );
+    if (!destConnection) return false;
+    return this.insertBlock(movingBlock, destConnection);
+  }
   /**
    * Disconnects the block from its parent and moves it to the position of the
    * workspace node.

--- a/src/navigation.ts
+++ b/src/navigation.ts
@@ -770,8 +770,7 @@ export class Navigation {
    *
    * @param stationaryNode The first node to connect.
    * @param movingBlock The block we're moving.
-   * @returns True if the key was handled; false if something went
-   *     wrong.
+   * @returns True if the connection was successful, false otherwise.
    */
   tryToConnectBlock(
     stationaryNode: Blockly.ASTNode,
@@ -784,6 +783,7 @@ export class Navigation {
     if (!destConnection) return false;
     return this.insertBlock(movingBlock, destConnection);
   }
+
   /**
    * Disconnects the block from its parent and moves it to the position of the
    * workspace node.


### PR DESCRIPTION
Fixes https://github.com/google/blockly-keyboard-experimentation/issues/421

Based on https://github.com/google/blockly-keyboard-experimentation/pull/438

This is intended to be reviewed one commit at a time; each commit is small.

### Behaviour after change
- Connecting a block to the target location happens after the move starts.
  - This avoids the problem identified in #421, where blocks were unexpectedly getting popped out onto the workspace at the start of drags.
  - Aborting a drag with `Escape` deletes the newly inserted block.
  - Aborting a drag with `Escape` puts the cursor at the last target connection, (if any).
  - Undo after insertion deletes the inserted block
  - Inserting around a value block happens correctly

### Additional information

This is largely the change that @microbit-matt-hillsdon made, rebased onto main.

I had a grand plan to do all the work to find the `insertStartPoint` in `KeyboardDragStrategy` instead of having to pass it into the drag strategy. That's the reason that I started by passing the block and `isNewBlock` into the drag strategy. This idea failed because `getStationaryNode` must be called _before_ creating the new block, to avoid updating the cursor. I could pass the stationary node into the drag strategy instead of the start point, but in both cases I'm doing layer bypass to move information around. So that was a dud.
 
A few changes:
- Pass the moving block into `startMove`, instead of expecting the mover to find it by looking at the cursor.
- Make the keyboard drag strategy responsible for selecting the moving block, rather than `startMove`.
- Make paired helpers to patch/unpatch the dragger. This is mostly so that we can see what we need to clean up later.
  - (Unfortunately, as I typed this I realized that the dragger is created new for every drag, so there is no point in unpatching it at the end).
- Set the cursor correctly after aborting an insertion https://github.com/google/blockly-keyboard-experimentation/commit/4da9e6df5400737c9821eb5d4e7d0e0d95288d03
- Fix event grouping so that undo deletes the newly inserted block https://github.com/google/blockly-keyboard-experimentation/commit/565031a1e6f61cf30832097758c559bc3a5e8a34
- Handle the issue when a value block is selected https://github.com/google/blockly-keyboard-experimentation/commit/f648b464e6828e6f93beb168a3fd9f0963bde56e
