### PR TITLE
fix: remove unneeded ts-expect-error directives

### DIFF
--- a/src/keyboard_drag_strategy.ts
+++ b/src/keyboard_drag_strategy.ts
@@ -61,7 +61,6 @@ export class KeyboardDragStrategy extends dragging.BlockDragStrategy {
     // @ts-expect-error connectionCandidate is private.
     this.connectionCandidate = this.createInitialCandidate();
     this.forceShowPreview();
-    // @ts-expect-error block is private.
     this.block.addIcon(new MoveIcon(this.block));
   }
 
@@ -100,7 +99,6 @@ export class KeyboardDragStrategy extends dragging.BlockDragStrategy {
 
   override endDrag(e?: PointerEvent) {
     super.endDrag(e);
-    // @ts-expect-error block is private.
     this.block.removeIcon(MoveIcon.type);
   }
 


### PR DESCRIPTION
Resolves compiler errors.

`block` is still `private` on the base class; the only reason the `expect-error` directives are unneeded is because there's an `expect-error` at the top level of the class that blocks issues with redeclaring a `private` property.

Followup on #472 