### PR TITLE
chore: Fix and enable field navigation unit tests.

### DIFF
--- a/test/webdriverio/test/basic_test.ts
+++ b/test/webdriverio/test/basic_test.ts
@@ -256,8 +256,7 @@ suite('Keyboard navigation on Blocks', function () {
       .to.include('controls_repeat_ext_1_connection_');
   });
 
-  // This test fails because the curly quote icons get selected.
-  test.skip('Right from text block selects input and skips curly quote icons', async function () {
+  test('Right from text block selects shadow block then field', async function () {
     await tabNavigateToWorkspace(this.browser);
     await this.browser.pause(PAUSE_TIME);
     await setCurrentCursorNodeById(this.browser, 'text_print_1');
@@ -270,10 +269,16 @@ suite('Keyboard navigation on Blocks', function () {
     await this.browser.keys(Key.ArrowRight);
     await this.browser.pause(PAUSE_TIME);
 
-    chai.assert.equal(
-      await getCurrentFocusNodeId(this.browser),
-      'text_print_1',
-    );
+    chai
+      .expect(await getCurrentFocusNodeId(this.browser))
+      .to.include('text_1_field_');
+
+    await this.browser.keys(Key.ArrowRight);
+    await this.browser.pause(PAUSE_TIME);
+
+    chai
+      .expect(await getCurrentFocusNodeId(this.browser))
+      .to.include('text_print_1_connection_');
     chai.assert.equal(
       await getFocusedConnectionType(this.browser),
       Blockly.ConnectionType.NEXT_STATEMENT,
@@ -282,7 +287,7 @@ suite('Keyboard navigation on Blocks', function () {
 });
 
 // TODO(#499) These tests fail because focusing on a field doesn't update the cursor
-suite.skip('Keyboard navigation on Fields', function () {
+suite('Keyboard navigation on Fields', function () {
   // Setting timeout to unlimited as these tests take a longer time to run than most mocha test
   this.timeout(0);
 
@@ -337,7 +342,7 @@ suite.skip('Keyboard navigation on Fields', function () {
       .expect(await getCurrentFocusNodeId(this.browser))
       .to.include('p5_canvas_1_field_');
 
-    chai.assert.equal(await getFocusedFieldName(this.browser), 'HIGHT');
+    chai.assert.equal(await getFocusedFieldName(this.browser), 'HEIGHT');
   });
 
   test('Left from second field selects first field', async function () {
@@ -371,10 +376,9 @@ suite.skip('Keyboard navigation on Fields', function () {
     await this.browser.keys(Key.ArrowRight);
     await this.browser.pause(PAUSE_TIME);
 
-    chai.assert.containSubset(
-      await getCurrentFocusNodeId(this.browser),
-      'p5_canvas_1_connection_',
-    );
+    chai
+      .expect(await getCurrentFocusNodeId(this.browser))
+      .to.include('p5_canvas_1_connection_');
   });
 
   test("Down from field selects block's next connection", async function () {
@@ -417,7 +421,7 @@ suite.skip('Keyboard navigation on Fields', function () {
 
     chai.assert.equal(
       await getFocusedConnectionType(this.browser),
-      Blockly.ConnectionType.INPUT_VALUE,
+      Blockly.ConnectionType.NEXT_STATEMENT,
     );
   });
 });

--- a/test/webdriverio/test/insert_test.ts
+++ b/test/webdriverio/test/insert_test.ts
@@ -15,7 +15,7 @@ import {
   testSetup,
 } from './test_setup.js';
 
-suite.only('Insert test', function () {
+suite('Insert test', function () {
   // Setting timeout to unlimited as these tests take longer time to run
   this.timeout(0);
 

--- a/test/webdriverio/test/test_setup.ts
+++ b/test/webdriverio/test/test_setup.ts
@@ -208,7 +208,11 @@ export async function setCurrentCursorNodeByIdAndFieldName(
       const block = workspaceSvg.getBlockById(blockId);
       const field = block?.getField(fieldName);
       if (field) {
-        field.getFocusableElement()?.focus();
+        // TODO: Stop referencing getCursor() and use focus() instead.
+        // getCursor().setCurNode() calls Marker.setCurNode(), but focus() does
+        // not accomplish the same goal yet.
+        workspaceSvg.getCursor()?.setCurNode(field);
+        // field.getFocusableElement()?.focus();
       }
     },
     blockId,


### PR DESCRIPTION
Many test methods had been disabled. In fact, only one of them was actually running (because it called `suite.only()`). I re-enabled most of the tests, adapted them to the current behavior, and temporarily reverted one line in `test_setup.ts` to `callgetCursor()?.setCurNode(field)` instead of `field.getFocusableElement()?.focus()` because the latter doesn't work yet and I figure it would be more useful for the tests to be functional and enabled.

EDIT: Whoops, it looks like existing code in this repo was broken by https://github.com/google/blockly/pull/9016 so github's automated test run fails for reasons that aren't related to my changes.