### PR TITLE
Finish drag on focus change

### DIFF
--- a/src/actions/mover.ts
+++ b/src/actions/mover.ts
@@ -128,7 +128,7 @@ export class Mover {
     // Set up a blur listener to end the move if the user clicks away
     const blurListener = () => {
       this.finishMove(workspace);
-    }
+    };
     // Record that a move is in progress and start dragging.
     workspace.setKeyboardMoveInProgress(true);
     const info = new MoveInfo(block, dragger, blurListener);
@@ -139,7 +139,7 @@ export class Mover {
     // In case the block is detached, ensure that it still retains focus
     // (otherwise dragging will break).
     getFocusManager().focusNode(block);
-    block.getFocusableElement().addEventListener('blur', blurListener)
+    block.getFocusableElement().addEventListener('blur', blurListener);
     return true;
   }
 
@@ -158,7 +158,9 @@ export class Mover {
     if (!info) throw new Error('no move info for workspace');
 
     // Remove the blur listener before ending the drag
-    info.block.getFocusableElement().removeEventListener('blur', info.blurListener);
+    info.block
+      .getFocusableElement()
+      .removeEventListener('blur', info.blurListener);
 
     info.dragger.onDragEnd(
       info.fakePointerEvent('pointerup'),

--- a/test/webdriverio/test/basic_test.ts
+++ b/test/webdriverio/test/basic_test.ts
@@ -253,7 +253,7 @@ suite('Keyboard navigation on Blocks', function () {
     await tabNavigateToWorkspace(this.browser);
     await this.browser.pause(PAUSE_TIME);
     await setCurrentCursorNodeById(this.browser, 'text_print_1');
-    await this.browser.keys("m");
+    await this.browser.keys('m');
     await this.browser.pause(PAUSE_TIME);
 
     chai.assert.isTrue(await isDragging(this.browser));

--- a/test/webdriverio/test/basic_test.ts
+++ b/test/webdriverio/test/basic_test.ts
@@ -7,6 +7,7 @@
 import * as chai from 'chai';
 import * as Blockly from 'blockly';
 import {
+  isDragging,
   setCurrentCursorNodeById,
   setCurrentCursorNodeByIdAndFieldName,
   getCurrentFocusNodeId,
@@ -246,6 +247,21 @@ suite('Keyboard navigation on Blocks', function () {
     chai
       .expect(await getCurrentFocusedBlockId(this.browser))
       .equal('controls_repeat_1');
+  });
+
+  test('Losing focus cancels move', async function () {
+    await tabNavigateToWorkspace(this.browser);
+    await this.browser.pause(PAUSE_TIME);
+    await setCurrentCursorNodeById(this.browser, 'text_print_1');
+    await this.browser.keys("m");
+    await this.browser.pause(PAUSE_TIME);
+
+    chai.assert.isTrue(await isDragging(this.browser));
+
+    await this.browser.keys(Key.Tab);
+    await this.browser.pause(PAUSE_TIME);
+
+    chai.assert.isFalse(await isDragging(this.browser));
   });
 });
 

--- a/test/webdriverio/test/test_setup.ts
+++ b/test/webdriverio/test/test_setup.ts
@@ -362,7 +362,9 @@ export async function tabNavigateForward(browser: WebdriverIO.Browser) {
  *
  * @param browser The active WebdriverIO Browser object.
  */
-export async function isDragging(browser: WebdriverIO.Browser): Promise<boolean> {
+export async function isDragging(
+  browser: WebdriverIO.Browser,
+): Promise<boolean> {
   return await browser.execute(() => {
     const workspaceSvg = Blockly.getMainWorkspace() as Blockly.WorkspaceSvg;
     return workspaceSvg.isDragging();

--- a/test/webdriverio/test/test_setup.ts
+++ b/test/webdriverio/test/test_setup.ts
@@ -356,3 +356,15 @@ export async function tabNavigateForward(browser: WebdriverIO.Browser) {
   await browser.keys(webdriverio.Key.Tab);
   await browser.pause(PAUSE_TIME);
 }
+
+/**
+ * Returns whether there's a drag in progress on the main workspace.
+ *
+ * @param browser The active WebdriverIO Browser object.
+ */
+export async function isDragging(browser: WebdriverIO.Browser): Promise<boolean> {
+  return await browser.execute(() => {
+    const workspaceSvg = Blockly.getMainWorkspace() as Blockly.WorkspaceSvg;
+    return workspaceSvg.isDragging();
+  });
+}


### PR DESCRIPTION
Fixes #444 

Adds a blur listener to the block's element during a keyboard move that ends the move if focus is lost.