### PR TITLE
feat: Allow visiting and activating icons via keyboard navigation.

### DIFF
--- a/src/actions/enter.ts
+++ b/src/actions/enter.ts
@@ -14,6 +14,7 @@ import {
   RenderedConnection,
   WorkspaceSvg,
   Field,
+  icons,
   FocusableTreeTraverser,
 } from 'blockly/core';
 
@@ -106,6 +107,8 @@ export class EnterAction {
       curNode instanceof WorkspaceSvg
     ) {
       this.navigation.openToolboxOrFlyout(workspace);
+    } else if (curNode instanceof icons.Icon) {
+      curNode.onClick();
     }
   }
 

--- a/test/index.html
+++ b/test/index.html
@@ -104,7 +104,10 @@
         .blocklyActiveFocus:is(.blocklyPath, .blocklyHighlightedConnectionPath),
       .blocklyKeyboardNavigation
         .blocklyActiveFocus.blocklyField
-        > .blocklyFieldRect {
+        > .blocklyFieldRect,
+      .blocklyKeyboardNavigation
+        .blocklyActiveFocus.blocklyIconGroup
+        > .blocklyIconShape:first-child {
         stroke: var(--blockly-active-node-color);
         stroke-width: var(--blockly-selection-width);
       }
@@ -115,7 +118,10 @@
         ),
       .blocklyKeyboardNavigation
         .blocklyPassiveFocus.blocklyField
-        > .blocklyFieldRect {
+        > .blocklyFieldRect,
+      .blocklyKeyboardNavigation
+        .blocklyPassiveFocus.blocklyIconGroup
+        > .blocklyIconShape:first-child {
         stroke: var(--blockly-active-node-color);
         stroke-dasharray: 5px 3px;
         stroke-width: var(--blockly-selection-width);


### PR DESCRIPTION
In conjunction with https://github.com/google/blockly/pull/9072, this PR partly fixes #189. It allows icons to be visited and activated. Support for moving focus to icon bubbles will be forthcoming in future PRs. Navigation logic is tested in the core PR.