### PR TITLE
fix: Broken tests + upgrade to Blockly 12.0.0.

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -13,7 +13,7 @@ permissions:
 
 jobs:
   build_tip_of_tree_v12:
-    name: Build test (against tip-of-tree core v12)
+    name: Build test (against tip-of-tree core develop)
     runs-on: ubuntu-latest
     steps:
       - name: Checkout experimentation plugin
@@ -25,7 +25,7 @@ jobs:
         uses: actions/checkout@v4
         with:
           repository: 'google/blockly'
-          ref: 'rc/v12.0.0'
+          ref: 'develop'
           path: core-blockly
 
       - name: Use Node.js 20.x
@@ -42,7 +42,7 @@ jobs:
           npm install
           cd ..
 
-      - name: Link latest Blockly v12
+      - name: Link latest Blockly develop
         run: |
           cd core-blockly
           npm run package
@@ -58,7 +58,7 @@ jobs:
           npm run build
 
   build:
-    name: Build test (against pinned v12)
+    name: Build test (against pinned v12.0.0)
     # Don't run pinned version checks for PRs.
     if: ${{ !github.base_ref }}
     runs-on: ubuntu-latest

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -58,7 +58,7 @@ jobs:
           npm run build
 
   build:
-    name: Build test (against pinned v12.0.0)
+    name: Build test (against pinned v12)
     # Don't run pinned version checks for PRs.
     if: ${{ !github.base_ref }}
     runs-on: ubuntu-latest

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -66,7 +66,7 @@ jobs:
           npm run test
 
   webdriverio_tests:
-    name: WebdriverIO tests (against pinned v12.0.0)
+    name: WebdriverIO tests (against pinned v12)
     # Don't run pinned version checks for PRs.
     if: ${{ !github.base_ref }}
     timeout-minutes: 10

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -14,7 +14,7 @@ permissions:
 
 jobs:
   webdriverio_tests_tip_of_tree_v12:
-    name: WebdriverIO tests (against tip-of-tree core v12)
+    name: WebdriverIO tests (against tip-of-tree core develop)
     timeout-minutes: 10
     runs-on: ${{ matrix.os }}
 
@@ -33,7 +33,7 @@ jobs:
         uses: actions/checkout@v4
         with:
           repository: 'google/blockly'
-          ref: 'rc/v12.0.0'
+          ref: 'develop'
           path: core-blockly
 
       - name: Use Node.js 20.x
@@ -50,7 +50,7 @@ jobs:
           npm install
           cd ..
 
-      - name: Link latest Blockly v12
+      - name: Link latest Blockly develop
         run: |
           cd core-blockly
           npm run package
@@ -66,7 +66,7 @@ jobs:
           npm run test
 
   webdriverio_tests:
-    name: WebdriverIO tests (against pinned v12)
+    name: WebdriverIO tests (against pinned v12.0.0)
     # Don't run pinned version checks for PRs.
     if: ${{ !github.base_ref }}
     timeout-minutes: 10

--- a/package-lock.json
+++ b/package-lock.json
@@ -18,7 +18,7 @@
         "@types/p5": "^1.7.6",
         "@typescript-eslint/eslint-plugin": "^6.7.2",
         "@typescript-eslint/parser": "^6.7.2",
-        "blockly": "^12.0.0-beta.4",
+        "blockly": "^12.0.0-beta.7",
         "chai": "^5.2.0",
         "eslint": "^8.49.0",
         "eslint-config-google": "^0.14.0",
@@ -34,18 +34,17 @@
         "webdriverio": "^9.12.1"
       },
       "peerDependencies": {
-        "blockly": "^12.0.0-beta.4"
+        "blockly": "^12.0.0-beta.7"
       }
     },
     "node_modules/@asamuzakjp/css-color": {
-      "version": "2.8.3",
-      "resolved": "https://registry.npmjs.org/@asamuzakjp/css-color/-/css-color-2.8.3.tgz",
-      "integrity": "sha512-GIc76d9UI1hCvOATjZPyHFmE5qhRccp3/zGfMPapK3jBi+yocEzp6BBB0UnfRYP9NP4FANqUZYb0hnfs3TM3hw==",
+      "version": "3.1.7",
+      "resolved": "https://registry.npmjs.org/@asamuzakjp/css-color/-/css-color-3.1.7.tgz",
+      "integrity": "sha512-Ok5fYhtwdyJQmU1PpEv6Si7Y+A4cYb8yNM9oiIJC9TzXPMuN9fvdonKJqcnz9TbFqV6bQ8z0giRq0iaOpGZV2g==",
       "dev": true,
-      "license": "MIT",
       "dependencies": {
-        "@csstools/css-calc": "^2.1.1",
-        "@csstools/css-color-parser": "^3.0.7",
+        "@csstools/css-calc": "^2.1.3",
+        "@csstools/css-color-parser": "^3.0.9",
         "@csstools/css-parser-algorithms": "^3.0.4",
         "@csstools/css-tokenizer": "^3.0.3",
         "lru-cache": "^10.4.3"
@@ -1006,15 +1005,14 @@
           "url": "https://opencollective.com/csstools"
         }
       ],
