### PR TITLE
chore(build): Build ghpages against tip-of-`develop`

### DIFF
--- a/.github/workflows/pages.yml
+++ b/.github/workflows/pages.yml
@@ -26,20 +26,46 @@ jobs:
   build:
     runs-on: ubuntu-latest
     steps:
-      - name: Checkout
+      - name: Checkout blockly
         uses: actions/checkout@v4
+        with:
+          path: blockly
+          repository: google/blockly
+          ref: develop
+
+      - name: Checkout blockly-keyboard-experimentation
+        uses: actions/checkout@v4
+        with:
+          path: blockly-keyboard-experimentation
+
       - name: Setup Node
         uses: actions/setup-node@v4
         with:
-          node-version: latest
-          cache: 'npm'
-      - run: npm ci
-      - run: npm run ghpages
+          node-version: 20.x
+
+      - name: Build blockly
+        run: |
+          cd blockly
+          npm ci
+          npm run package
+          cd dist
+          npm link
+          cd ../..
+
+      - name: Build blockly-keyboard-experimentation
+        run: |
+          cd blockly-keyboard-experimentation
+          npm ci
+          npm link blockly
+          npm run ghpages
+          cd ..
+
       - name: Upload artifact
         uses: actions/upload-pages-artifact@v3
         with:
           # Upload build folder
-          path: './dist'
+          path: './blockly-keyboard-experimentation/dist'
+
   deploy:
     environment:
       name: github-pages


### PR DESCRIPTION
Install the `blockly` and `blockly-keyboard-experimentation` repos side-by-side, and use `npm link` to use build the keyboard experimentation demo pages against the current tip of `develop` .

Fixes #461.