### PR TITLE
fix(mover): Don't heal rows when disconnecting at start of move

### DIFF
--- a/src/keyboard_drag_strategy.ts
+++ b/src/keyboard_drag_strategy.ts
@@ -326,6 +326,6 @@ export class KeyboardDragStrategy extends dragging.BlockDragStrategy {
   }
 
   override shouldHealStack(e: PointerEvent | undefined): boolean {
-    return true;
+    return Boolean(this.block.previousConnection);
   }
 }

--- a/test/index.html
+++ b/test/index.html
@@ -184,6 +184,7 @@
                 <option value="navigationTestBlocks">
                   navigation test blocks
                 </option>
+                <option value="moveTestBlocks">move test blocks</option>
               </select>
             </div>
             <div>

--- a/test/loadTestBlocks.js
+++ b/test/loadTestBlocks.js
@@ -570,6 +570,298 @@ const navigationTestBlocks = {
   },
 };
 
+const moveTestBlocks = {
+  'blocks': {
+    'languageVersion': 0,
+    'blocks': [
+      {
+        'type': 'p5_setup',
+        'id': 'p5_setup_1',
+        'x': 0,
+        'y': 75,
+        'deletable': false,
+        'inputs': {
+          'STATEMENTS': {
+            'block': {
+              'type': 'p5_canvas',
+              'id': 'p5_canvas_1',
+              'deletable': false,
+              'movable': false,
+              'fields': {
+                'WIDTH': 400,
+                'HEIGHT': 400,
+              },
+            },
+          },
+        },
+      },
+      {
+        'type': 'p5_draw',
+        'id': 'p5_draw_1',
+        'x': 0,
+        'y': 332,
+        'deletable': false,
+        'inputs': {
+          'STATEMENTS': {
+            'block': {
+              'type': 'controls_if',
+              'id': 'statement_1',
+              'inputs': {
+                'IF0': {
+                  'block': {
+                    'type': 'logic_operation',
+                    'id': 'value_1',
+                    'fields': {
+                      'OP': 'AND',
+                    },
+                    'inputs': {
+                      'A': {
+                        'block': {
+                          'type': 'logic_boolean',
+                          'id': 'value_1_1',
+                          'fields': {
+                            'BOOL': 'TRUE',
+                          },
+                        },
+                      },
+                      'B': {
+                        'block': {
+                          'type': 'logic_boolean',
+                          'id': 'value_1_2',
+                          'fields': {
+                            'BOOL': 'TRUE',
+                          },
+                        },
+                      },
+                    },
+                  },
+                },
+              },
+              'next': {
+                'block': {
+                  'type': 'controls_if',
+                  'id': 'statement_2',
+                  'inputs': {
+                    'IF0': {
+                      'block': {
+                        'type': 'logic_negate',
+                        'id': 'value_2',
+                        'inputs': {
+                          'BOOL': {
+                            'block': {
+                              'type': 'logic_boolean',
+                              'id': 'value_2_1',
+                              'fields': {
+                                'BOOL': 'TRUE',
+                              },
+                            },
+                          },
+                        },
+                      },
+                    },
+                  },
+                  'next': {
+                    'block': {
+                      'type': 'controls_repeat_ext',
+                      'id': 'statement_3',
+                      'inputs': {
+                        'TIMES': {
+                          'shadow': {
+                            'type': 'math_number',
+                            'id': 'shadow_3',
+                            'fields': {
+                              'NUM': 10,
+                            },
+                          },
+                          'block': {
+                            'type': 'math_arithmetic',
+                            'id': 'value_3',
+                            'fields': {
+                              'OP': 'ADD',
+                            },
+                            'inputs': {
+                              'A': {
+                                'shadow': {
+                                  'type': 'math_number',
+                                  'id': 'shadow_3_1',
+                                  'fields': {
+                                    'NUM': 1,
+                                  },
+                                },
+                                'block': {
+                                  'type': 'math_number',
+                                  'id': 'value_3_1',
+                                  'fields': {
+                                    'NUM': 0,
+                                  },
+                                },
+                              },
+                              'B': {
+                                'shadow': {
+                                  'type': 'math_number',
+                                  'id': 'shadow_3_2',
+                                  'fields': {
+                                    'NUM': 1,
+                                  },
+                                },
+                                'block': {
+                                  'type': 'math_number',
+                                  'id': 'value_3_2',
+                                  'fields': {
+                                    'NUM': 0,
+                                  },
+                                },
+                              },
+                            },
+                          },
+                        },
+                      },
+                      'next': {
+                        'block': {
+                          'type': 'controls_repeat_ext',
+                          'id': 'statement_4',
+                          'inputs': {
+                            'TIMES': {
+                              'shadow': {
+                                'type': 'math_number',
+                                'id': 'shadow_4',
+                                'fields': {
+                                  'NUM': 10,
+                                },
+                              },
+                              'block': {
+                                'type': 'math_trig',
+                                'id': 'value_4',
+                                'fields': {
+                                  'OP': 'SIN',
+                                },
+                                'inputs': {
+                                  'NUM': {
+                                    'shadow': {
+                                      'type': 'math_number',
+                                      'id': 'shadow_4_1',
+                                      'fields': {
+                                        'NUM': 45,
+                                      },
+                                    },
+                                    'block': {
+                                      'type': 'math_number',
+                                      'id': 'value_4_1',
+                                      'fields': {
+                                        'NUM': 180,
+                                      },
+                                    },
+                                  },
+                                },
+                              },
+                            },
+                          },
+                          'next': {
+                            'block': {
+                              'type': 'text_print',
+                              'id': 'statement_5',
+                              'inputs': {
+                                'TEXT': {
+                                  'shadow': {
+                                    'type': 'text',
+                                    'id': 'shadow_5',
+                                    'fields': {
+                                      'TEXT': 'abc',
+                                    },
+                                  },
+                                  'block': {
+                                    'type': 'text_join',
+                                    'id': 'value_5',
+                                    'extraState': {
+                                      'itemCount': 2,
+                                    },
+                                    'inputs': {
+                                      'ADD0': {
+                                        'block': {
+                                          'type': 'text',
+                                          'id': 'value_5_1',
+                                          'fields': {
+                                            'TEXT': 'test',
+                                          },
+                                        },
+                                      },
+                                      'ADD1': {
+                                        'block': {
+                                          'type': 'text',
+                                          'id': 'value_5_2',
+                                          'fields': {
+                                            'TEXT': 'test',
+                                          },
+                                        },
+                                      },
+                                    },
+                                  },
+                                },
+                              },
+                              'next': {
+                                'block': {
+                                  'type': 'text_print',
+                                  'id': 'statement_6',
+                                  'inputs': {
+                                    'TEXT': {
+                                      'shadow': {
+                                        'type': 'text',
+                                        'id': 'shadow_6',
+                                        'fields': {
+                                          'TEXT': 'abc',
+                                        },
+                                      },
+                                      'block': {
+                                        'type': 'text_reverse',
+                                        'id': 'value_6',
+                                        'inputs': {
+                                          'TEXT': {
+                                            'shadow': {
+                                              'type': 'text',
+                                              'id': 'shadow_6_1',
+                                              'fields': {
+                                                'TEXT': '',
+                                              },
+                                            },
+                                            'block': {
+                                              'type': 'text',
+                                              'id': 'value_6_1',
+                                              'fields': {
+                                                'TEXT': 'test',
+                                              },
+                                            },
+                                          },
+                                        },
+                                      },
+                                    },
+                                  },
+                                  'next': {
+                                    'block': {
+                                      'type': 'draw_emoji',
+                                      'id': 'statement_7',
+                                      'fields': {
+                                        'emoji': '❤️',
+                                      },
+                                    },
+                                  },
+                                },
+                              },
+                            },
+                          },
+                        },
+                      },
+                    },
+                  },
+                },
+              },
+            },
+          },
+        },
+      },
+    ],
+  },
+};
+
 /**
  * Loads saved state from local storage into the given workspace.
  * @param {Blockly.Workspace} workspace Blockly workspace to load into.
@@ -582,6 +874,7 @@ export const load = function (workspace, scenarioString) {
     'simpleCircle': simpleCircle,
     'moreBlocks': moreBlocks,
     'navigationTestBlocks': navigationTestBlocks,
+    'moveTestBlocks': moveTestBlocks,
   };
 
   const data = JSON.stringify(scenarioMap[scenarioString]);

--- a/test/webdriverio/test/move_test.ts
+++ b/test/webdriverio/test/move_test.ts
@@ -30,7 +30,7 @@ suite('Move tests', function () {
   // moved, with subsequent statement blocks below it in the stack
   // reattached to where the moving block was - i.e., that a stack
   // heal will occur.
-  test.only('Start moving statement blocks', async function () {
+  test('Start moving statement blocks', async function () {
     for (let i = 1; i < 7; i++) {
       // Navigate to statement_<i>.
       await tabNavigateToWorkspace(this.browser);
@@ -90,7 +90,7 @@ suite('Move tests', function () {
   // When a move of a value block begins, it is expected that block
   // and all blocks connected to its inputs will be moved - i.e., that
   // a stack heal (really: unary operator chain heal) will NOT occur.
-  test.only('Start moving value blocks', async function () {
+  test('Start moving value blocks', async function () {
     for (let i = 1; i < 7; i++) {
       // Navigate to statement_<i>.
       await tabNavigateToWorkspace(this.browser);

--- a/test/webdriverio/test/move_test.ts
+++ b/test/webdriverio/test/move_test.ts
@@ -4,6 +4,7 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
+import * as Blockly from 'blockly';
 import * as chai from 'chai';
 import {Browser, Key} from 'webdriverio';
 import {
@@ -24,4 +25,184 @@ suite('Move tests', function () {
     this.browser = await testSetup(testFileLocations.MOVE_TEST_BLOCKS);
     await this.browser.pause(PAUSE_TIME);
   });
+
+  // When a move of a statement block begins, it is expected that only
+  // that block (and all blocks connected to its inputs) will be
+  // moved, with subsequent statement blocks below it in the stack
+  // reattached to where the moving block was - i.e., that a stack
+  // heal will occur.
+  test.only('Start moving statement blocks', async function () {
+    for (let i = 1; i < 7; i++) {
+      // Navigate to statement_<i>.
+      await tabNavigateToWorkspace(this.browser);
+      await setCurrentCursorNodeById(this.browser, `statement_${i}`);
+
+      // Get information about parent connection of selected block,
+      // and block connected to selected block's next connection.
+      const info = await getSelectedNeighbourInfo(this.browser);
+
+      chai.assert(info.parentId, 'selected block has no parent block');
+      chai.assert(
+        typeof info.parentIndex === 'number',
+        'parent connection index not found',
+      );
+      chai.assert(info.nextId, 'selected block has no next block');
+
+      // Start move.
+      await this.browser.keys('m');
+
+      // Check that the moving block has nothing connected it its
+      // next/previous connections, and same thing connected to value
+      // input.
+      const newInfo = await getSelectedNeighbourInfo(this.browser);
+      chai.assert(
+        newInfo.parentId === null,
+        'moving block should have no parent block',
+      );
+      chai.assert(
+        newInfo.nextId === null,
+        'moving block should have no next block',
+      );
+      chai.assert.strictEqual(
+        newInfo.valueId,
+        info.valueId,
+        'moving block should have same attached value block',
+      );
+
+      // Get ID of next block now connected to the (former) parent
+      // connection of the currently-moving block (skipping insertion
+      // markers), and make sure it's same as the ID of the block that
+      // was formerly attached to the moving block's next connection.
+      const newNextId = await this.browser.execute(
+        (parentId: string, index: number) => {
+          const parent = Blockly.getMainWorkspace().getBlockById(parentId);
+          if (!parent) throw new Error('parent block gone');
+          let block = parent.getConnections_(true)[index].targetBlock();
+          while (block?.isInsertionMarker()) {
+            block = block.getNextBlock();
+          }
+          return block?.id;
+        },
+        info.parentId,
+        info.parentIndex,
+      );
+      chai.assert.strictEqual(
+        newNextId,
+        info.nextId,
+        'former parent connection should be connected to former next block',
+      );
+
+      // Abort move.
+      await this.browser.keys(Key.Escape);
+    }
+  });
+
+  // When a move of a value block begins, it is expected that block
+  // and all blocks connected to its inputs will be moved - i.e., that
+  // a stack heal (really: unary operator chain heal) will NOT occur.
+  test.only('Start moving value blocks', async function () {
+    for (let i = 1; i < 7; i++) {
+      // Navigate to statement_<i>.
+      await tabNavigateToWorkspace(this.browser);
+      await setCurrentCursorNodeById(this.browser, `value_${i}`);
+
+      // Get information about parent connection of selected block,
+      // and block connected to selected block's value input.
+      const info = await getSelectedNeighbourInfo(this.browser);
+
+      chai.assert(info.parentId, 'selected block has no parent block');
+      chai.assert(
+        typeof info.parentIndex === 'number',
+        'parent connection index not found',
+      );
+      chai.assert(info.valueId, 'selected block has no child value block');
+
+      // Start move.
+      await this.browser.keys('m');
+
+      // Check that the moving block has nothing connected it its
+      // next/previous connections, and same thing connected to value
+      // input.
+      const newInfo = await getSelectedNeighbourInfo(this.browser);
+      chai.assert(
+        newInfo.parentId === null,
+        'moving block should have no parent block',
+      );
+      chai.assert(
+        newInfo.nextId === null,
+        'moving block should have no next block',
+      );
+      chai.assert.strictEqual(
+        newInfo.valueId,
+        info.valueId,
+        'moving block should have same attached value block',
+      );
+
+      // Check the (former) parent connection of the currently-moving
+      // block is (skipping insertion markers) either unconnected or
+      // connected to a shadow block, and that is is not the block
+      // (originally and still) connected to the moving block's zeroth
+      // value input.
+      const newValueInfo = await this.browser.execute(
+        (parentId: string, index: number) => {
+          const parent = Blockly.getMainWorkspace().getBlockById(parentId);
+          if (!parent) throw new Error('parent block gone');
+          let block = parent.getConnections_(true)[index].targetBlock() ?? null;
+          while (block?.isInsertionMarker()) {
+            block = block.inputList[0].connection?.targetBlock() ?? null;
+          }
+          return {
+            id: block?.id ?? null,
+            shadow: block?.isShadow() ?? null,
+          };
+        },
+        info.parentId,
+        info.parentIndex,
+      );
+      chai.assert(
+        newValueInfo.id === null || newValueInfo.shadow,
+        'former parent connection should be unconnected (or shadow)',
+      );
+      chai.assert.notStrictEqual(
+        newValueInfo.id,
+        info.valueId,
+        'former parent connection should NOT be connected to value block',
+      );
+
+      // Abort move.
+      await this.browser.keys(Key.Escape);
+    }
+  });
 });
+
+/**
+ * Get information about the currently-selected block's parent and
+ * child blocks.
+ *
+ * N.B. explicitly converts any undefined values to null because
+ * browser.execute does this implicitly and so otherwise this function
+ * would return values that were not compliant with its own inferred
+ * type signature!
+ *
+ * @returns A promise setting to an object containing the parent block
+ * ID, index of parent connection, next block ID, and ID of the block
+ * connected to the zeroth value value input.
+ */
+function getSelectedNeighbourInfo(browser: WebdriverIO.Browser) {
+  return browser.execute(() => {
+    const block = Blockly.getFocusManager().getFocusedNode() as
+      | Blockly.BlockSvg
+      | undefined;
+    if (!block) throw new Error('no selected block');
+    const parent = block?.getParent();
+    return {
+      parentId: parent?.id ?? null,
+      parentIndex:
+        parent
+          ?.getConnections_(true)
+          .findIndex((conn) => conn.targetBlock() === block) ?? null,
+      nextId: block?.getNextBlock()?.id ?? null,
+      valueId: block?.inputList[0].connection?.targetBlock()?.id ?? null,
+    };
+  });
+}

