### PR TITLE
fix: Fix positioning of move indicator for blocks with children.

### DIFF
--- a/src/move_indicator.ts
+++ b/src/move_indicator.ts
@@ -88,7 +88,7 @@ export class MoveIndicatorBubble
    * Recalculates this bubble's location, keeping it adjacent to its block.
    */
   updateLocation() {
-    const bounds = this.sourceBlock.getBoundingRectangle();
+    const bounds = this.sourceBlock.getBoundingRectangleWithoutChildren();
     const x = this.sourceBlock.workspace.RTL
       ? bounds.left + 20
       : bounds.right - 20;


### PR DESCRIPTION
This PR fixes #475 by positioning the move indicator relative to the bounds of the block being moved not including its children, which causes it to always be attached to the corner of the root block being moved.