### PR TITLE
chore: Improve safety of flyout change listener.

### DIFF
--- a/src/navigation.ts
+++ b/src/navigation.ts
@@ -239,9 +239,9 @@ export class Navigation {
     if (!e.workspaceId) {
       return;
     }
-    const flyoutWorkspace = Blockly.Workspace.getById(e.workspaceId) as
-      | Blockly.WorkspaceSvg
-      | undefined;
+    const flyoutWorkspace = Blockly.Workspace.getById(
+      e.workspaceId,
+    ) as Blockly.WorkspaceSvg | null;
     const mainWorkspace = flyoutWorkspace?.targetWorkspace;
     if (!mainWorkspace) {
       return;

--- a/src/navigation.ts
+++ b/src/navigation.ts
@@ -239,10 +239,10 @@ export class Navigation {
     if (!e.workspaceId) {
       return;
     }
-    const flyoutWorkspace = Blockly.Workspace.getById(
-      e.workspaceId,
-    ) as Blockly.WorkspaceSvg;
-    const mainWorkspace = flyoutWorkspace.targetWorkspace;
+    const flyoutWorkspace = Blockly.Workspace.getById(e.workspaceId) as
+      | Blockly.WorkspaceSvg
+      | undefined;
+    const mainWorkspace = flyoutWorkspace?.targetWorkspace;
     if (!mainWorkspace) {
       return;
     }


### PR DESCRIPTION
This PR fixes an issue where the flyout change listener could throw if an event's workspace wasn't found. This happens when attempting to integrate with Scratch, which does a fair bit of initialization work that might result in that scenario.