### PR TITLE
feat: active/passive focus styling

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -109,8 +109,14 @@ export class KeyboardNavigation {
     const metrics = this.workspace.getMetrics();
     ring.setAttribute('x', (metrics.absoluteLeft + inset).toString());
     ring.setAttribute('y', (metrics.absoluteTop + inset).toString());
-    ring.setAttribute('width', (metrics.viewWidth - inset * 2).toString());
-    ring.setAttribute('height', (metrics.svgHeight - inset * 2).toString());
+    ring.setAttribute(
+      'width',
+      Math.max(0, metrics.viewWidth - inset * 2).toString(),
+    );
+    ring.setAttribute(
+      'height',
+      Math.max(0, metrics.svgHeight - inset * 2).toString(),
+    );
   }
 
   /**

--- a/src/index.ts
+++ b/src/index.ts
@@ -7,6 +7,7 @@
 import * as Blockly from 'blockly/core';
 import {NavigationController} from './navigation_controller';
 import {enableBlocksOnDrag} from './disabled_blocks';
+import {InputModeTracker} from './input_mode_tracker';
 
 /** Plugin for keyboard navigation. */
 export class KeyboardNavigation {
@@ -26,6 +27,27 @@ export class KeyboardNavigation {
   private originalTheme: Blockly.Theme;
 
   /**
+   * Input mode tracking.
+   */
+  private inputModeTracker: InputModeTracker;
+
+  /**
+   * Focus ring in the workspace.
+   */
+  private workspaceFocusRing: Element | null = null;
+  /**
+   * Selection ring inside the workspace.
+   */
+  private workspaceSelectionRing: Element | null = null;
+
+  /**
+   * Used to restore monkey patch.
+   */
+  private oldWorkspaceResize:
+    | InstanceType<typeof Blockly.WorkspaceSvg>['resize']
+    | null = null;
+
+  /**
    * Constructs the keyboard navigation.
    *
    * @param workspace The workspace that the plugin will be added to.
@@ -37,6 +59,7 @@ export class KeyboardNavigation {
     this.navigationController.init();
     this.navigationController.addWorkspace(workspace);
     this.navigationController.enable(workspace);
+    this.inputModeTracker = new InputModeTracker(workspace);
 
     this.originalTheme = workspace.getTheme();
     this.setGlowTheme();
@@ -57,18 +80,56 @@ export class KeyboardNavigation {
         workspace.getParentSvg(),
       );
     }
+
+    this.oldWorkspaceResize = workspace.resize;
+    workspace.resize = () => {
+      this.oldWorkspaceResize?.call(this.workspace);
+      this.resizeWorkspaceRings();
+    };
+    this.workspaceSelectionRing = Blockly.utils.dom.createSvgElement('rect', {
+      fill: 'none',
+      class: 'blocklyWorkspaceSelectionRing',
+    });
+    workspace.getSvgGroup().appendChild(this.workspaceSelectionRing);
+    this.workspaceFocusRing = Blockly.utils.dom.createSvgElement('rect', {
+      fill: 'none',
+      class: 'blocklyWorkspaceFocusRing',
+    });
+    workspace.getSvgGroup().appendChild(this.workspaceFocusRing);
+    this.resizeWorkspaceRings();
+  }
+
+  private resizeWorkspaceRings() {
+    if (!this.workspaceFocusRing || !this.workspaceSelectionRing) return;
+    this.resizeFocusRingInternal(this.workspaceSelectionRing, 5);
+    this.resizeFocusRingInternal(this.workspaceFocusRing, 0);
+  }
+
+  private resizeFocusRingInternal(ring: Element, inset: number) {
+    const metrics = this.workspace.getMetrics();
+    ring.setAttribute('x', (metrics.absoluteLeft + inset).toString());
+    ring.setAttribute('y', (metrics.absoluteTop + inset).toString());
+    ring.setAttribute('width', (metrics.viewWidth - inset * 2).toString());
+    ring.setAttribute('height', (metrics.svgHeight - inset * 2).toString());
   }
 
   /**
    * Disables keyboard navigation for this navigator's workspace.
    */
   dispose() {
+    this.workspaceFocusRing?.remove();
+    this.workspaceSelectionRing?.remove();
+    if (this.oldWorkspaceResize) {
+      this.workspace.resize = this.oldWorkspaceResize;
+    }
+
     // Remove the event listener that enables blocks on drag
     this.workspace.removeChangeListener(enableBlocksOnDrag);
 
     this.workspace.setTheme(this.originalTheme);
 
     this.navigationController.dispose();
+    this.inputModeTracker.dispose();
   }
 
   /**

--- a/src/index.ts
+++ b/src/index.ts
@@ -35,6 +35,7 @@ export class KeyboardNavigation {
    * Focus ring in the workspace.
    */
   private workspaceFocusRing: Element | null = null;
+
   /**
    * Selection ring inside the workspace.
    */

--- a/src/input_mode_tracker.ts
+++ b/src/input_mode_tracker.ts
@@ -1,0 +1,48 @@
+import {WorkspaceSvg} from 'blockly';
+
+/**
+ * Types of user input.
+ */
+const enum InputMode {
+  Keyboard,
+  Pointer,
+}
+
+/**
+ * Tracks the most recent input mode and sets a class indicating we're in
+ * keyboard nav mode.
+ */
+export class InputModeTracker {
+  private lastEventMode: InputMode | null = null;
+
+  private pointerEventHandler = () => {
+    this.lastEventMode = InputMode.Pointer;
+  };
+  private keyboardEventHandler = () => {
+    this.lastEventMode = InputMode.Keyboard;
+  };
+  private focusChangeHandler = () => {
+    const isKeyboard = this.lastEventMode === InputMode.Keyboard;
+    const classList = this.workspace.getInjectionDiv().classList;
+    const className = 'blocklyKeyboardNavigation';
+    if (isKeyboard) {
+      classList.add(className);
+    } else {
+      classList.remove(className);
+    }
+  };
+
+  constructor(private workspace: WorkspaceSvg) {
+    document.addEventListener('pointerdown', this.pointerEventHandler, true);
+    document.addEventListener('keydown', this.keyboardEventHandler, true);
+    document.addEventListener('focusout', this.focusChangeHandler, true);
+    document.addEventListener('focusin', this.focusChangeHandler, true);
+  }
+
+  dispose() {
+    document.removeEventListener('pointerdown', this.pointerEventHandler, true);
+    document.removeEventListener('keydown', this.keyboardEventHandler, true);
+    document.removeEventListener('focusout', this.focusChangeHandler, true);
+    document.removeEventListener('focusin', this.focusChangeHandler, true);
+  }
+}

--- a/test/index.html
+++ b/test/index.html
@@ -31,13 +31,6 @@
         width: 100%;
         max-height: 100%;
         position: relative;
-        --outline-width: 5px;
-      }
-
-      .blocklyFlyout {
-        top: var(--outline-width);
-        left: var(--outline-width);
-        height: calc(100% - calc(var(--outline-width) * 2));
       }
 
       .blocklyToolboxDiv ~ .blocklyFlyout:focus {
@@ -97,52 +90,70 @@
         font-weight: bold;
       }
 
-      .blocklyActiveFocus:is(
-          .blocklyField,
-          .blocklyPath,
+      html {
+        --blockly-active-node-color: #ffa200;
+        --blockly-active-tree-color: #60a5fa;
+        --blockly-selection-width: 3px;
+      }
+      * {
+        box-sizing: border-box;
+      }
+
+      /* Blocks, connections and fields. */
+      .blocklyKeyboardNavigation
+        .blocklyActiveFocus:is(.blocklyPath, .blocklyHighlightedConnectionPath),
+      .blocklyKeyboardNavigation
+        .blocklyActiveFocus.blocklyField
+        > .blocklyFieldRect {
+        stroke: var(--blockly-active-node-color);
+        stroke-width: var(--blockly-selection-width);
+      }
+      .blocklyKeyboardNavigation
+        .blocklyPassiveFocus:is(
+          .blocklyPath:not(.blocklyFlyout .blocklyPath),
           .blocklyHighlightedConnectionPath
-        ) {
-        stroke: #ffa200;
-        stroke-width: 3px;
-      }
-      .blocklyActiveFocus > .blocklyFlyoutBackground,
-      .blocklyActiveFocus > .blocklyMainBackground {
-        stroke: #ffa200;
-        stroke-width: 3px;
-      }
-      .blocklyActiveFocus:is(
-          .blocklyToolbox,
-          .blocklyToolboxCategoryContainer
-        ) {
-        outline: 3px solid #ffa200;
-      }
-      .blocklyPassiveFocus:is(
-          .blocklyField,
-          .blocklyPath,
-          .blocklyHighlightedConnectionPath
-        ) {
-        stroke: #ffa200;
+        ),
+      .blocklyKeyboardNavigation
+        .blocklyPassiveFocus.blocklyField
+        > .blocklyFieldRect {
+        stroke: var(--blockly-active-node-color);
         stroke-dasharray: 5px 3px;
-        stroke-width: 3px;
+        stroke-width: var(--blockly-selection-width);
       }
-      .blocklyPassiveFocus > .blocklyFlyoutBackground,
-      .blocklyPassiveFocus > .blocklyMainBackground {
-        stroke: #ffa200;
-        stroke-dasharray: 5px 3px;
-        stroke-width: 3px;
+      .blocklyKeyboardNavigation
+        .blocklyPassiveFocus.blocklyHighlightedConnectionPath {
+        /* The connection path is being unexpectedly hidden in core */
+        display: unset !important;
       }
-      .blocklyPassiveFocus:is(
-          .blocklyToolbox,
-          .blocklyToolboxCategoryContainer
-        ) {
-        border: 3px dashed #ffa200;
+
+      /* Toolbox and flyout. */
+      .blocklyKeyboardNavigation .blocklyFlyout:has(.blocklyActiveFocus),
+      .blocklyKeyboardNavigation .blocklyToolbox:has(.blocklyActiveFocus),
+      .blocklyKeyboardNavigation
+        .blocklyActiveFocus:is(.blocklyFlyout, .blocklyToolbox) {
+        outline-offset: calc(var(--blockly-selection-width) * -1);
+        outline: var(--blockly-selection-width) solid
+          var(--blockly-active-tree-color);
       }
-      .blocklySelected:is(.blocklyPath) {
-        stroke: #ffa200;
-        stroke-width: 5;
+      /* Workspace */
+      .blocklyKeyboardNavigation
+        .blocklyWorkspace:has(.blocklyActiveFocus)
+        .blocklyWorkspaceFocusRing,
+      .blocklyKeyboardNavigation
+        .blocklyWorkspace.blocklyActiveFocus
+        .blocklyWorkspaceFocusRing {
+        stroke: var(--blockly-active-tree-color);
+        stroke-width: calc(var(--blockly-selection-width) * 2);
       }
-      .blocklySelected > .blocklyPathLight {
-        display: none;
+      .blocklyKeyboardNavigation
+        .blocklyWorkspace.blocklyActiveFocus
+        .blocklyWorkspaceSelectionRing {
+        stroke: var(--blockly-active-node-color);
+        stroke-width: var(--blockly-selection-width);
+      }
+      .blocklyKeyboardNavigation
+        .blocklyToolboxCategoryContainer:focus-visible {
+        outline: none;
       }
     </style>
   </head>


### PR DESCRIPTION
Depends on #520 so it can build against latest v12. [Clean diff vs that branch](https://github.com/google/blockly-keyboard-experimentation/compare/navigable-to-focusable...microbit-matt-hillsdon:blockly-keyboard-experimentation:passive-focus).

Demo: https://passive-focus.blockly-keyboard-experimentation.pages.dev/ (built against latest v12)

Closes #507
Closes https://github.com/google/blockly/issues/8966
Closes https://github.com/google/blockly/issues/8964

Obviously all the CSS is still in the index.html so we should consider whether it should move for a plugin release or whether each integrator needs to copy/paste/tweak.

## Key changes:
- Avoid setting stroke on field text, target the rect instead
- Hack on passive focus for connections (unexpectedly hidden in core). I still think these are going away but just in case.
- Dial down passive focus to only be used in the workspace
- Use focus outlines around focus trees to indicate active area (flyout, toolbox).
- Added rect outlines to the workspace for active area and also workspace selection
    - These need to resize like scrollbars so I've added a monkey patch for resize. Could move into core. See also relevant discussion on https://github.com/google/blockly/issues/8965
- Removed the gap between the toolbox and the flyout (added long ago to make an outline visible but I don't think we're proposing everyone does this)
- Set `box-sizing: border-box`. We think most apps will do this and it avoids the toolbox's default padding moving it slightly off the bottom of the screen (noticeable when adding an outline).
- Remove active styling from toolbox. I think we have conflicting internal views on this one and will discuss further. If we do keep it it needs to move to using "outline" so it doesn't cause glitchy jumping around.
- Remove styles that related to selection as they don't do anything
- Add heuristic input mode tracking that avoids keyboard-nav-related focus styles when you're clicking. A simple approach seems to work surprisingly well here.

## Serious outstanding issues that can feel broken or confusing:
- ~~Move mode is quite broken with a passive and active selection showing at once~~
- ~~Mouse drags show passive focus but that feels wrong when you're interacting with the passive thing. We think this behaviour should not change from current Blockly.~~
- Extra tab stop issue for the workspace - now discussed on https://github.com/google/blockly/issues/8965

## Other outstanding issues
- In Firefox/Safari it looks like more outline resets might be needed for the newly focusable blocks
- We'd prefer not to have passive focus on fields (and full block fields) when the field editor is showing. https://github.com/google/blockly-keyboard-experimentation/issues/508
    - I don't know an easy way to fix this in the plugin other than tracking focus of widget/dropdown divs ourselves. Can we have a class on the field when the editor is open? There doesn't seem to be one.
- We'd prefer to have the passive focus only show when you were navigating to or within the toolbox/flyout via keyboard,  where it serves a purpose as a reference point. Otherwise it doesn't justify the visual noise.
- We'd prefer the focus outlines for the areas (and passive focus in general) to only show for keyboard interaction, like focus-visible (otherwise this is a significant visual change to Blockly). This might be hard to achieve.
    - Since added input mode tracking which seems viable.
- I've made liberal use of CSS "has". If that's an issue for browser support it can likely be fixed by having the focus manger set some classes on focus trees indicating the focus within.
    - Intend to fix via new classes in Blockly as separate PR