### PR TITLE
Fix: Finish any ongoing moves when the workspace loses focus

### DIFF
--- a/src/navigation_controller.ts
+++ b/src/navigation_controller.ts
@@ -180,6 +180,10 @@ export class NavigationController {
   }
 
   handleBlurWorkspace(workspace: Blockly.WorkspaceSvg) {
+    // Before we blur, end any ongoing move
+    if (this.mover.isMoving(workspace)) {
+      this.mover.finishMove(workspace);
+    }
     this.navigation.handleBlurWorkspace(workspace);
   }
 


### PR DESCRIPTION
Fixes #444 

Previously, if the user clicked outside of the Blockly div during a keyboard move the mover would get into a bad state that blocked interaction with Blockly. This adds a call to finish any ongoing keyboard drags when focus is lost to ensure we're in a good state.