-      "license": "MIT-0",
       "engines": {
         "node": ">=18"
       }
     },
     "node_modules/@csstools/css-calc": {
-      "version": "2.1.2",
-      "resolved": "https://registry.npmjs.org/@csstools/css-calc/-/css-calc-2.1.2.tgz",
-      "integrity": "sha512-TklMyb3uBB28b5uQdxjReG4L80NxAqgrECqLZFQbyLekwwlcDDS8r3f07DKqeo8C4926Br0gf/ZDe17Zv4wIuw==",
+      "version": "2.1.3",
+      "resolved": "https://registry.npmjs.org/@csstools/css-calc/-/css-calc-2.1.3.tgz",
+      "integrity": "sha512-XBG3talrhid44BY1x3MHzUx/aTG8+x/Zi57M4aTKK9RFB4aLlF3TTSzfzn8nWVHWL3FgAXAxmupmDd6VWww+pw==",
       "dev": true,
       "funding": [
         {
@@ -1026,7 +1024,6 @@
           "url": "https://opencollective.com/csstools"
         }
       ],
-      "license": "MIT",
       "engines": {
         "node": ">=18"
       },
@@ -1036,9 +1033,9 @@
       }
     },
     "node_modules/@csstools/css-color-parser": {
-      "version": "3.0.8",
-      "resolved": "https://registry.npmjs.org/@csstools/css-color-parser/-/css-color-parser-3.0.8.tgz",
-      "integrity": "sha512-pdwotQjCCnRPuNi06jFuP68cykU1f3ZWExLe/8MQ1LOs8Xq+fTkYgd+2V8mWUWMrOn9iS2HftPVaMZDaXzGbhQ==",
+      "version": "3.0.9",
+      "resolved": "https://registry.npmjs.org/@csstools/css-color-parser/-/css-color-parser-3.0.9.tgz",
+      "integrity": "sha512-wILs5Zk7BU86UArYBJTPy/FMPPKVKHMj1ycCEyf3VUptol0JNRLFU/BZsJ4aiIHJEbSLiizzRrw8Pc1uAEDrXw==",
       "dev": true,
       "funding": [
         {
@@ -1050,10 +1047,9 @@
           "url": "https://opencollective.com/csstools"
         }
       ],
-      "license": "MIT",
       "dependencies": {
         "@csstools/color-helpers": "^5.0.2",
-        "@csstools/css-calc": "^2.1.2"
+        "@csstools/css-calc": "^2.1.3"
       },
       "engines": {
         "node": ">=18"
@@ -1078,7 +1074,6 @@
           "url": "https://opencollective.com/csstools"
         }
       ],
-      "license": "MIT",
       "engines": {
         "node": ">=18"
       },
@@ -1101,7 +1096,6 @@
           "url": "https://opencollective.com/csstools"
         }
       ],
-      "license": "MIT",
       "engines": {
         "node": ">=18"
       }
@@ -2878,13 +2872,6 @@
       "integrity": "sha512-htCUDlxyyCLMgaM3xXg0C0LW2xqfuQ6p05pCEIsXuyQ+a1koYKTuBMzRNwmybfLgvJDMd0r1LTn4+E0Ti6C2AA==",
       "dev": true
     },
