### PR TITLE
chore: Remove now-obsolete call to `connectionPreviewer.hidePreview`

### DIFF
--- a/src/actions/mover.ts
+++ b/src/actions/mover.ts
@@ -177,10 +177,6 @@ export class Mover {
       dragStrategy.isNewBlock,
     );
 
-    // Explicitly call `hidePreview` because it is not called in revertDrag.
-    // @ts-expect-error Access to private property connectionPreviewer.
-    dragStrategy.connectionPreviewer.hidePreview();
-
     // Save the position so we can put the cursor in a reasonable spot.
     // @ts-expect-error Access to private property connectionCandidate.
     const target = dragStrategy.connectionCandidate?.neighbour;

--- a/src/keyboard_drag_strategy.ts
+++ b/src/keyboard_drag_strategy.ts
@@ -61,7 +61,6 @@ export class KeyboardDragStrategy extends dragging.BlockDragStrategy {
     // @ts-expect-error connectionCandidate is private.
     this.connectionCandidate = this.createInitialCandidate();
     this.forceShowPreview();
-    // @ts-expect-error block is private.
     this.block.addIcon(new MoveIcon(this.block));
   }
 
@@ -100,7 +99,6 @@ export class KeyboardDragStrategy extends dragging.BlockDragStrategy {
 
   override endDrag(e?: PointerEvent) {
     super.endDrag(e);
-    // @ts-expect-error block is private.
     this.block.removeIcon(MoveIcon.type);
   }
 


### PR DESCRIPTION
This is no longer needed after google/blockly#8934.

Fixes google/blockly#8853.
