### PR TITLE
fix: make insert compile against rc/v12.0.0

### DIFF
--- a/src/actions/insert.ts
+++ b/src/actions/insert.ts
@@ -88,9 +88,13 @@ export class InsertAction {
         return this.insertPrecondition(ws) ? 'enabled' : 'hidden';
       },
       callback: (scope: ContextMenuRegistry.Scope) => {
-        const ws =
-          scope.focusedNode?.workspace ??
-          (scope.focusedNode?.getSourceBlock().workspace as WorkspaceSvg);
+        let block;
+        if (scope.focusedNode instanceof Blockly.Block) {
+          block = scope.focusedNode;
+        } else if (scope.focusedNode instanceof Blockly.Connection) {
+          block = scope.focusedNode.getSourceBlock();
+        }
+        const ws = block?.workspace as WorkspaceSvg | null;
         if (!ws) return false;
         this.insertCallback(ws);
       },


### PR DESCRIPTION
This uses the same logic as the precondition above and similar callbacks in clipboard.ts.

It builds against beta.5 and rc/v12.0.0 whereas the previous code relied on an `any` that was removed in https://github.com/google/blockly/pull/9016 (so only builds against beta.5).

I'm a bit hazy on whether the plugin is targeting beta.5 or a future release (I suspect the latter) but this change feels like progress either way.