-    "node_modules/asynckit": {
-      "version": "0.4.0",
-      "resolved": "https://registry.npmjs.org/asynckit/-/asynckit-0.4.0.tgz",
-      "integrity": "sha512-Oei9OH4tRh0YqU3GxhX79dM/mwVgvbZJaSNaRk+bshkj0S5cfHcgYakreBjrHwatXKbz+IoIdYLxrKim2MjW0Q==",
-      "dev": true,
-      "license": "MIT"
-    },
     "node_modules/b4a": {
       "version": "1.6.7",
       "resolved": "https://registry.npmjs.org/b4a/-/b4a-1.6.7.tgz",
@@ -3062,13 +3049,12 @@
       }
     },
     "node_modules/blockly": {
-      "version": "12.0.0-beta.4",
-      "resolved": "https://registry.npmjs.org/blockly/-/blockly-12.0.0-beta.4.tgz",
-      "integrity": "sha512-KY26RP8GfJRTqX/EUWSwu7ilVwhdGU0qQTrgdUGl+frsgqlBqCtIWZJVCxMafCAUWyAlU9+5aQ7UBItcR2MVQQ==",
+      "version": "12.0.0-beta.7",
+      "resolved": "https://registry.npmjs.org/blockly/-/blockly-12.0.0-beta.7.tgz",
+      "integrity": "sha512-yKwPekH7cu2mELAoznExl11dfrCT4Phmynmm7fLJYmOsuVjUmPOUWRPGQd4e8ccCemkt5NLm7KmRWRZ1+4pXEA==",
       "dev": true,
-      "license": "Apache-2.0",
       "dependencies": {
-        "jsdom": "25.0.1"
+        "jsdom": "26.1.0"
       },
       "engines": {
         "node": ">=18"
@@ -3706,19 +3692,6 @@
       "dev": true,
       "license": "MIT"
     },
-    "node_modules/combined-stream": {
-      "version": "1.0.8",
-      "resolved": "https://registry.npmjs.org/combined-stream/-/combined-stream-1.0.8.tgz",
-      "integrity": "sha512-FQN4MRfuJeHf7cBbBMJFXhKSDq+2kAArBlmRBvcvFE5BB1HZKXtSFASDhdlz9zOYwxh8lDdnvmMOe/+5cdoEdg==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "delayed-stream": "~1.0.0"
-      },
-      "engines": {
-        "node": ">= 0.8"
-      }
-    },
     "node_modules/commander": {
       "version": "2.20.3",
       "resolved": "https://registry.npmjs.org/commander/-/commander-2.20.3.tgz",
@@ -3996,25 +3969,17 @@
       }
     },
     "node_modules/cssstyle": {
-      "version": "4.2.1",
-      "resolved": "https://registry.npmjs.org/cssstyle/-/cssstyle-4.2.1.tgz",
-      "integrity": "sha512-9+vem03dMXG7gDmZ62uqmRiMRNtinIZ9ZyuF6BdxzfOD+FdN5hretzynkn0ReS2DO2GSw76RWHs0UmJPI2zUjw==",
+      "version": "4.3.1",
+      "resolved": "https://registry.npmjs.org/cssstyle/-/cssstyle-4.3.1.tgz",
+      "integrity": "sha512-ZgW+Jgdd7i52AaLYCriF8Mxqft0gD/R9i9wi6RWBhs1pqdPEzPjym7rvRKi397WmQFf3SlyUsszhw+VVCbx79Q==",
       "dev": true,
-      "license": "MIT",
       "dependencies": {
-        "@asamuzakjp/css-color": "^2.8.2",
+        "@asamuzakjp/css-color": "^3.1.2",
         "rrweb-cssom": "^0.8.0"
       },
       "engines": {
         "node": ">=18"
       }
-    },
-    "node_modules/cssstyle/node_modules/rrweb-cssom": {
-      "version": "0.8.0",
-      "resolved": "https://registry.npmjs.org/rrweb-cssom/-/rrweb-cssom-0.8.0.tgz",
-      "integrity": "sha512-guoltQEx+9aMf2gDZ0s62EcV8lsXR+0w8915TC3ITdn2YueuNjdAYh/levpU9nFaoChh9RUS5ZdQMrKfVEN9tw==",
-      "dev": true,
-      "license": "MIT"
     },
     "node_modules/data-uri-to-buffer": {
       "version": "4.0.1",
@@ -4030,7 +3995,6 @@
       "resolved": "https://registry.npmjs.org/data-urls/-/data-urls-5.0.0.tgz",
       "integrity": "sha512-ZYP5VBHshaDAiVZxjbRVcFJpc+4xGgT0bK3vzy1HLN8jTO975HEbuYzZJcHoQEY5K1a0z8YayJkyVETa08eNTg==",
       "dev": true,
-      "license": "MIT",
       "dependencies": {
         "whatwg-mimetype": "^4.0.0",
         "whatwg-url": "^14.0.0"
@@ -4073,8 +4037,7 @@
       "version": "10.5.0",
       "resolved": "https://registry.npmjs.org/decimal.js/-/decimal.js-10.5.0.tgz",
       "integrity": "sha512-8vDa8Qxvr/+d94hSh5P3IJwI5t8/c0KsMp+g8bNw9cY2icONa5aPfvKeieW1WlG0WQYwwhJ7mjui2xtiePQSXw==",
-      "dev": true,
-      "license": "MIT"
+      "dev": true
     },
     "node_modules/deep-eql": {
       "version": "5.0.2",
@@ -4166,16 +4129,6 @@
       },
       "engines": {
         "node": ">= 14"
-      }
-    },
-    "node_modules/delayed-stream": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/delayed-stream/-/delayed-stream-1.0.0.tgz",
-      "integrity": "sha512-ZySD7Nf91aLB0RxL4KGrKHBXl7Eds1DAmEdcoVawXnLD7SDhpNgtuII2aAkg7a7QS41jxPSZ17p4VdGnMHk3MQ==",
-      "dev": true,
-      "license": "MIT",
-      "engines": {
-        "node": ">=0.4.0"
       }
     },
     "node_modules/depd": {
@@ -4615,22 +4568,6 @@
       "license": "MIT",
       "dependencies": {
         "es-errors": "^1.3.0"
-      },
-      "engines": {
-        "node": ">= 0.4"
-      }
-    },
-    "node_modules/es-set-tostringtag": {
-      "version": "2.1.0",
-      "resolved": "https://registry.npmjs.org/es-set-tostringtag/-/es-set-tostringtag-2.1.0.tgz",
-      "integrity": "sha512-j6vWzfrGVfyXxge+O0x5sh6cvxAog0a/4Rdd2K36zCMV5eJ+/+tOAngRO8cODMNWbVRdVlmGZQL2YS3yR8bIUA==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "es-errors": "^1.3.0",
-        "get-intrinsic": "^1.2.6",
-        "has-tostringtag": "^1.0.2",
-        "hasown": "^2.0.2"
       },
       "engines": {
         "node": ">= 0.4"
@@ -5561,22 +5498,6 @@
         "url": "https://opencollective.com/webpack"
       }
     },
-    "node_modules/form-data": {
-      "version": "4.0.2",
-      "resolved": "https://registry.npmjs.org/form-data/-/form-data-4.0.2.tgz",
-      "integrity": "sha512-hGfm/slu0ZabnNt4oaRZ6uREyfCj6P4fT/n6A1rGV+Z0VdGXjfOhVUpkn6qVQONHGIFwmveGXyDs75+nr6FM8w==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "asynckit": "^0.4.0",
-        "combined-stream": "^1.0.8",
-        "es-set-tostringtag": "^2.1.0",
-        "mime-types": "^2.1.12"
-      },
-      "engines": {
-        "node": ">= 6"
-      }
-    },
     "node_modules/formdata-polyfill": {
       "version": "4.0.10",
       "resolved": "https://registry.npmjs.org/formdata-polyfill/-/formdata-polyfill-4.0.10.tgz",
@@ -5936,22 +5857,6 @@
         "url": "https://github.com/sponsors/ljharb"
       }
     },
