### PR TITLE
Fix: Fix tests broken by changes to block positions

### DIFF
--- a/test/loadTestBlocks.js
+++ b/test/loadTestBlocks.js
@@ -182,7 +182,7 @@ const simpleCircle = {
     'blocks': [
       {
         'type': 'p5_setup',
-        'id': '5.{;T}3Qv}Awi:1M$:ut',
+        'id': 'p5_setup_1',
         'x': 0,
         'y': 75,
         'deletable': false,

--- a/test/webdriverio/test/basic_test.ts
+++ b/test/webdriverio/test/basic_test.ts
@@ -6,8 +6,13 @@
 
 import * as chai from 'chai';
 import * as Blockly from 'blockly';
-import {testSetup, testFileLocations, PAUSE_TIME} from './test_setup.js';
-import {Key} from 'webdriverio';
+import {
+  testSetup,
+  testFileLocations,
+  PAUSE_TIME,
+  getBlockElementById,
+  clickBlock,} from './test_setup.js';
+import {Key, ClickOptions,} from 'webdriverio';
 
 suite('Keyboard navigation', function () {
   // Setting timeout to unlimited as these tests take a longer time to run than most mocha test
@@ -27,13 +32,11 @@ suite('Keyboard navigation', function () {
   });
 
   test('Selected block', async function () {
-    const workspace = await this.browser.$(
-      '#blocklyDiv > div > svg.blocklySvg > g',
-    );
-    await workspace.click();
+    const block = await getBlockElementById(this.browser, 'p5_setup_1');
+    await clickBlock(this.browser, block, {button: 0} as ClickOptions);
     await this.browser.pause(PAUSE_TIME);
 
-    for (let i = 0; i < 9; i++) {
+    for (let i = 0; i < 8; i++) {
       await this.browser.keys(Key.ArrowDown);
       await this.browser.pause(PAUSE_TIME);
     }

--- a/test/webdriverio/test/basic_test.ts
+++ b/test/webdriverio/test/basic_test.ts
@@ -11,8 +11,9 @@ import {
   testFileLocations,
   PAUSE_TIME,
   getBlockElementById,
-  clickBlock,} from './test_setup.js';
-import {Key, ClickOptions,} from 'webdriverio';
+  clickBlock,
+} from './test_setup.js';
+import {Key, ClickOptions} from 'webdriverio';
 
 suite('Keyboard navigation', function () {
   // Setting timeout to unlimited as these tests take a longer time to run than most mocha test

--- a/test/webdriverio/test/clipboard_test.ts
+++ b/test/webdriverio/test/clipboard_test.ts
@@ -35,7 +35,7 @@ suite('Clipboard test', function () {
 
   test('Copy and paste while block selected', async function () {
     const block = await getBlockElementById(this.browser, 'draw_circle_1');
-    await clickBlock(this.browser, block, {button: 1} as ClickOptions);
+    await clickBlock(this.browser, block, {button: 0} as ClickOptions);
 
     // Copy and paste
     await this.browser.keys([Key.Ctrl, 'c']);
@@ -55,7 +55,7 @@ suite('Clipboard test', function () {
 
   test('Cut and paste while block selected', async function () {
     const block = await getBlockElementById(this.browser, 'draw_circle_1');
-    await clickBlock(this.browser, block, {button: 1} as ClickOptions);
+    await clickBlock(this.browser, block, {button: 0} as ClickOptions);
 
     // Cut and paste
     await this.browser.keys([Key.Ctrl, 'x']);

--- a/test/webdriverio/test/test_setup.ts
+++ b/test/webdriverio/test/test_setup.ts
@@ -201,8 +201,11 @@ export async function clickBlock(
   // In the browser context, find the element that we want and give it a findable ID.
   await browser.execute(
     (blockId, newElemId) => {
-      const block = Blockly.getMainWorkspace().getBlockById(blockId);
+      const workspaceSvg = Blockly.getMainWorkspace() as Blockly.WorkspaceSvg;
+      const block = workspaceSvg.getBlockById(blockId);
       if (block) {
+        // Ensure the block we want to click is within the viewport.
+        workspaceSvg.scrollBoundsIntoView(block.getBoundingRectangleWithoutChildren());
         for (const input of block.inputList) {
           for (const field of input.fieldRow) {
             if (field instanceof Blockly.FieldLabel) {
@@ -214,9 +217,9 @@ export async function clickBlock(
             }
           }
         }
+        // No label field found. Fall back to the block's SVG root.
+        block.getSvgRoot().id = findableId;
       }
-      // No label field found. Fall back to the block's SVG root.
-      (block as Blockly.BlockSvg).getSvgRoot().id = findableId;
     },
     block.id,
     findableId,

--- a/test/webdriverio/test/test_setup.ts
+++ b/test/webdriverio/test/test_setup.ts
@@ -205,7 +205,9 @@ export async function clickBlock(
       const block = workspaceSvg.getBlockById(blockId);
       if (block) {
         // Ensure the block we want to click is within the viewport.
-        workspaceSvg.scrollBoundsIntoView(block.getBoundingRectangleWithoutChildren());
+        workspaceSvg.scrollBoundsIntoView(
+          block.getBoundingRectangleWithoutChildren(),
+        );
         for (const input of block.inputList) {
           for (const field of input.fieldRow) {
             if (field instanceof Blockly.FieldLabel) {


### PR DESCRIPTION
Fixes #468 

It appears the blocks used in the test shifted positions slightly leading to two issues with the tests.

1. Generating a click event on the workspace was landing on one of the blocks in the stack, which broke an assumption that focus would be on the workspace. This was fixed by clicking a specific block instead.
2. Clicking on a block that was slightly out of the window's viewport was generating a click event that the browser ignored. This was fixed by scrolling the block into view before trying to click it.

This PR also has a couple minor non-functional tweaks for correctness:

1. Changes to using 0 instead of 1 for the mouse button options (left button instead of middle).
2. Moves the fallback to getting the block's root svg inside the check that the block exists.