--- a/test/webdriverio/test/move_test.ts
+++ b/test/webdriverio/test/move_test.ts
@@ -197,11 +197,7 @@ function getFocusedNeighbourInfo(browser: Browser) {
  *     the connected block or null if no block is connected, and
  *     shadow is true iff the connected block is a shadow.
  */
-function getConnectedBlockInfo(
-  browser: Browser,
-  id: string,
-  index: number,
-) {
+function getConnectedBlockInfo(browser: Browser, id: string, index: number) {
   return browser.execute(
     (id: string, index: number) => {
       const parent = Blockly.getMainWorkspace().getBlockById(id);

--- a/test/webdriverio/test/move_test.ts
+++ b/test/webdriverio/test/move_test.ts
@@ -1,0 +1,27 @@
+/**
+ * @license
+ * Copyright 2025 Google LLC
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import * as chai from 'chai';
+import {Browser, Key} from 'webdriverio';
+import {
+  getFocusedBlockType,
+  PAUSE_TIME,
+  setCurrentCursorNodeById,
+  tabNavigateToWorkspace,
+  testFileLocations,
+  testSetup,
+} from './test_setup.js';
+
+suite('Move tests', function () {
+  // Setting timeout to unlimited as these tests take longer time to run
+  this.timeout(0);
+
+  // Clear the workspace and load start blocks
+  setup(async function () {
+    this.browser = await testSetup(testFileLocations.MOVE_TEST_BLOCKS);
+    await this.browser.pause(PAUSE_TIME);
+  });
+});

--- a/test/webdriverio/test/move_test.ts
+++ b/test/webdriverio/test/move_test.ts
@@ -190,10 +190,12 @@ suite('Move tests', function () {
  */
 function getSelectedNeighbourInfo(browser: WebdriverIO.Browser) {
   return browser.execute(() => {
-    const block = Blockly.getFocusManager().getFocusedNode() as
-      | Blockly.BlockSvg
-      | undefined;
-    if (!block) throw new Error('no selected block');
+    const focused = Blockly.getFocusManager().getFocusedNode();
+    if (!focused) throw new Error('nothing focused');
+    if (!(focused instanceof Blockly.BlockSvg)) {
+      throw new TypeError('focused node is not a BlockSvg');
+    }
+    const block = focused; // Inferred as BlockSvg.
     const parent = block?.getParent();
     return {
       parentId: parent?.id ?? null,

--- a/test/webdriverio/test/move_test.ts
+++ b/test/webdriverio/test/move_test.ts
@@ -8,7 +8,6 @@ import * as Blockly from 'blockly';
 import * as chai from 'chai';
 import {Browser, Key} from 'webdriverio';
 import {
-  getFocusedBlockType,
   PAUSE_TIME,
   setCurrentCursorNodeById,
   tabNavigateToWorkspace,
@@ -152,13 +151,14 @@ suite('Move tests', function () {
  * Get information about the currently-selected block's parent and
  * child blocks.
  *
+ * @param browser The webdriverio browser session.
  * @returns A promise setting to {parentId, parentIndex, nextId,
  *   valueId}, being respectively the parent block ID, index of parent
  *   connection, next block ID, and ID of the block connected to the
  *   zeroth value value input, or null if the given item does not
  *   exist.
  */
-function getFocusedNeighbourInfo(browser: WebdriverIO.Browser) {
+function getFocusedNeighbourInfo(browser: Browser) {
   return browser.execute(() => {
     const focused = Blockly.getFocusManager().getFocusedNode();
     if (!focused) throw new Error('nothing focused');
@@ -189,6 +189,7 @@ function getFocusedNeighbourInfo(browser: WebdriverIO.Browser) {
  * and return that block's ID and a boolean indicating whether that
  * block is a shadow or not.
  *
+ * @param browser The webdriverio browser session.
  * @param id The ID of the block having the connection we wish to examine.
  * @param index The index of the connection we wish to examine, within
  *     the array returned by calling .getConnections_(true) on that block.
@@ -197,7 +198,7 @@ function getFocusedNeighbourInfo(browser: WebdriverIO.Browser) {
  *     shadow is true iff the connected block is a shadow.
  */
 function getConnectedBlockInfo(
-  browser: WebdriverIO.Browser,
+  browser: Browser,
   id: string,
   index: number,
 ) {

--- a/test/webdriverio/test/test_setup.ts
+++ b/test/webdriverio/test/test_setup.ts
@@ -330,6 +330,7 @@ export async function getFocusedBlockType(
     return block?.type;
   });
 }
+
 /**
  * Get the connection type of the current focused node. Assumes the current node
  * is a connection.

--- a/test/webdriverio/test/test_setup.ts
+++ b/test/webdriverio/test/test_setup.ts
@@ -137,6 +137,7 @@ export const testFileLocations = {
   NAVIGATION_TEST_BLOCKS: createTestUrl(
     new URLSearchParams({scenario: 'navigationTestBlocks'}),
   ),
+  // eslint-disable-next-line @typescript-eslint/naming-convention
   MOVE_TEST_BLOCKS: createTestUrl(
     new URLSearchParams({scenario: 'moveTestBlocks'}),
   ),

--- a/test/webdriverio/test/test_setup.ts
+++ b/test/webdriverio/test/test_setup.ts
@@ -137,6 +137,9 @@ export const testFileLocations = {
   NAVIGATION_TEST_BLOCKS: createTestUrl(
     new URLSearchParams({scenario: 'navigationTestBlocks'}),
   ),
+  MOVE_TEST_BLOCKS: createTestUrl(
+    new URLSearchParams({scenario: 'moveTestBlocks'}),
+  ),
   // eslint-disable-next-line @typescript-eslint/naming-convention
   BASE_RTL: createTestUrl(new URLSearchParams({rtl: 'true'})),
   GERAS: createTestUrl(new URLSearchParams({renderer: 'geras'})),


### PR DESCRIPTION
Modify `KeyboardDragStrategy.prototype.shouldHealStack` so that only stacks will be healed.

Fixes #456.

Also add tests for starting to move both stack and value blocks, with the value blocks being both single-value-input and multiple-value-input.
