### PR TITLE
fix: remove calls to cursor.hide

### DIFF
--- a/src/navigation.ts
+++ b/src/navigation.ts
@@ -885,10 +885,6 @@ export class Navigation {
       workspace.keyboardAccessibilityMode
     ) {
       workspace.keyboardAccessibilityMode = false;
-      workspace.getCursor()?.hide();
-      if (this.getFlyoutCursor(workspace)) {
-        this.getFlyoutCursor(workspace)?.hide();
-      }
     }
   }
 


### PR DESCRIPTION
Part of https://github.com/google/blockly/issues/8962

Related to https://github.com/google/blockly/pull/8924

The keyboard navigation plugin currently explicitly turns keyboard mode on and off, and that includes explicitly hiding the cursor. After https://github.com/google/blockly/pull/8924 we will use CSS to control whether active and passive focus are visible, and updating that CSS will be done by the new `KeyboardNavigationController`.