-    "node_modules/has-tostringtag": {
-      "version": "1.0.2",
-      "resolved": "https://registry.npmjs.org/has-tostringtag/-/has-tostringtag-1.0.2.tgz",
-      "integrity": "sha512-NqADB8VjPFLM2V0VvHUewwwsw0ZWBaIdgo+ieHtK3hasLz4qeCRjYcqfB6AQrBggRKppKF8L52/VqdVsO47Dlw==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "has-symbols": "^1.0.3"
-      },
-      "engines": {
-        "node": ">= 0.4"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/ljharb"
-      }
-    },
     "node_modules/hasown": {
       "version": "2.0.2",
       "resolved": "https://registry.npmjs.org/hasown/-/hasown-2.0.2.tgz",
@@ -6026,7 +5931,6 @@
       "resolved": "https://registry.npmjs.org/html-encoding-sniffer/-/html-encoding-sniffer-4.0.0.tgz",
       "integrity": "sha512-Y22oTqIU4uuPgEemfz7NDJz6OeKf12Lsu+QC+s3BVpda64lTiMYCyGwg5ki4vFxkMwQdeZDl2adZoqUgdFuTgQ==",
       "dev": true,
-      "license": "MIT",
       "dependencies": {
         "whatwg-encoding": "^3.1.1"
       },
@@ -6588,8 +6492,7 @@
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/is-potential-custom-element-name/-/is-potential-custom-element-name-1.0.1.tgz",
       "integrity": "sha512-bCYeRA2rVibKZd+s2625gGnGF/t7DSqDs4dP7CrLA1m7jKWz6pps0LpYLJN8Q64HtmPKJ1hrN3nzPNKFEKOUiQ==",
-      "dev": true,
-      "license": "MIT"
+      "dev": true
     },
     "node_modules/is-stream": {
       "version": "2.0.1",
@@ -6739,31 +6642,29 @@
       }
     },
     "node_modules/jsdom": {
-      "version": "25.0.1",
-      "resolved": "https://registry.npmjs.org/jsdom/-/jsdom-25.0.1.tgz",
-      "integrity": "sha512-8i7LzZj7BF8uplX+ZyOlIz86V6TAsSs+np6m1kpW9u0JWi4z/1t+FzcK1aek+ybTnAC4KhBL4uXCNT0wcUIeCw==",
+      "version": "26.1.0",
+      "resolved": "https://registry.npmjs.org/jsdom/-/jsdom-26.1.0.tgz",
+      "integrity": "sha512-Cvc9WUhxSMEo4McES3P7oK3QaXldCfNWp7pl2NNeiIFlCoLr3kfq9kb1fxftiwk1FLV7CvpvDfonxtzUDeSOPg==",
       "dev": true,
-      "license": "MIT",
       "dependencies": {
-        "cssstyle": "^4.1.0",
+        "cssstyle": "^4.2.1",
         "data-urls": "^5.0.0",
-        "decimal.js": "^10.4.3",
-        "form-data": "^4.0.0",
+        "decimal.js": "^10.5.0",
         "html-encoding-sniffer": "^4.0.0",
         "http-proxy-agent": "^7.0.2",
-        "https-proxy-agent": "^7.0.5",
+        "https-proxy-agent": "^7.0.6",
         "is-potential-custom-element-name": "^1.0.1",
-        "nwsapi": "^2.2.12",
-        "parse5": "^7.1.2",
-        "rrweb-cssom": "^0.7.1",
+        "nwsapi": "^2.2.16",
+        "parse5": "^7.2.1",
+        "rrweb-cssom": "^0.8.0",
         "saxes": "^6.0.0",
         "symbol-tree": "^3.2.4",
-        "tough-cookie": "^5.0.0",
+        "tough-cookie": "^5.1.1",
         "w3c-xmlserializer": "^5.0.0",
         "webidl-conversions": "^7.0.0",
         "whatwg-encoding": "^3.1.1",
         "whatwg-mimetype": "^4.0.0",
-        "whatwg-url": "^14.0.0",
+        "whatwg-url": "^14.1.1",
         "ws": "^8.18.0",
         "xml-name-validator": "^5.0.0"
       },
@@ -6771,7 +6672,7 @@
         "node": ">=18"
       },
       "peerDependencies": {
-        "canvas": "^2.11.2"
+        "canvas": "^3.0.0"
       },
       "peerDependenciesMeta": {
         "canvas": {
@@ -7591,11 +7492,10 @@
       }
     },
     "node_modules/nwsapi": {
-      "version": "2.2.16",
-      "resolved": "https://registry.npmjs.org/nwsapi/-/nwsapi-2.2.16.tgz",
-      "integrity": "sha512-F1I/bimDpj3ncaNDhfyMWuFqmQDBwDB0Fogc2qpL3BWvkQteFD/8BzWuIRl83rq0DXfm8SGt/HFhLXZyljTXcQ==",
-      "dev": true,
-      "license": "MIT"
+      "version": "2.2.20",
+      "resolved": "https://registry.npmjs.org/nwsapi/-/nwsapi-2.2.20.tgz",
+      "integrity": "sha512-/ieB+mDe4MrrKMT8z+mQL8klXydZWGR5Dowt4RAGKbJ3kIGEx3X4ljUo+6V73IXtUPWgfOlU5B9MlGxFO5T+cA==",
+      "dev": true
     },
     "node_modules/object-inspect": {
       "version": "1.13.4",
@@ -8622,11 +8522,10 @@
       }
     },
     "node_modules/rrweb-cssom": {
-      "version": "0.7.1",
-      "resolved": "https://registry.npmjs.org/rrweb-cssom/-/rrweb-cssom-0.7.1.tgz",
-      "integrity": "sha512-TrEMa7JGdVm0UThDJSx7ddw5nVm3UJS9o9CCIZ72B1vSyEZoziDqBYP3XIoi/12lKrJR8rE3jeFHMok2F/Mnsg==",
-      "dev": true,
-      "license": "MIT"
+      "version": "0.8.0",
+      "resolved": "https://registry.npmjs.org/rrweb-cssom/-/rrweb-cssom-0.8.0.tgz",
+      "integrity": "sha512-guoltQEx+9aMf2gDZ0s62EcV8lsXR+0w8915TC3ITdn2YueuNjdAYh/levpU9nFaoChh9RUS5ZdQMrKfVEN9tw==",
+      "dev": true
     },
     "node_modules/run-applescript": {
       "version": "7.0.0",
@@ -8707,7 +8606,6 @@
       "resolved": "https://registry.npmjs.org/saxes/-/saxes-6.0.0.tgz",
       "integrity": "sha512-xAg7SOnEhrm5zI3puOOKyy1OMcMlIJZYNJY7xLBwSze0UjhPLnWfj2GF2EpT0jmzaJKIWKHLsaSSajf35bcYnA==",
       "dev": true,
-      "license": "ISC",
       "dependencies": {
         "xmlchars": "^2.2.0"
       },
@@ -9513,8 +9411,7 @@
       "version": "3.2.4",
       "resolved": "https://registry.npmjs.org/symbol-tree/-/symbol-tree-3.2.4.tgz",
       "integrity": "sha512-9QNk5KwDF+Bvz+PyObkmSYjI5ksVUYtjW7AU22r2NKcfLJcXp96hkDWU3+XndOsUb+AQ9QhfzfCT2O+CNWT5Tw==",
-      "dev": true,
-      "license": "MIT"
+      "dev": true
     },
     "node_modules/table": {
       "version": "6.8.2",
@@ -9738,24 +9635,22 @@
       "license": "MIT"
     },
     "node_modules/tldts": {
-      "version": "6.1.78",
-      "resolved": "https://registry.npmjs.org/tldts/-/tldts-6.1.78.tgz",
-      "integrity": "sha512-fSgYrW0ITH0SR/CqKMXIruYIPpNu5aDgUp22UhYoSrnUQwc7SBqifEBFNce7AAcygUPBo6a/gbtcguWdmko4RQ==",
+      "version": "6.1.86",
+      "resolved": "https://registry.npmjs.org/tldts/-/tldts-6.1.86.tgz",
+      "integrity": "sha512-WMi/OQ2axVTf/ykqCQgXiIct+mSQDFdH2fkwhPwgEwvJ1kSzZRiinb0zF2Xb8u4+OqPChmyI6MEu4EezNJz+FQ==",
       "dev": true,
-      "license": "MIT",
       "dependencies": {
-        "tldts-core": "^6.1.78"
+        "tldts-core": "^6.1.86"
       },
       "bin": {
         "tldts": "bin/cli.js"
       }
     },
     "node_modules/tldts-core": {
-      "version": "6.1.78",
-      "resolved": "https://registry.npmjs.org/tldts-core/-/tldts-core-6.1.78.tgz",
-      "integrity": "sha512-jS0svNsB99jR6AJBmfmEWuKIgz91Haya91Z43PATaeHJ24BkMoNRb/jlaD37VYjb0mYf6gRL/HOnvS1zEnYBiw==",
-      "dev": true,
-      "license": "MIT"
+      "version": "6.1.86",
+      "resolved": "https://registry.npmjs.org/tldts-core/-/tldts-core-6.1.86.tgz",
+      "integrity": "sha512-Je6p7pkk+KMzMv2XXKmAE3McmolOQFdxkKw0R8EYNr7sELW46JqnNeTX8ybPiQgvg1ymCoF8LXs5fzFaZvJPTA==",
+      "dev": true
     },
     "node_modules/to-fast-properties": {
       "version": "2.0.0",
@@ -9791,11 +9686,10 @@
       }
     },
     "node_modules/tough-cookie": {
-      "version": "5.1.1",
-      "resolved": "https://registry.npmjs.org/tough-cookie/-/tough-cookie-5.1.1.tgz",
-      "integrity": "sha512-Ek7HndSVkp10hmHP9V4qZO1u+pn1RU5sI0Fw+jCU3lyvuMZcgqsNgc6CmJJZyByK4Vm/qotGRJlfgAX8q+4JiA==",
+      "version": "5.1.2",
+      "resolved": "https://registry.npmjs.org/tough-cookie/-/tough-cookie-5.1.2.tgz",
+      "integrity": "sha512-FVDYdxtnj0G6Qm/DhNPSb8Ju59ULcup3tuJxkFb5K8Bv2pUXILbf0xZWU8PX8Ov19OXljbUyveOFwRMwkXzO+A==",
       "dev": true,
-      "license": "BSD-3-Clause",
       "dependencies": {
         "tldts": "^6.1.32"
       },
@@ -9804,11 +9698,10 @@
       }
     },
     "node_modules/tr46": {
-      "version": "5.0.0",
-      "resolved": "https://registry.npmjs.org/tr46/-/tr46-5.0.0.tgz",
-      "integrity": "sha512-tk2G5R2KRwBd+ZN0zaEXpmzdKyOYksXwywulIX95MBODjSzMIuQnQ3m8JxgbhnL1LeVo7lqQKsYa1O3Htl7K5g==",
+      "version": "5.1.1",
+      "resolved": "https://registry.npmjs.org/tr46/-/tr46-5.1.1.tgz",
+      "integrity": "sha512-hdF5ZgjTqgAntKkklYw0R03MG2x/bSzTtkxmIRw/sTNV8YXsCJ1tfLAX23lhxhHJlEf3CRCOCGGWw3vI3GaSPw==",
       "dev": true,
-      "license": "MIT",
       "dependencies": {
         "punycode": "^2.3.1"
       },
@@ -10121,7 +10014,6 @@
       "resolved": "https://registry.npmjs.org/w3c-xmlserializer/-/w3c-xmlserializer-5.0.0.tgz",
       "integrity": "sha512-o8qghlI8NZHU1lLPrpi2+Uq7abh4GGPpYANlalzWxyWteJOCsr/P+oPBA49TOLu5FTZO4d3F9MnWJfiMo4BkmA==",
       "dev": true,
-      "license": "MIT",
       "dependencies": {
         "xml-name-validator": "^5.0.0"
       },
@@ -10300,7 +10192,6 @@
       "resolved": "https://registry.npmjs.org/webidl-conversions/-/webidl-conversions-7.0.0.tgz",
       "integrity": "sha512-VwddBukDzu71offAQR975unBIGqfKZpM+8ZX6ySk8nYhVoo5CYaZyzt3YBvYtRtO+aoGlqxPg/B87NGVZ/fu6g==",
       "dev": true,
-      "license": "BSD-2-Clause",
       "engines": {
         "node": ">=12"
       }
@@ -10736,13 +10627,12 @@
       }
     },
     "node_modules/whatwg-url": {
-      "version": "14.1.1",
-      "resolved": "https://registry.npmjs.org/whatwg-url/-/whatwg-url-14.1.1.tgz",
-      "integrity": "sha512-mDGf9diDad/giZ/Sm9Xi2YcyzaFpbdLpJPr+E9fSkyQ7KpQD4SdFcugkRQYzhmfI4KeV4Qpnn2sKPdo+kmsgRQ==",
+      "version": "14.2.0",
+      "resolved": "https://registry.npmjs.org/whatwg-url/-/whatwg-url-14.2.0.tgz",
+      "integrity": "sha512-De72GdQZzNTUBBChsXueQUnPKDkg/5A5zp7pFDuQAj5UFoENpiACU0wlCvzpAGnTkj++ihpKwKyYewn/XNUbKw==",
       "dev": true,
-      "license": "MIT",
       "dependencies": {
-        "tr46": "^5.0.0",
+        "tr46": "^5.1.0",
         "webidl-conversions": "^7.0.0"
       },
       "engines": {
@@ -10857,7 +10747,6 @@
       "resolved": "https://registry.npmjs.org/xml-name-validator/-/xml-name-validator-5.0.0.tgz",
       "integrity": "sha512-EvGK8EJ3DhaHfbRlETOWAS5pO9MZITeauHKJyb8wyajUfQUenkIg2MvLDTZ4T/TgIcm3HU0TFBgWWboAZ30UHg==",
       "dev": true,
-      "license": "Apache-2.0",
       "engines": {
         "node": ">=18"
       }
@@ -10866,8 +10755,7 @@
       "version": "2.2.0",
       "resolved": "https://registry.npmjs.org/xmlchars/-/xmlchars-2.2.0.tgz",
       "integrity": "sha512-JZnDKK8B0RCDw84FNdDAIpZK+JuJw+s7Lz8nksI7SIuU3UXJJslUthsi+uWBUYOwPFwW7W7PRLRfUKpxjtjFCw==",
-      "dev": true,
-      "license": "MIT"
+      "dev": true
     },
     "node_modules/y18n": {
       "version": "5.0.8",

--- a/package-lock.json
+++ b/package-lock.json
@@ -18,7 +18,7 @@
         "@types/p5": "^1.7.6",
         "@typescript-eslint/eslint-plugin": "^6.7.2",
         "@typescript-eslint/parser": "^6.7.2",
-        "blockly": "^12.0.0-beta.7",
+        "blockly": "^12.0.0",
         "chai": "^5.2.0",
         "eslint": "^8.49.0",
         "eslint-config-google": "^0.14.0",
@@ -34,7 +34,7 @@
         "webdriverio": "^9.12.1"
       },
       "peerDependencies": {
-        "blockly": "^12.0.0-beta.7"
+        "blockly": "^12.0.0"
       }
     },
     "node_modules/@asamuzakjp/css-color": {
@@ -3049,9 +3049,9 @@
       }
     },
     "node_modules/blockly": {
-      "version": "12.0.0-beta.7",
-      "resolved": "https://registry.npmjs.org/blockly/-/blockly-12.0.0-beta.7.tgz",
-      "integrity": "sha512-yKwPekH7cu2mELAoznExl11dfrCT4Phmynmm7fLJYmOsuVjUmPOUWRPGQd4e8ccCemkt5NLm7KmRWRZ1+4pXEA==",
+      "version": "12.0.0",
+      "resolved": "https://registry.npmjs.org/blockly/-/blockly-12.0.0.tgz",
+      "integrity": "sha512-CrwxGjbgCh/zGg46VTlp26NYblSi/82n4VFsamyW5b4W6t3HXaf/b3CbMuu4/YnFvqlyJs+8zR4OKNTbIc28EA==",
       "dev": true,
       "dependencies": {
         "jsdom": "26.1.0"

--- a/package.json
+++ b/package.json
@@ -57,7 +57,7 @@
     "@types/p5": "^1.7.6",
     "@typescript-eslint/eslint-plugin": "^6.7.2",
     "@typescript-eslint/parser": "^6.7.2",
-    "blockly": "^12.0.0-beta.4",
+    "blockly": "^12.0.0-beta.7",
     "chai": "^5.2.0",
     "eslint": "^8.49.0",
     "eslint-config-google": "^0.14.0",
@@ -73,11 +73,11 @@
     "webdriverio": "^9.12.1"
   },
   "peerDependencies": {
-    "blockly": "^12.0.0-beta.4"
+    "blockly": "^12.0.0-beta.7"
   },
   "overrides": {
     "@blockly/field-colour": {
-      "blockly": "^12.0.0-beta.4"
+      "blockly": "^12.0.0-beta.7"
     }
   },
   "publishConfig": {

--- a/package.json
+++ b/package.json
@@ -57,7 +57,7 @@
     "@types/p5": "^1.7.6",
     "@typescript-eslint/eslint-plugin": "^6.7.2",
     "@typescript-eslint/parser": "^6.7.2",
-    "blockly": "^12.0.0-beta.7",
+    "blockly": "^12.0.0",
     "chai": "^5.2.0",
     "eslint": "^8.49.0",
     "eslint-config-google": "^0.14.0",
@@ -73,11 +73,11 @@
     "webdriverio": "^9.12.1"
   },
   "peerDependencies": {
-    "blockly": "^12.0.0-beta.7"
+    "blockly": "^12.0.0"
   },
   "overrides": {
     "@blockly/field-colour": {
-      "blockly": "^12.0.0-beta.7"
+      "blockly": "^12.0.0"
     }
   },
   "publishConfig": {

--- a/test/webdriverio/test/basic_test.ts
+++ b/test/webdriverio/test/basic_test.ts
@@ -10,7 +10,7 @@ import {
   setCurrentCursorNodeById,
   setCurrentCursorNodeByIdAndFieldName,
   getCurrentFocusNodeId,
-  getFocusedConnectionType,
+  getCurrentFocusedBlockId,
   getFocusedFieldName,
   testSetup,
   testFileLocations,
@@ -45,7 +45,7 @@ suite('Keyboard navigation on Blocks', function () {
     }
 
     chai
-      .expect(await getCurrentFocusNodeId(this.browser))
+      .expect(await getCurrentFocusedBlockId(this.browser))
       .equal('controls_if_2');
   });
 
@@ -57,7 +57,9 @@ suite('Keyboard navigation on Blocks', function () {
     await this.browser.keys(Key.ArrowDown);
     await this.browser.pause(PAUSE_TIME);
 
-    chai.expect(await getCurrentFocusNodeId(this.browser)).equal('p5_draw_1');
+    chai
+      .expect(await getCurrentFocusedBlockId(this.browser))
+      .equal('p5_draw_1');
   });
 
   test('Up from statement block selects previous block', async function () {
@@ -69,7 +71,7 @@ suite('Keyboard navigation on Blocks', function () {
     await this.browser.pause(PAUSE_TIME);
 
     chai
-      .expect(await getCurrentFocusNodeId(this.browser))
+      .expect(await getCurrentFocusedBlockId(this.browser))
       .equal('draw_emoji_1');
   });
 
@@ -80,7 +82,9 @@ suite('Keyboard navigation on Blocks', function () {
     await this.browser.pause(PAUSE_TIME);
     await this.browser.keys(Key.ArrowDown);
     await this.browser.pause(PAUSE_TIME);
-    chai.expect(await getCurrentFocusNodeId(this.browser)).equal('p5_canvas_1');
+    chai
+      .expect(await getCurrentFocusedBlockId(this.browser))
+      .equal('p5_canvas_1');
   });
 
   test('Up from child block selects parent block', async function () {
@@ -90,7 +94,9 @@ suite('Keyboard navigation on Blocks', function () {
     await this.browser.pause(PAUSE_TIME);
     await this.browser.keys(Key.ArrowUp);
     await this.browser.pause(PAUSE_TIME);
-    chai.expect(await getCurrentFocusNodeId(this.browser)).equal('p5_setup_1');
+    chai
+      .expect(await getCurrentFocusedBlockId(this.browser))
+      .equal('p5_setup_1');
   });
 
   test('Right from block selects first field', async function () {
@@ -117,7 +123,7 @@ suite('Keyboard navigation on Blocks', function () {
     await this.browser.pause(PAUSE_TIME);
 
     chai.assert.equal(
-      await getCurrentFocusNodeId(this.browser),
+      await getCurrentFocusedBlockId(this.browser),
       'colour_picker_1',
     );
   });
@@ -131,7 +137,7 @@ suite('Keyboard navigation on Blocks', function () {
     await this.browser.pause(PAUSE_TIME);
 
     chai.assert.equal(
-      await getCurrentFocusNodeId(this.browser),
+      await getCurrentFocusedBlockId(this.browser),
       'controls_repeat_ext_1',
     );
   });
@@ -145,7 +151,7 @@ suite('Keyboard navigation on Blocks', function () {
     await this.browser.pause(PAUSE_TIME);
 
     chai.assert.equal(
-      await getCurrentFocusNodeId(this.browser),
+      await getCurrentFocusedBlockId(this.browser),
       'math_modulo_1',
     );
   });
@@ -159,7 +165,7 @@ suite('Keyboard navigation on Blocks', function () {
     await this.browser.pause(PAUSE_TIME);
 
     chai.assert.equal(
-      await getCurrentFocusNodeId(this.browser),
+      await getCurrentFocusedBlockId(this.browser),
       'math_number_3',
     );
   });
@@ -173,7 +179,7 @@ suite('Keyboard navigation on Blocks', function () {
     await this.browser.pause(PAUSE_TIME);
 
     chai.assert.equal(
-      await getCurrentFocusNodeId(this.browser),
+      await getCurrentFocusedBlockId(this.browser),
       'math_number_2',
     );
   });
@@ -187,7 +193,7 @@ suite('Keyboard navigation on Blocks', function () {
     await this.browser.pause(PAUSE_TIME);
 
     chai
-      .expect(await getCurrentFocusNodeId(this.browser))
+      .expect(await getCurrentFocusedBlockId(this.browser))
       .equal('controls_repeat_ext_1');
   });
 
@@ -200,7 +206,7 @@ suite('Keyboard navigation on Blocks', function () {
     await this.browser.pause(PAUSE_TIME);
 
     chai
-      .expect(await getCurrentFocusNodeId(this.browser))
+      .expect(await getCurrentFocusedBlockId(this.browser))
       .equal('controls_repeat_ext_1');
   });
 
@@ -213,7 +219,7 @@ suite('Keyboard navigation on Blocks', function () {
     await this.browser.pause(PAUSE_TIME);
 
     chai
-      .expect(await getCurrentFocusNodeId(this.browser))
+      .expect(await getCurrentFocusedBlockId(this.browser))
       .equal('text_print_1');
   });
 
@@ -225,7 +231,7 @@ suite('Keyboard navigation on Blocks', function () {
     await this.browser.keys(Key.ArrowRight);
     await this.browser.pause(PAUSE_TIME);
 
-    chai.assert.equal(await getCurrentFocusNodeId(this.browser), 'text_1');
+    chai.assert.equal(await getCurrentFocusedBlockId(this.browser), 'text_1');
 
     await this.browser.keys(Key.ArrowRight);
     await this.browser.pause(PAUSE_TIME);
@@ -238,7 +244,7 @@ suite('Keyboard navigation on Blocks', function () {
     await this.browser.pause(PAUSE_TIME);
 
     chai
-      .expect(await getCurrentFocusNodeId(this.browser))
+      .expect(await getCurrentFocusedBlockId(this.browser))
       .equal('controls_repeat_1');
   });
 });
@@ -265,7 +271,10 @@ suite('Keyboard navigation on Fields', function () {
     await this.browser.keys(Key.ArrowUp);
     await this.browser.pause(PAUSE_TIME);
 
-    chai.assert.equal(await getCurrentFocusNodeId(this.browser), 'p5_canvas_1');
+    chai.assert.equal(
+      await getCurrentFocusedBlockId(this.browser),
+      'p5_canvas_1',
+    );
   });
 
   test('Left from first field selects block', async function () {
@@ -280,7 +289,10 @@ suite('Keyboard navigation on Fields', function () {
     await this.browser.keys(Key.ArrowLeft);
     await this.browser.pause(PAUSE_TIME);
 
-    chai.assert.equal(await getCurrentFocusNodeId(this.browser), 'p5_canvas_1');
+    chai.assert.equal(
+      await getCurrentFocusedBlockId(this.browser),
+      'p5_canvas_1',
+    );
   });
 
   test('Right from first field selects second field', async function () {
@@ -333,7 +345,9 @@ suite('Keyboard navigation on Fields', function () {
     await this.browser.keys(Key.ArrowRight);
     await this.browser.pause(PAUSE_TIME);
 
-    chai.expect(await getCurrentFocusNodeId(this.browser)).equal('p5_draw_1');
+    chai
+      .expect(await getCurrentFocusedBlockId(this.browser))
+      .equal('p5_draw_1');
   });
 
   test('Down from field selects next block', async function () {
@@ -348,7 +362,9 @@ suite('Keyboard navigation on Fields', function () {
     await this.browser.keys(Key.ArrowDown);
     await this.browser.pause(PAUSE_TIME);
 
-    chai.expect(await getCurrentFocusNodeId(this.browser)).equal('p5_draw_1');
+    chai
+      .expect(await getCurrentFocusedBlockId(this.browser))
+      .equal('p5_draw_1');
   });
 
   test("Down from field selects block's child block", async function () {
@@ -364,7 +380,7 @@ suite('Keyboard navigation on Fields', function () {
     await this.browser.pause(PAUSE_TIME);
 
     chai
-      .expect(await getCurrentFocusNodeId(this.browser))
+      .expect(await getCurrentFocusedBlockId(this.browser))
       .equal('draw_emoji_1');
   });
 });


### PR DESCRIPTION
Fixes #525

These tests were broken as a result of https://github.com/google/blockly/pull/9045 and have been updated as such:
- Many of these existing `getCurrentFocusNodeId` calls have been updated to use a new `getCurrentFocusedBlockId` since they actually want to match against a block's data ID rather than its focus-specific ID (which is new as of https://github.com/google/blockly/pull/9045).
- There are still some existing uses for `getCurrentFocusNodeId` (specifically fields).

Separately, `clickBlock` has been removed. Its uses were removed in #482 (I think) in favor of direct keyboard navigation. I suspect this is the pattern we want to keep moving forward since it has better alignment with real user behavior, so removing the helper ensures tests don't fall back on it instead of trying to use real navigation.

Finally, this PR also updates the plugin to 12.0.0 of Blockly now that it's fully launched. I've tested this against a variety of scenarios yesterday and today so it seems to be working pretty well (#526 notwithstanding). Additionally, the CI workflows have been updated to link against latest develop as the new "tip-of-tree" v12. Unfortunately there was a behavioral discrepancy between beta.7 and the full 12.0.0 release which resulted in 1 new test failing. This will be fixed by https://github.com/google/blockly/pull/9063 but it means two things:
1. The CI for this PR won't pass until https://github.com/google/blockly/pull/9063 is merged.
2. The `main` branch's CI won't pass once this is merged due to that one test failing. Once we push a 12.0.1 or 12.1.0 version of Blockly and update this plugin accordingly, the test will start passing in `main`'s CI.