### PR TITLE
chore: Implement initial block navigation tests.

### DIFF
--- a/test/index.ts
+++ b/test/index.ts
@@ -129,4 +129,9 @@ document.addEventListener('DOMContentLoaded', () => {
   addP5();
   createWorkspace();
   document.getElementById('run')?.addEventListener('click', runCode);
+  // Add Blockly to the global scope so that test code can access it to
+  // verify state after keypresses.
+  // eslint-disable-next-line @typescript-eslint/ban-ts-comment
+  // @ts-expect-error
+  window.Blockly = Blockly;
 });

--- a/test/loadTestBlocks.js
+++ b/test/loadTestBlocks.js
@@ -190,7 +190,7 @@ const simpleCircle = {
           'STATEMENTS': {
             'block': {
               'type': 'p5_canvas',
-              'id': 'spya_H-5F=K8+DhedX$y',
+              'id': 'create_canvas_1',
               'deletable': false,
               'movable': false,
               'fields': {
@@ -200,12 +200,12 @@ const simpleCircle = {
               'next': {
                 'block': {
                   'type': 'p5_background_color',
-                  'id': 'i/Hvi~^DYffkN/WpT_Ck',
+                  'id': 'set_background_color_1',
                   'inputs': {
                     'COLOR': {
                       'shadow': {
                         'type': 'colour_picker',
-                        'id': 'B:zpi7kg+.GF_Dutd9GL',
+                        'id': 'set_background_color_1_color',
                         'fields': {
                           'COLOUR': '#9999ff',
                         },
@@ -220,7 +220,7 @@ const simpleCircle = {
       },
       {
         'type': 'p5_draw',
-        'id': '3iI4f%2#Gmk}=OjI7(8h',
+        'id': 'draw_root',
         'x': 0,
         'y': 332,
         'deletable': false,
@@ -234,7 +234,7 @@ const simpleCircle = {
                 'COLOR': {
                   'shadow': {
                     'type': 'colour_picker',
-                    'id': 'gq(POne}j:hVw%C3t{vx',
+                    'id': 'draw_circle_1_color',
                     'fields': {
                       'COLOUR': '#ffff00',
                     },

--- a/test/webdriverio/test/basic_test.ts
+++ b/test/webdriverio/test/basic_test.ts
@@ -119,7 +119,7 @@ suite('Keyboard navigation', function () {
     );
   });
 
-  test('Right from block selects field', async function () {
+  test('Right from block selects first field', async function () {
     await focusWorkspace(this.browser);
     await this.browser.pause(PAUSE_TIME);
     await setCurrentCursorNodeById(this.browser, 'create_canvas_1');

--- a/test/webdriverio/test/basic_test.ts
+++ b/test/webdriverio/test/basic_test.ts
@@ -127,7 +127,10 @@ suite('Keyboard navigation', function () {
     await this.browser.keys(Key.ArrowRight);
     await this.browser.pause(PAUSE_TIME);
 
-    chai.assert.equal(await getCurrentCursorNodeId(this.browser), 'create_canvas_1');
+    chai.assert.equal(
+      await getCurrentCursorNodeId(this.browser),
+      'create_canvas_1',
+    );
     chai.assert.equal(
       await getCurrentCursorNodeType(this.browser),
       Blockly.ASTNode.types.FIELD,

--- a/test/webdriverio/test/basic_test.ts
+++ b/test/webdriverio/test/basic_test.ts
@@ -7,6 +7,11 @@
 import * as chai from 'chai';
 import * as Blockly from 'blockly';
 import {
+  focusWorkspace,
+  setCurrentCursorNodeById,
+  getCurrentCursorNodeFieldName,
+  getCurrentCursorNodeId,
+  getCurrentCursorNodeType,
   testSetup,
   testFileLocations,
   PAUSE_TIME,
@@ -46,5 +51,90 @@ suite('Keyboard navigation', function () {
       return Blockly.common.getSelected()?.id;
     });
     chai.assert.equal(selectedId, 'draw_circle_1');
+  });
+
+  test('Down from statement block selects next connection', async function () {
+    await focusWorkspace(this.browser);
+    await this.browser.pause(PAUSE_TIME);
+    await setCurrentCursorNodeById(this.browser, 'create_canvas_1');
+    await this.browser.pause(PAUSE_TIME);
+    await this.browser.keys(Key.ArrowDown);
+    await this.browser.pause(PAUSE_TIME);
+
+    chai.assert.equal(
+      await getCurrentCursorNodeId(this.browser),
+      'create_canvas_1',
+    );
+    chai.assert.equal(
+      await getCurrentCursorNodeType(this.browser),
+      Blockly.ASTNode.types.NEXT,
+    );
+  });
+
+  test("Up from statement block selects previous block's connection", async function () {
+    await focusWorkspace(this.browser);
+    await this.browser.pause(PAUSE_TIME);
+    await setCurrentCursorNodeById(this.browser, 'set_background_color_1');
+    await this.browser.pause(PAUSE_TIME);
+    await this.browser.keys(Key.ArrowUp);
+    await this.browser.pause(PAUSE_TIME);
+
+    chai.assert.equal(
+      await getCurrentCursorNodeId(this.browser),
+      'create_canvas_1',
+    );
+    chai.assert.equal(
+      await getCurrentCursorNodeType(this.browser),
+      Blockly.ASTNode.types.NEXT,
+    );
+  });
+
+  test('Down from parent block selects input connection', async function () {
+    await focusWorkspace(this.browser);
+    await this.browser.pause(PAUSE_TIME);
+    await setCurrentCursorNodeById(this.browser, 'p5_setup_1');
+    await this.browser.pause(PAUSE_TIME);
+    await this.browser.keys(Key.ArrowDown);
+    await this.browser.pause(PAUSE_TIME);
+
+    chai.assert.equal(await getCurrentCursorNodeId(this.browser), 'p5_setup_1');
+    chai.assert.equal(
+      await getCurrentCursorNodeType(this.browser),
+      Blockly.ASTNode.types.INPUT,
+    );
+  });
+
+  test('Up from child block selects input connection', async function () {
+    await focusWorkspace(this.browser);
+    await this.browser.pause(PAUSE_TIME);
+    await setCurrentCursorNodeById(this.browser, 'create_canvas_1');
+    await this.browser.pause(PAUSE_TIME);
+    await this.browser.keys(Key.ArrowUp);
+    await this.browser.pause(PAUSE_TIME);
+
+    chai.assert.equal(await getCurrentCursorNodeId(this.browser), 'p5_setup_1');
+    chai.assert.equal(
+      await getCurrentCursorNodeType(this.browser),
+      Blockly.ASTNode.types.INPUT,
+    );
+  });
+
+  test('Right from block selects field', async function () {
+    await focusWorkspace(this.browser);
+    await this.browser.pause(PAUSE_TIME);
+    await setCurrentCursorNodeById(this.browser, 'create_canvas_1');
+    await this.browser.pause(PAUSE_TIME);
+    await this.browser.keys(Key.ArrowRight);
+    await this.browser.pause(PAUSE_TIME);
+
+    chai.assert.equal(await getCurrentCursorNodeId(this.browser), 'create_canvas_1');
+    chai.assert.equal(
+      await getCurrentCursorNodeType(this.browser),
+      Blockly.ASTNode.types.FIELD,
+    );
+    chai.assert.equal(
+      await getCurrentCursorNodeFieldName(this.browser),
+      'WIDTH',
+    );
   });
 });

--- a/test/webdriverio/test/test_setup.ts
+++ b/test/webdriverio/test/test_setup.ts
@@ -180,9 +180,11 @@ export async function setCurrentCursorNodeById(
   return await browser.execute((blockId) => {
     const workspaceSvg = Blockly.getMainWorkspace() as Blockly.WorkspaceSvg;
     const rootBlock = workspaceSvg.getBlockById(blockId);
-    workspaceSvg
-      .getCursor()
-      ?.setCurNode(Blockly.ASTNode.createBlockNode(rootBlock!)!);
+    if (rootBlock) {
+      workspaceSvg
+        .getCursor()
+        ?.setCurNode(Blockly.ASTNode.createBlockNode(rootBlock));
+    }
   }, blockId);
 }
 

--- a/test/webdriverio/test/test_setup.ts
+++ b/test/webdriverio/test/test_setup.ts
@@ -155,6 +155,86 @@ export async function getSelectedBlockId(browser: WebdriverIO.Browser) {
   });
 }
 
+/**
+ * Clicks in the workspace to focus it.
+ *
+ * @param browser The active WebdriverIO Browser object.
+ */
+export async function focusWorkspace(browser: WebdriverIO.Browser) {
+  const workspaceElement = await browser.$(
+    '#blocklyDiv > div > svg.blocklySvg > g',
+  );
+  await workspaceElement.click();
+}
+
+/**
+ * Select a block with the given id as the current cursor node.
+ *
+ * @param browser The active WebdriverIO Browser object.
+ * @param blockId The id of the block to select.
+ */
+export async function setCurrentCursorNodeById(
+  browser: WebdriverIO.Browser,
+  blockId: string,
+) {
+  return await browser.execute((blockId) => {
+    const workspaceSvg = Blockly.getMainWorkspace() as Blockly.WorkspaceSvg;
+    const rootBlock = workspaceSvg.getBlockById(blockId);
+    workspaceSvg
+      .getCursor()
+      ?.setCurNode(Blockly.ASTNode.createBlockNode(rootBlock!)!);
+  }, blockId);
+}
+
+/**
+ * Get the ID of the block at the current cursor node.
+ *
+ * @param browser The active WebdriverIO Browser object.
+ * @returns A Promise that resolves to the ID of the current cursor node.
+ */
+export async function getCurrentCursorNodeId(
+  browser: WebdriverIO.Browser,
+): Promise<string | undefined> {
+  return await browser.execute(() => {
+    const workspaceSvg = Blockly.getMainWorkspace() as Blockly.WorkspaceSvg;
+    return workspaceSvg.getCursor()?.getCurNode()?.getSourceBlock()?.id;
+  });
+}
+
+/**
+ * Get the type of the current cursor node.
+ *
+ * @param browser The active WebdriverIO Browser object.
+ * @returns A Promise that resolves to the type of the current cursor node.
+ */
+export async function getCurrentCursorNodeType(
+  browser: WebdriverIO.Browser,
+): Promise<string | undefined> {
+  return await browser.execute(() => {
+    const workspaceSvg = Blockly.getMainWorkspace() as Blockly.WorkspaceSvg;
+    return workspaceSvg.getCursor()?.getCurNode()?.getType();
+  });
+}
+
+/**
+ * Get the field name of the current cursor node.
+ *
+ * @param browser The active WebdriverIO Browser object.
+ * @returns A Promise that resolves to the field name of the current cursor node.
+ */
+export async function getCurrentCursorNodeFieldName(
+  browser: WebdriverIO.Browser,
+): Promise<string | undefined> {
+  return await browser.execute(() => {
+    const workspaceSvg = Blockly.getMainWorkspace() as Blockly.WorkspaceSvg;
+    const field = workspaceSvg
+      .getCursor()
+      ?.getCurNode()
+      ?.getLocation() as Blockly.Field;
+    return field.name;
+  });
+}
+
 export interface ElementWithId extends WebdriverIO.Element {
   id: string;
 }


### PR DESCRIPTION
Implements several unit tests described at https://docs.google.com/document/d/1pIIX5sKEG9f_NcWDIQJJEOMM7w7pQUf8eJoT3lrAElQ involving navigating with the arrow keys when starting from a block:

* Pressing down from a statement block selects its next connection.
* Pressing up from a statement block selects the previous statement's next connection.
* Pressing down from a parent block selects its input connection.
* Pressing up from a child block selects its parent's input connection.
* Pressing right from a block selects its first field.