### PR TITLE
refactor: Update to use `IFocusableNode` in place of `INavigable`.

### DIFF
--- a/src/actions/clipboard.ts
+++ b/src/actions/clipboard.ts
@@ -17,7 +17,7 @@ import {
   getFocusManager,
 } from 'blockly';
 import * as Constants from '../constants';
-import type {BlockSvg, WorkspaceSvg, INavigable} from 'blockly';
+import type {BlockSvg, WorkspaceSvg} from 'blockly';
 import {Navigation} from '../navigation';
 import {getShortActionShortcut} from '../shortcut_formatting';
 import * as Blockly from 'blockly';
@@ -366,9 +366,7 @@ export class Clipboard {
       ? workspace
       : this.copyWorkspace;
 
-    const targetNode = FocusableTreeTraverser.findFocusedNode(
-      pasteWorkspace,
-    ) as unknown as INavigable<any>;
+    const targetNode = FocusableTreeTraverser.findFocusedNode(pasteWorkspace);
     // If we're pasting in the flyout it still targets the workspace. Focus
     // first as to ensure correct selection handling.
     getFocusManager().focusTree(workspace);

--- a/src/actions/delete.ts
+++ b/src/actions/delete.ts
@@ -12,7 +12,7 @@ import {
   LineCursor,
 } from 'blockly';
 import * as Constants from '../constants';
-import type {BlockSvg, WorkspaceSvg} from 'blockly';
+import type {WorkspaceSvg} from 'blockly';
 import {Navigation} from '../navigation';
 
 const KeyCodes = BlocklyUtils.KeyCodes;

--- a/src/actions/disconnect.ts
+++ b/src/actions/disconnect.ts
@@ -11,7 +11,7 @@ import {
   utils as BlocklyUtils,
 } from 'blockly';
 import * as Constants from '../constants';
-import type {WorkspaceSvg, INavigable} from 'blockly';
+import type {WorkspaceSvg, IFocusableNode} from 'blockly';
 import {Navigation} from '../navigation';
 
 const KeyCodes = BlocklyUtils.KeyCodes;
@@ -79,7 +79,7 @@ export class DisconnectAction {
     if (!cursor) {
       return;
     }
-    let curNode: INavigable<any> | null = cursor.getCurNode();
+    let curNode: IFocusableNode | null = cursor.getCurNode();
     let wasVisitingConnection = true;
     while (
       curNode &&

--- a/src/actions/enter.ts
+++ b/src/actions/enter.ts
@@ -17,7 +17,7 @@ import {
   FocusableTreeTraverser,
 } from 'blockly/core';
 
-import type {Block, INavigable} from 'blockly/core';
+import type {Block} from 'blockly/core';
 
 import * as Constants from '../constants';
 import type {Navigation} from '../navigation';
@@ -59,7 +59,6 @@ export class EnterAction {
 
         let flyoutCursor;
         let curNode;
-        let nodeType;
 
         switch (this.navigation.getState(workspace)) {
           case Constants.STATE.WORKSPACE:
@@ -128,9 +127,7 @@ export class EnterAction {
       Events.setGroup(true);
     }
 
-    const stationaryNode = FocusableTreeTraverser.findFocusedNode(
-      workspace,
-    ) as unknown as INavigable<any>;
+    const stationaryNode = FocusableTreeTraverser.findFocusedNode(workspace);
     const newBlock = this.createNewBlock(workspace);
     if (!newBlock) return;
     const insertStartPoint = stationaryNode

--- a/src/flyout_cursor.ts
+++ b/src/flyout_cursor.ts
@@ -33,7 +33,7 @@ export class FlyoutCursor extends Blockly.LineCursor {
    * @returns The next element, or null if the current node is
    *     not set or there is no next value.
    */
-  override next(): Blockly.INavigable<any> | null {
+  override next(): Blockly.IFocusableNode | null {
     const curNode = this.getCurNode();
     if (!curNode) {
       return null;
@@ -47,21 +47,12 @@ export class FlyoutCursor extends Blockly.LineCursor {
   }
 
   /**
-   * This is a no-op since a flyout cursor can not go in.
-   *
-   * @returns Always null.
-   */
-  override in(): null {
-    return null;
-  }
-
-  /**
    * Moves the cursor to the previous stack of blocks in the flyout.
    *
    * @returns The previous element, or null if the current
    *     node is not set or there is no previous value.
    */
-  override prev(): Blockly.INavigable<any> | null {
+  override prev(): Blockly.IFocusableNode | null {
     const curNode = this.getCurNode();
     if (!curNode) {
       return null;
@@ -74,16 +65,7 @@ export class FlyoutCursor extends Blockly.LineCursor {
     return newNode;
   }
 
-  /**
-   * This is a  no-op since a flyout cursor can not go out.
-   *
-   * @returns Always null.
-   */
-  override out(): null {
-    return null;
-  }
-
-  override setCurNode(node: Blockly.INavigable<any> | null) {
+  override setCurNode(node: Blockly.IFocusableNode | null) {
     super.setCurNode(node);
 
     let bounds: Blockly.utils.Rect | undefined;

--- a/src/index.ts
+++ b/src/index.ts
@@ -8,16 +8,6 @@ import * as Blockly from 'blockly/core';
 import {NavigationController} from './navigation_controller';
 import {enableBlocksOnDrag} from './disabled_blocks';
 
-/** Options object for KeyboardNavigation instances. */
-export interface NavigationOptions {
-  cursor: Partial<Blockly.CursorOptions>;
-}
-
-/** Default options for LineCursor instances. */
-const defaultOptions: NavigationOptions = {
-  cursor: {},
-};
-
 /** Plugin for keyboard navigation. */
 export class KeyboardNavigation {
   /** The workspace. */
@@ -38,18 +28,10 @@ export class KeyboardNavigation {
   /**
    * Constructs the keyboard navigation.
    *
-   * @param workspace The workspace that the plugin will
-   *     be added to.
-   * @param options Options.
+   * @param workspace The workspace that the plugin will be added to.
    */
-  constructor(
-    workspace: Blockly.WorkspaceSvg,
-    options: Partial<NavigationOptions>,
-  ) {
+  constructor(workspace: Blockly.WorkspaceSvg) {
     this.workspace = workspace;
-
-    // Regularise options and apply defaults.
-    options = {...defaultOptions, ...options};
 
     this.navigationController = new NavigationController();
     this.navigationController.init();
@@ -59,7 +41,7 @@ export class KeyboardNavigation {
     this.originalTheme = workspace.getTheme();
     this.setGlowTheme();
 
-    this.cursor = new Blockly.LineCursor(workspace, options.cursor);
+    this.cursor = new Blockly.LineCursor(workspace);
 
     // Add the event listener to enable disabled blocks on drag.
     workspace.addChangeListener(enableBlocksOnDrag);

--- a/src/keyboard_drag_strategy.ts
+++ b/src/keyboard_drag_strategy.ts
@@ -10,7 +10,6 @@ import {
   RenderedConnection,
   dragging,
   utils,
-  INavigable,
 } from 'blockly';
 import {Direction, getDirectionFromXY} from './drag_direction';
 import {showUnconstrainedMoveHint} from './hints';

--- a/src/navigation.ts
+++ b/src/navigation.ts
@@ -15,7 +15,6 @@ import * as Constants from './constants';
 import {
   registrationName as cursorRegistrationName,
   registrationType as cursorRegistrationType,
-  FlyoutCursor,
 } from './flyout_cursor';
 
 /**
@@ -151,7 +150,7 @@ export class Navigation {
     if (FlyoutCursorClass) {
       flyoutWorkspace
         .getMarkerManager()
-        .setCursor(new Blockly.LineCursor(flyout.getWorkspace()));
+        .setCursor(new FlyoutCursorClass(flyout));
     }
   }
 
@@ -258,7 +257,7 @@ export class Navigation {
   }
 
   private isFlyoutItemDisposed(
-    node: Blockly.INavigable<any>,
+    node: Blockly.IFocusableNode,
     sourceBlock: Blockly.BlockSvg | null,
   ) {
     if (sourceBlock?.disposed) {
@@ -368,9 +367,7 @@ export class Navigation {
         : flyoutContents[flyoutContents.length - 1];
     if (!defaultFlyoutItem) return false;
     const defaultFlyoutItemElement = defaultFlyoutItem.getElement();
-    flyoutCursor.setCurNode(
-      defaultFlyoutItemElement as unknown as Blockly.INavigable<any>,
-    );
+    flyoutCursor.setCurNode(defaultFlyoutItemElement);
     return true;
   }
 
@@ -420,11 +417,11 @@ export class Navigation {
    * @param workspace The main workspace the flyout is on.
    * @returns The flyout's cursor or null if no flyout exists.
    */
-  getFlyoutCursor(workspace: Blockly.WorkspaceSvg): FlyoutCursor | null {
+  getFlyoutCursor(workspace: Blockly.WorkspaceSvg): Blockly.LineCursor | null {
     const flyout = workspace.getFlyout();
     const cursor = flyout ? flyout.getWorkspace().getCursor() : null;
 
-    return cursor as FlyoutCursor;
+    return cursor;
   }
 
   /**
@@ -437,7 +434,7 @@ export class Navigation {
    *     wrong.
    */
   findInsertStartPoint(
-    stationaryNode: Blockly.INavigable<any>,
+    stationaryNode: Blockly.IFocusableNode,
     movingBlock: Blockly.BlockSvg,
   ): Blockly.RenderedConnection | null {
     const movingHasOutput = !!movingBlock.outputConnection;
@@ -517,7 +514,7 @@ export class Navigation {
    * @returns True if the connection was successful, false otherwise.
    */
   tryToConnectBlock(
-    stationaryNode: Blockly.INavigable<any>,
+    stationaryNode: Blockly.IFocusableNode,
     movingBlock: Blockly.BlockSvg,
   ): boolean {
     const destConnection = this.findInsertStartPoint(

--- a/test/index.html
+++ b/test/index.html
@@ -190,14 +190,6 @@
                 <option value="zelos">Zelos</option>
               </select>
             </div>
-            <div>
-              <label for="stackConnections">Disable stack connections:</label>
-              <input
-                type="checkbox"
-                name="noStack"
-                id="noStack"
-                onChange="document.forms.options.submit()" />
-            </div>
           </form>
         </div>
       </div>

--- a/test/index.ts
+++ b/test/index.ts
@@ -49,9 +49,6 @@ function getOptions() {
     renderer = 'thrasos';
   }
 
-  const noStackParam = params.get('noStack');
-  const stackConnections = !noStackParam;
-
   const toolboxParam = params.get('toolbox');
   const toolbox = toolboxParam ?? 'toolbox';
   const toolboxObject =
@@ -66,13 +63,10 @@ function getOptions() {
     (document.getElementById('toolbox') as HTMLSelectElement).value = toolbox;
     (document.getElementById('renderer') as HTMLSelectElement).value = renderer;
     (document.getElementById('scenario') as HTMLSelectElement).value = scenario;
-    (document.getElementById('noStack') as HTMLInputElement).checked =
-      !stackConnections;
   });
 
   return {
     scenario,
-    stackConnections,
     renderer,
     toolbox: toolboxObject,
   };
@@ -85,7 +79,7 @@ function getOptions() {
  * @returns The created workspace.
  */
 function createWorkspace(): Blockly.WorkspaceSvg {
-  const {scenario, stackConnections, renderer, toolbox} = getOptions();
+  const {scenario, renderer, toolbox} = getOptions();
 
   const injectOptions = {
     toolbox,
@@ -97,10 +91,7 @@ function createWorkspace(): Blockly.WorkspaceSvg {
   }
   const workspace = Blockly.inject(blocklyDiv, injectOptions);
 
-  const navigationOptions = {
-    cursor: {stackConnections},
-  };
-  new KeyboardNavigation(workspace, navigationOptions);
+  new KeyboardNavigation(workspace);
   registerRunCodeShortcut();
 
   // Disable blocks that aren't inside the setup or draw loops.

--- a/test/webdriverio/index.ts
+++ b/test/webdriverio/index.ts
@@ -44,9 +44,6 @@ function getOptions() {
     renderer = 'thrasos';
   }
 
-  const noStackParam = params.get('noStack');
-  const stackConnections = !noStackParam;
-
   const toolboxParam = params.get('toolbox');
   const toolbox = toolboxParam ?? 'toolbox';
   const toolboxObject =
@@ -57,7 +54,6 @@ function getOptions() {
 
   return {
     scenario,
-    stackConnections,
     renderer,
     toolbox: toolboxObject,
     rtl,
@@ -71,7 +67,7 @@ function getOptions() {
  * @returns The created workspace.
  */
 function createWorkspace(): Blockly.WorkspaceSvg {
-  const {scenario, stackConnections, renderer, toolbox, rtl} = getOptions();
+  const {scenario, renderer, toolbox, rtl} = getOptions();
 
   const injectOptions = {
     toolbox,
@@ -84,10 +80,7 @@ function createWorkspace(): Blockly.WorkspaceSvg {
   }
   const workspace = Blockly.inject(blocklyDiv, injectOptions);
 
-  const navigationOptions = {
-    cursor: {stackConnections},
-  };
-  new KeyboardNavigation(workspace, navigationOptions);
+  new KeyboardNavigation(workspace);
 
   // Disable blocks that aren't inside the setup or draw loops.
   workspace.addChangeListener(Blockly.Events.disableOrphans);

--- a/test/webdriverio/test/basic_test.ts
+++ b/test/webdriverio/test/basic_test.ts
@@ -44,13 +44,12 @@ suite('Keyboard navigation on Blocks', function () {
       await this.browser.pause(PAUSE_TIME);
     }
 
-    const selectedId = await this.browser.execute(() => {
-      return Blockly.common.getSelected()?.id;
-    });
-    chai.assert.equal(selectedId, 'controls_repeat_1');
+    chai
+      .expect(await getCurrentFocusNodeId(this.browser))
+      .to.include('controls_if_2');
   });
 
-  test('Down from statement block selects next connection', async function () {
+  test('Down from statement block selects next block across stacks', async function () {
     await tabNavigateToWorkspace(this.browser);
     await this.browser.pause(PAUSE_TIME);
     await setCurrentCursorNodeById(this.browser, 'p5_canvas_1');
@@ -60,15 +59,10 @@ suite('Keyboard navigation on Blocks', function () {
 
     chai
       .expect(await getCurrentFocusNodeId(this.browser))
-      .to.include('p5_canvas_1_connection_');
-
-    chai.assert.equal(
-      await getFocusedConnectionType(this.browser),
-      Blockly.ConnectionType.NEXT_STATEMENT,
-    );
+      .to.include('p5_draw_1');
   });
 
-  test("Up from statement block selects previous block's connection", async function () {
+  test('Up from statement block selects previous block', async function () {
     await tabNavigateToWorkspace(this.browser);
     await this.browser.pause(PAUSE_TIME);
     await setCurrentCursorNodeById(this.browser, 'simple_circle_1');
@@ -78,15 +72,10 @@ suite('Keyboard navigation on Blocks', function () {
 
     chai
       .expect(await getCurrentFocusNodeId(this.browser))
-      .to.include('draw_emoji_1_connection_');
-
-    chai.assert.equal(
-      await getFocusedConnectionType(this.browser),
-      Blockly.ConnectionType.NEXT_STATEMENT,
-    );
+      .to.include('draw_emoji_1');
   });
 
-  test('Down from parent block selects input connection', async function () {
+  test('Down from parent block selects first child block', async function () {
     await tabNavigateToWorkspace(this.browser);
     await this.browser.pause(PAUSE_TIME);
     await setCurrentCursorNodeById(this.browser, 'p5_setup_1');
@@ -95,15 +84,10 @@ suite('Keyboard navigation on Blocks', function () {
     await this.browser.pause(PAUSE_TIME);
     chai
       .expect(await getCurrentFocusNodeId(this.browser))
-      .to.include('p5_setup_1_connection_');
-
-    chai.assert.equal(
-      await getFocusedConnectionType(this.browser),
-      Blockly.ConnectionType.NEXT_STATEMENT,
-    );
+      .to.include('p5_canvas_1');
   });
 
-  test('Up from child block selects input connection', async function () {
+  test('Up from child block selects parent block', async function () {
     await tabNavigateToWorkspace(this.browser);
     await this.browser.pause(PAUSE_TIME);
     await setCurrentCursorNodeById(this.browser, 'p5_canvas_1');
@@ -112,12 +96,7 @@ suite('Keyboard navigation on Blocks', function () {
     await this.browser.pause(PAUSE_TIME);
     chai
       .expect(await getCurrentFocusNodeId(this.browser))
-      .to.include('p5_setup_1_connection_');
-
-    chai.assert.equal(
-      await getFocusedConnectionType(this.browser),
-      Blockly.ConnectionType.NEXT_STATEMENT,
-    );
+      .to.include('p5_setup_1');
   });
 
   test('Right from block selects first field', async function () {
@@ -205,8 +184,7 @@ suite('Keyboard navigation on Blocks', function () {
     );
   });
 
-  // Test will fail until we update to a newer version of field-colour
-  test.skip("Right from last inline input selects block's next connection", async function () {
+  test('Right from last inline input selects next block', async function () {
     await tabNavigateToWorkspace(this.browser);
     await this.browser.pause(PAUSE_TIME);
     await setCurrentCursorNodeById(this.browser, 'colour_picker_1');
@@ -216,16 +194,10 @@ suite('Keyboard navigation on Blocks', function () {
 
     chai
       .expect(await getCurrentFocusNodeId(this.browser))
-      .to.include('simple_circle_1_connection_');
-
-    chai.assert.equal(
-      await getFocusedConnectionType(this.browser),
-      Blockly.ConnectionType.NEXT_STATEMENT,
-    );
+      .to.include('controls_repeat_ext_1');
   });
 
-  // Test will fail until we update to a newer version of field-colour
-  test.skip("Down from inline input selects block's next connection", async function () {
+  test('Down from inline input selects next block', async function () {
     await tabNavigateToWorkspace(this.browser);
     await this.browser.pause(PAUSE_TIME);
     await setCurrentCursorNodeById(this.browser, 'colour_picker_1');
@@ -235,25 +207,20 @@ suite('Keyboard navigation on Blocks', function () {
 
     chai
       .expect(await getCurrentFocusNodeId(this.browser))
-      .to.include('simple_circle_1_connection_');
-
-    chai.assert.equal(
-      await getFocusedConnectionType(this.browser),
-      Blockly.ConnectionType.NEXT_STATEMENT,
-    );
+      .to.include('controls_repeat_ext_1');
   });
 
-  test("Down from inline input selects block's child connection", async function () {
+  test("Down from inline input selects block's child block", async function () {
     await tabNavigateToWorkspace(this.browser);
     await this.browser.pause(PAUSE_TIME);
-    await setCurrentCursorNodeById(this.browser, 'math_number_2');
+    await setCurrentCursorNodeById(this.browser, 'logic_boolean_1');
     await this.browser.pause(PAUSE_TIME);
     await this.browser.keys(Key.ArrowDown);
     await this.browser.pause(PAUSE_TIME);
 
     chai
       .expect(await getCurrentFocusNodeId(this.browser))
-      .to.include('controls_repeat_ext_1_connection_');
+      .to.include('text_print_1');
   });
 
   test('Right from text block selects shadow block then field', async function () {
@@ -278,11 +245,7 @@ suite('Keyboard navigation on Blocks', function () {
 
     chai
       .expect(await getCurrentFocusNodeId(this.browser))
-      .to.include('text_print_1_connection_');
-    chai.assert.equal(
-      await getFocusedConnectionType(this.browser),
-      Blockly.ConnectionType.NEXT_STATEMENT,
-    );
+      .to.include('controls_repeat_1');
   });
 });
 
@@ -364,7 +327,7 @@ suite('Keyboard navigation on Fields', function () {
     chai.assert.equal(await getFocusedFieldName(this.browser), 'WIDTH');
   });
 
-  test("Right from second field selects block's next connection", async function () {
+  test('Right from second field selects next block', async function () {
     await tabNavigateToWorkspace(this.browser);
     await this.browser.pause(PAUSE_TIME);
     await setCurrentCursorNodeByIdAndFieldName(
@@ -378,10 +341,10 @@ suite('Keyboard navigation on Fields', function () {
 
     chai
       .expect(await getCurrentFocusNodeId(this.browser))
-      .to.include('p5_canvas_1_connection_');
+      .to.include('p5_draw_1');
   });
 
-  test("Down from field selects block's next connection", async function () {
+  test('Down from field selects next block', async function () {
     await tabNavigateToWorkspace(this.browser);
     await this.browser.pause(PAUSE_TIME);
     await setCurrentCursorNodeByIdAndFieldName(
@@ -395,15 +358,10 @@ suite('Keyboard navigation on Fields', function () {
 
     chai
       .expect(await getCurrentFocusNodeId(this.browser))
-      .to.include('p5_canvas_1_connection_');
-
-    chai.assert.equal(
-      await getFocusedConnectionType(this.browser),
-      Blockly.ConnectionType.NEXT_STATEMENT,
-    );
+      .to.include('p5_draw_1');
   });
 
-  test("Down from field selects block's child connection", async function () {
+  test("Down from field selects block's child block", async function () {
     await tabNavigateToWorkspace(this.browser);
     await this.browser.pause(PAUSE_TIME);
     await setCurrentCursorNodeByIdAndFieldName(
@@ -417,11 +375,6 @@ suite('Keyboard navigation on Fields', function () {
 
     chai
       .expect(await getCurrentFocusNodeId(this.browser))
-      .to.include('controls_repeat_1_connection_');
-
-    chai.assert.equal(
-      await getFocusedConnectionType(this.browser),
-      Blockly.ConnectionType.NEXT_STATEMENT,
-    );
+      .to.include('draw_emoji_1');
   });
 });

--- a/test/webdriverio/test/basic_test.ts
+++ b/test/webdriverio/test/basic_test.ts
@@ -46,7 +46,7 @@ suite('Keyboard navigation on Blocks', function () {
 
     chai
       .expect(await getCurrentFocusNodeId(this.browser))
-      .to.include('controls_if_2');
+      .equal('controls_if_2');
   });
 
   test('Down from statement block selects next block across stacks', async function () {
@@ -57,9 +57,7 @@ suite('Keyboard navigation on Blocks', function () {
     await this.browser.keys(Key.ArrowDown);
     await this.browser.pause(PAUSE_TIME);
 
-    chai
-      .expect(await getCurrentFocusNodeId(this.browser))
-      .to.include('p5_draw_1');
+    chai.expect(await getCurrentFocusNodeId(this.browser)).equal('p5_draw_1');
   });
 
   test('Up from statement block selects previous block', async function () {
@@ -72,7 +70,7 @@ suite('Keyboard navigation on Blocks', function () {
 
     chai
       .expect(await getCurrentFocusNodeId(this.browser))
-      .to.include('draw_emoji_1');
+      .equal('draw_emoji_1');
   });
 
   test('Down from parent block selects first child block', async function () {
@@ -82,9 +80,7 @@ suite('Keyboard navigation on Blocks', function () {
     await this.browser.pause(PAUSE_TIME);
     await this.browser.keys(Key.ArrowDown);
     await this.browser.pause(PAUSE_TIME);
-    chai
-      .expect(await getCurrentFocusNodeId(this.browser))
-      .to.include('p5_canvas_1');
+    chai.expect(await getCurrentFocusNodeId(this.browser)).equal('p5_canvas_1');
   });
 
   test('Up from child block selects parent block', async function () {
@@ -94,9 +90,7 @@ suite('Keyboard navigation on Blocks', function () {
     await this.browser.pause(PAUSE_TIME);
     await this.browser.keys(Key.ArrowUp);
     await this.browser.pause(PAUSE_TIME);
-    chai
-      .expect(await getCurrentFocusNodeId(this.browser))
-      .to.include('p5_setup_1');
+    chai.expect(await getCurrentFocusNodeId(this.browser)).equal('p5_setup_1');
   });
 
   test('Right from block selects first field', async function () {
@@ -194,7 +188,7 @@ suite('Keyboard navigation on Blocks', function () {
 
     chai
       .expect(await getCurrentFocusNodeId(this.browser))
-      .to.include('controls_repeat_ext_1');
+      .equal('controls_repeat_ext_1');
   });
 
   test('Down from inline input selects next block', async function () {
@@ -207,7 +201,7 @@ suite('Keyboard navigation on Blocks', function () {
 
     chai
       .expect(await getCurrentFocusNodeId(this.browser))
-      .to.include('controls_repeat_ext_1');
+      .equal('controls_repeat_ext_1');
   });
 
   test("Down from inline input selects block's child block", async function () {
@@ -220,7 +214,7 @@ suite('Keyboard navigation on Blocks', function () {
 
     chai
       .expect(await getCurrentFocusNodeId(this.browser))
-      .to.include('text_print_1');
+      .equal('text_print_1');
   });
 
   test('Right from text block selects shadow block then field', async function () {
@@ -245,7 +239,7 @@ suite('Keyboard navigation on Blocks', function () {
 
     chai
       .expect(await getCurrentFocusNodeId(this.browser))
-      .to.include('controls_repeat_1');
+      .equal('controls_repeat_1');
   });
 });
 
@@ -339,9 +333,7 @@ suite('Keyboard navigation on Fields', function () {
     await this.browser.keys(Key.ArrowRight);
     await this.browser.pause(PAUSE_TIME);
 
-    chai
-      .expect(await getCurrentFocusNodeId(this.browser))
-      .to.include('p5_draw_1');
+    chai.expect(await getCurrentFocusNodeId(this.browser)).equal('p5_draw_1');
   });
 
   test('Down from field selects next block', async function () {
@@ -356,9 +348,7 @@ suite('Keyboard navigation on Fields', function () {
     await this.browser.keys(Key.ArrowDown);
     await this.browser.pause(PAUSE_TIME);
 
-    chai
-      .expect(await getCurrentFocusNodeId(this.browser))
-      .to.include('p5_draw_1');
+    chai.expect(await getCurrentFocusNodeId(this.browser)).equal('p5_draw_1');
   });
 
   test("Down from field selects block's child block", async function () {
@@ -375,6 +365,6 @@ suite('Keyboard navigation on Fields', function () {
 
     chai
       .expect(await getCurrentFocusNodeId(this.browser))
-      .to.include('draw_emoji_1');
+      .equal('draw_emoji_1');
   });
 });


### PR DESCRIPTION
This PR updates the keyboard experiment for compatibility with https://github.com/google/blockly/pull/9037 by using IFocusableNode in place of INavigable.