### PR TITLE
fix: make sure initial candidate is valid

### DIFF
--- a/src/keyboard_drag_strategy.ts
+++ b/src/keyboard_drag_strategy.ts
@@ -297,18 +297,26 @@ export class KeyboardDragStrategy extends dragging.BlockDragStrategy {
     if (neighbour) {
       this.searchNode = neighbour;
       switch (neighbour.type) {
-        case ConnectionType.INPUT_VALUE:
-          return {
-            neighbour: neighbour,
-            local: this.block.outputConnection,
-            distance: 0,
-          };
-        case ConnectionType.NEXT_STATEMENT:
-          return {
-            neighbour: neighbour,
-            local: this.block.previousConnection,
-            distance: 0,
-          };
+        case ConnectionType.INPUT_VALUE: {
+          if (this.block.outputConnection) {
+            return {
+              neighbour: neighbour,
+              local: this.block.outputConnection,
+              distance: 0,
+            };
+          }
+          break;
+        }
+        case ConnectionType.NEXT_STATEMENT: {
+          if (this.block.previousConnection) {
+            return {
+              neighbour: neighbour,
+              local: this.block.previousConnection,
+              distance: 0,
+            };
+          }
+          break;
+        }
       }
     }
     return null;

--- a/test/webdriverio/test/insert_test.ts
+++ b/test/webdriverio/test/insert_test.ts
@@ -1,0 +1,62 @@
+/**
+ * @license
+ * Copyright 2025 Google LLC
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import * as chai from 'chai';
+import {Browser, Key} from 'webdriverio';
+import {
+  getFocusedBlockType,
+  PAUSE_TIME,
+  setCurrentCursorNodeById,
+  tabNavigateToWorkspace,
+  testFileLocations,
+  testSetup,
+} from './test_setup.js';
+
+suite.only('Insert test', function () {
+  // Setting timeout to unlimited as these tests take longer time to run
+  this.timeout(0);
+
+  // Clear the workspace and load start blocks
+  setup(async function () {
+    this.browser = await testSetup(testFileLocations.BASE);
+    await this.browser.pause(PAUSE_TIME);
+  });
+
+  test('Insert C-shaped block with statement block selected', async function () {
+    // Navigate to draw_circle_1.
+    await tabNavigateToWorkspace(this.browser);
+    await setCurrentCursorNodeById(this.browser, 'draw_circle_1');
+
+    await moveToToolboxCategory(this.browser, 'Functions');
+    // Move to flyout.
+    await this.browser.keys(Key.ArrowRight);
+    // Select Function block.
+    await this.browser.keys(Key.Enter);
+    // Confirm move.
+    await this.browser.keys(Key.Enter);
+
+    chai.assert.equal(
+      'procedures_defnoreturn',
+      await getFocusedBlockType(this.browser),
+    );
+  });
+});
+
+async function moveToToolboxCategory(browser: Browser, category: string) {
+  await browser.keys('t');
+  const categoryIndex = await browser.execute((category) => {
+    const all = Array.from(
+      document.querySelectorAll('.blocklyToolboxCategoryLabel'),
+    ).map((node) => node.textContent);
+    return all.indexOf(category);
+  }, category);
+  if (categoryIndex < 0) {
+    throw new Error(`No category found: ${category}`);
+  }
+  if (categoryIndex > 0) {
+    await browser.keys(Key.ArrowDown.repeat(categoryIndex));
+  }
+}

--- a/test/webdriverio/test/test_setup.ts
+++ b/test/webdriverio/test/test_setup.ts
@@ -232,6 +232,24 @@ export async function getCurrentFocusNodeId(
 }
 
 /**
+ * Get the block type of the current focused node. Assumes the current node
+ * is a block.
+ *
+ * @param browser The active WebdriverIO Browser object.
+ * @returns A Promise that resolves to the block type of the current cursor
+ * node.
+ */
+export async function getFocusedBlockType(
+  browser: WebdriverIO.Browser,
+): Promise<string | undefined> {
+  return await browser.execute(() => {
+    const block = Blockly.getFocusManager().getFocusedNode() as
+      | Blockly.BlockSvg
+      | undefined;
+    return block?.type;
+  });
+}
+/**
  * Get the connection type of the current focused node. Assumes the current node
  * is a connection.
  *


### PR DESCRIPTION
Previously when inserting a C-shape block with a statement block selected the
code assumed the C-shaped block had a previous connection. The preview code
then failed to preview the nonsense connection.

Adds an insert test for this scenario only.

Fixes https://github.com/google/blockly-keyboard-experimentation/issues/476