### PR TITLE
feat: delegate clipboard actions to core

### DIFF
--- a/src/actions/clipboard.ts
+++ b/src/actions/clipboard.ts
@@ -238,8 +238,10 @@ export class Clipboard {
         return 'disabled';
       },
       callback: (scope, menuOpenEvent) => {
-        const ws = scope.block?.workspace;
-        if (!ws) return;
+        if (!isCopyable(scope.focusedNode)) return false;
+        const ws = scope.focusedNode.workspace;
+        if (!(ws instanceof WorkspaceSvg)) return false;
+
         return this.copyCallback(ws, menuOpenEvent, undefined, scope);
       },
       id: 'blockCopyFromContextMenu',

--- a/src/actions/clipboard.ts
+++ b/src/actions/clipboard.ts
@@ -168,7 +168,9 @@ export class Clipboard {
   private cutCallback(
     workspace: WorkspaceSvg,
     e: Event,
-    shortcut: ShortcutRegistry.KeyboardShortcut | undefined,
+    shortcut: ShortcutRegistry.KeyboardShortcut = {
+      name: Constants.SHORTCUT_NAMES.CUT,
+    },
     scope: ContextMenuRegistry.Scope,
   ) {
     const didCut =
@@ -260,7 +262,9 @@ export class Clipboard {
   private copyCallback(
     workspace: WorkspaceSvg,
     e: Event,
-    shortcut: ShortcutRegistry.KeyboardShortcut | undefined,
+    shortcut: ShortcutRegistry.KeyboardShortcut = {
+      name: Constants.SHORTCUT_NAMES.CUT,
+    },
     scope: ContextMenuRegistry.Scope,
   ) {
     const didCopy =
@@ -392,10 +396,14 @@ export class Clipboard {
   private pasteCallback(
     workspace: WorkspaceSvg,
     e: Event,
-    shortcut: ShortcutRegistry.KeyboardShortcut | undefined,
+    shortcut: ShortcutRegistry.KeyboardShortcut = {
+      name: Constants.SHORTCUT_NAMES.CUT,
+    },
     scope: ContextMenuRegistry.Scope,
   ) {
-    const didPaste = !!this.oldPasteCallback && this.oldPasteCallback();
+    const didPaste =
+      !!this.oldPasteCallback &&
+      this.oldPasteCallback(workspace, e, shortcut, scope);
 
     // Clear the paste hints regardless of whether something was pasted
     // Some implementations of paste are async and we should clear the hint

--- a/src/actions/clipboard.ts
+++ b/src/actions/clipboard.ts
@@ -105,7 +105,7 @@ export class Clipboard {
       callback: this.cutCallback.bind(this),
       // The registry gives back keycodes as an object instead of an array
       // See https://github.com/google/blockly/issues/9008
-      keyCodes: Object.values(oldCutShortcut.keyCodes ?? []),
+      keyCodes: oldCutShortcut.keyCodes,
       allowCollision: false,
     };
 
@@ -122,25 +122,12 @@ export class Clipboard {
    */
   private registerCutContextMenuAction() {
     const cutAction: ContextMenuRegistry.RegistryItem = {
-      displayText: (scope) => Msg['CUT_SHORTCUT'].replace('%1', getShortActionShortcut(Constants.SHORTCUT_NAMES.CUT)),
-      preconditionFn: (scope) => {
-        const focused = scope.focusedNode;
-
-        if (!focused || !isCopyable(focused)) return 'hidden';
-
-        const workspace = focused.workspace;
-        if (
-          !workspace.isReadOnly() &&
-          isDeletable(focused) &&
-          focused.isDeletable() &&
-          isDraggable(focused) &&
-          focused.isMovable() &&
-          !focused.workspace.isFlyout
-        )
-          return 'enabled';
-
-        return 'disabled';
-      },
+      displayText: (scope) =>
+        Msg['CUT_SHORTCUT'].replace(
+          '%1',
+          getShortActionShortcut(Constants.SHORTCUT_NAMES.CUT),
+        ),
+      preconditionFn: (scope) => this.cutCopyPrecondition(scope),
       callback: (scope, menuOpenEvent) => {
         if (!isCopyable(scope.focusedNode)) return false;
         const ws = scope.focusedNode.workspace;
@@ -153,6 +140,34 @@ export class Clipboard {
     };
 
     ContextMenuRegistry.registry.register(cutAction);
+  }
+
+  /**
+   * Precondition for cut and copy context menus. These are similar to the
+   * ones in core but they don't check if a gesture is in progress,
+   * because a gesture will always be in progress if the context menu
+   * is open.
+   *
+   * @param scope scope on which the menu was opened.
+   * @returns 'enabled', 'disabled', or 'hidden' as appropriate
+   */
+  private cutCopyPrecondition(scope: ContextMenuRegistry.Scope): string {
+    const focused = scope.focusedNode;
+
+    if (!focused || !isCopyable(focused)) return 'hidden';
+
+    const workspace = focused.workspace;
+    if (
+      !workspace.isReadOnly() &&
+      isDeletable(focused) &&
+      focused.isDeletable() &&
+      isDraggable(focused) &&
+      focused.isMovable() &&
+      !focused.workspace.isFlyout
+    )
+      return 'enabled';
+
+    return 'disabled';
   }
 
   /**
@@ -200,7 +215,7 @@ export class Clipboard {
       callback: this.copyCallback.bind(this),
       // The registry gives back keycodes as an object instead of an array
       // See https://github.com/google/blockly/issues/9008
-      keyCodes: Object.values(oldCopyShortcut.keyCodes ?? []),
+      keyCodes: oldCopyShortcut.keyCodes,
       allowCollision: false,
     };
 
@@ -218,25 +233,11 @@ export class Clipboard {
   private registerCopyContextMenuAction() {
     const copyAction: ContextMenuRegistry.RegistryItem = {
       displayText: (scope) =>
-        Msg['COPY_SHORTCUT'].replace('%1', getShortActionShortcut(Constants.SHORTCUT_NAMES.COPY)),
-      preconditionFn: (scope) => {
-        const focused = scope.focusedNode;
-
-        if (!focused || !isCopyable(focused)) return 'hidden';
-
-        const workspace = focused.workspace;
-        if (
-          !workspace.isReadOnly() &&
-          isDeletable(focused) &&
-          focused.isDeletable() &&
-          isDraggable(focused) &&
-          focused.isMovable() &&
-          !focused.workspace.isFlyout
-        )
-          return 'enabled';
-
-        return 'disabled';
-      },
+        Msg['COPY_SHORTCUT'].replace(
+          '%1',
+          getShortActionShortcut(Constants.SHORTCUT_NAMES.COPY),
+        ),
+      preconditionFn: (scope) => this.cutCopyPrecondition(scope),
       callback: (scope, menuOpenEvent) => {
         if (!isCopyable(scope.focusedNode)) return false;
         const ws = scope.focusedNode.workspace;
@@ -314,7 +315,7 @@ export class Clipboard {
       },
       // The registry gives back keycodes as an object instead of an array
       // See https://github.com/google/blockly/issues/9008
-      keyCodes: Object.values(oldPasteShortcut.keyCodes ?? []),
+      keyCodes: oldPasteShortcut.keyCodes,
       allowCollision: false,
     };
 
@@ -332,7 +333,10 @@ export class Clipboard {
   private registerPasteContextMenuAction() {
     const pasteAction: ContextMenuRegistry.RegistryItem = {
       displayText: (scope) =>
-        Msg['PASTE_SHORTCUT'].replace('%1', getShortActionShortcut(Constants.SHORTCUT_NAMES.PASTE)),
+        Msg['PASTE_SHORTCUT'].replace(
+          '%1',
+          getShortActionShortcut(Constants.SHORTCUT_NAMES.PASTE),
+        ),
       preconditionFn: (scope: ContextMenuRegistry.Scope) => {
         const workspace = this.getPasteWorkspace(scope);
         if (!workspace) return 'hidden';

--- a/src/hints.ts
+++ b/src/hints.ts
@@ -68,8 +68,8 @@ export function clearMoveHints(workspace: WorkspaceSvg) {
  */
 export function showCopiedHint(workspace: WorkspaceSvg) {
   Toast.show(workspace, {
-    message: `Copied. Press ${getShortActionShortcut('paste')} to paste.`,
-    duration: 7000,
+    message: `Copied. Press ${getShortActionShortcut(SHORTCUT_NAMES.PASTE)} to paste.`,
+    duration: 7,
     id: copiedHintId,
   });
 }
@@ -81,8 +81,8 @@ export function showCopiedHint(workspace: WorkspaceSvg) {
  */
 export function showCutHint(workspace: WorkspaceSvg) {
   Toast.show(workspace, {
-    message: `Cut. Press ${getShortActionShortcut('paste')} to paste.`,
-    duration: 7000,
+    message: `Cut. Press ${getShortActionShortcut(SHORTCUT_NAMES.PASTE)} to paste.`,
+    duration: 7,
     id: cutHintId,
   });
 }

--- a/test/webdriverio/test/delete_test.ts
+++ b/test/webdriverio/test/delete_test.ts
@@ -7,9 +7,7 @@
 import * as chai from 'chai';
 import {
   blockIsPresent,
-  currentFocusIsMainWorkspace,
   setCurrentCursorNodeById,
-  getCurrentFocusNodeId,
   getCurrentFocusedBlockId,
   getFocusedBlockType,
   moveToToolboxCategory,
@@ -51,7 +49,7 @@ suite('Deleting Blocks', function () {
       .to.include('controls_if_1');
   });
 
-  test('Cutting block selects previous connection', async function () {
+  test('Cutting block selects parent block', async function () {
     await tabNavigateToWorkspace(this.browser);
     await this.browser.pause(PAUSE_TIME);
     await setCurrentCursorNodeById(this.browser, 'controls_if_2');
@@ -69,8 +67,8 @@ suite('Deleting Blocks', function () {
       .equal(false);
 
     chai
-      .expect(await getCurrentFocusNodeId(this.browser))
-      .to.include('controls_if_1_connection_');
+      .expect(await getCurrentFocusedBlockId(this.browser))
+      .to.include('controls_if_1');
   });
 
   test('Deleting block also deletes children and inputs', async function () {
@@ -139,7 +137,7 @@ suite('Deleting Blocks', function () {
       .to.include('controls_if_2');
   });
 
-  test('Cutting inline input selects parent connection', async function () {
+  test('Cutting inline input selects parent block', async function () {
     await tabNavigateToWorkspace(this.browser);
     await this.browser.pause(PAUSE_TIME);
     await setCurrentCursorNodeById(this.browser, 'logic_boolean_1');
@@ -157,8 +155,8 @@ suite('Deleting Blocks', function () {
       .equal(false);
 
     chai
-      .expect(await getCurrentFocusNodeId(this.browser))
-      .to.include('controls_if_2_connection_');
+      .expect(await getCurrentFocusedBlockId(this.browser))
+      .to.include('controls_if_2');
   });
 
   test('Deleting stranded block selects top block', async function () {
@@ -194,7 +192,7 @@ suite('Deleting Blocks', function () {
     );
   });
 
-  test('Cutting stranded block selects workspace', async function () {
+  test('Cutting stranded block selects top block', async function () {
     await tabNavigateToWorkspace(this.browser);
     await this.browser.pause(PAUSE_TIME);
 
@@ -216,6 +214,9 @@ suite('Deleting Blocks', function () {
     await this.browser.keys([Key.Ctrl, 'x']);
     await this.browser.pause(PAUSE_TIME);
 
-    chai.expect(await currentFocusIsMainWorkspace(this.browser)).equal(true);
+    chai.assert.equal(
+      await getCurrentFocusedBlockId(this.browser),
+      'p5_setup_1',
+    );
   });
 });


### PR DESCRIPTION
Works on #488 
Fixes #237 
Fixes #500

This PR removes all of the custom copy/paste logic and simply delegates the responsibility for copy/pasting to core, or the currently registered copy/paste functions. This simplifies the plugin, and makes it possible to use the cross-tab-copy-paste plugin as long as that plugin registers its replacement shortcuts under the same shortcut names that core uses.
The only custom logic for keyboard shortcuts is that we show/hide toasts on clipboard actions, and we paste in the main workspace instead of flyout workspaces.

We add the context menu options but those also largely use the implementations from core. We can't totally reuse the preconditionFn from core for the keyboard shortcuts, because we can't use the check if a gesture is in progress (it always is during a right click/context menu being open). We can also handle additional places of showing these options in the context menu, such as showing paste on the workspace's menu and not just a block's.

Also note that I decreased the toast time from almost 2 hours (7000 seconds) to 7 seconds.

Adopting this approach would mean that any edge cases around what to do when you try to copy a connection for example would need to be added in core, not in the plugin.

One downside to this approach is that the "paste" option appears enabled even if you have never copied anything. The core implementation does not expose this information so we can't check it, and we can't use the precondition from the keyboard shortcut because that checks if there's a gesture in progress. However, it may be possible to expose the clipboard data from core. Doing so would probably be semi-ugly (I sort of hate that the clipboard data is just held in the keyboard shortcut items file instead of being its own class).

And finally, note that until https://github.com/google/blockly/issues/8793 is fixed, this PR doesn't handle cut behavior correctly. After cutting a block, nothing is focused, so you have to click the workspace again before you can paste or do something else with the workspace.

@microbit-matt-hillsdon I would appreciate if you could take a look and let me know if you think this approach would work with the makecode special pasting logic.

