### PR TITLE
chore: fix lint warnings.

### DIFF
--- a/src/actions/action_menu.ts
+++ b/src/actions/action_menu.ts
@@ -86,8 +86,11 @@ export class ActionMenu {
     const node = cursor.getCurNode();
     if (!node) return false;
     // TODO(google/blockly#8847): Add typeguard for IContextMenu in core when this moves over
-    const location = node.getLocation() as any;
-    if (location.showContextMenu) {
+    const location = node.getLocation();
+    if (
+      'showContextMenu' in location &&
+      typeof location.showContextMenu === 'function'
+    ) {
       location.showContextMenu(menuOpenEvent);
     } else {
       console.info(`No action menu for ASTNode of type ${node.getType()}`);

--- a/src/keyboard_drag_strategy.ts
+++ b/src/keyboard_drag_strategy.ts
@@ -8,7 +8,6 @@ import {
   ASTNode,
   BlockSvg,
   ConnectionType,
-  LineCursor,
   RenderedConnection,
   dragging,
   utils,


### PR DESCRIPTION
This PR fixes two pre-existing lint warnings so that they don't clutter up the output for unrelated changes.