### PR TITLE
chore: remove last use of ASTNode in tests

### DIFF
--- a/test/webdriverio/test/basic_test.ts
+++ b/test/webdriverio/test/basic_test.ts
@@ -275,8 +275,8 @@ suite('Keyboard navigation on Blocks', function () {
       'text_print_1',
     );
     chai.assert.equal(
-      await getCurrentFocusNodeId(this.browser),
-      Blockly.ASTNode.types.NEXT,
+      await getFocusedConnectionType(this.browser),
+      Blockly.ConnectionType.NEXT_STATEMENT,
     );
   });
 });


### PR DESCRIPTION
Part of fixing https://github.com/google/blockly/issues/9010

Removes the last use of ASTNode in tests. This line is in a skipped test and I believe was using the wrong getter function--I compared to the test above and changed from `getCurrentFocusNodeId` to `getFocusedConnectionType`. Note that the previous assertion already checks the value of `getCurrentFocusNodeId`.
