### PR TITLE
chore(deps): Update @blockly/field-colour to 6.0.0

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -9,8 +9,8 @@
       "version": "0.0.8",
       "license": "Apache-2.0",
       "devDependencies": {
-        "@blockly/dev-scripts": "^4.0.1",
-        "@blockly/field-colour": "^5.0.7",
+        "@blockly/dev-scripts": "^4.0.8",
+        "@blockly/field-colour": "^6.0.0",
         "@eslint/eslintrc": "^2.1.2",
         "@eslint/js": "^8.49.0",
         "@types/chai": "^5.2.1",
@@ -323,11 +323,10 @@
       }
     },
     "node_modules/@blockly/dev-scripts": {
-      "version": "4.0.7",
-      "resolved": "https://registry.npmjs.org/@blockly/dev-scripts/-/dev-scripts-4.0.7.tgz",
-      "integrity": "sha512-viRLV1HO/NwpfQ1NO/S6br/oyJxnp4owTpQGS+bGx/yOVD1Aiku/bRCjeL/apLnwstNXqSmQl4kEvwnF5i3z2g==",
+      "version": "4.0.8",
+      "resolved": "https://registry.npmjs.org/@blockly/dev-scripts/-/dev-scripts-4.0.8.tgz",
+      "integrity": "sha512-DGCY0jTYMTpychPsq4P088J7d4zOxovzfSOCGv6m8oB0g+Un20xyyQsZ0SiMsC3tnrgOHJxJ/T9gi4DsdPtpMQ==",
       "dev": true,
-      "license": "Apache-2.0",
       "dependencies": {
         "@babel/code-frame": "^7.8.3",
         "@blockly/eslint-config": "^4.0.1",
@@ -978,16 +977,15 @@
       }
     },
     "node_modules/@blockly/field-colour": {
-      "version": "5.0.7",
-      "resolved": "https://registry.npmjs.org/@blockly/field-colour/-/field-colour-5.0.7.tgz",
-      "integrity": "sha512-nY58wS2lw4mVS5dHwsuitmBRXd2LLlkkgelfv3BO1IdghYgR5h3qe9Oa7mYyrhgc9KliMT+edmsizD5JCzer5g==",
+      "version": "6.0.0",
+      "resolved": "https://registry.npmjs.org/@blockly/field-colour/-/field-colour-6.0.0.tgz",
+      "integrity": "sha512-cKmXb4YMpr29a5a34bMOh5gpVv3Fh19tpEeSAy6V+LhOpEx3DQ57Ch8wEcC8K37fvCUp9tMtzcL2OXBT5LtdNA==",
       "dev": true,
-      "license": "Apache-2.0",
       "engines": {
         "node": ">=8.0.0"
       },
       "peerDependencies": {
-        "blockly": "^11.0.0"
+        "blockly": "^12.0.0"
       }
     },
     "node_modules/@csstools/color-helpers": {

--- a/package.json
+++ b/package.json
@@ -48,8 +48,8 @@
     "src"
   ],
   "devDependencies": {
-    "@blockly/dev-scripts": "^4.0.1",
-    "@blockly/field-colour": "^5.0.7",
+    "@blockly/dev-scripts": "^4.0.8",
+    "@blockly/field-colour": "^6.0.0",
     "@eslint/eslintrc": "^2.1.2",
     "@eslint/js": "^8.49.0",
     "@types/chai": "^5.2.1",
@@ -74,11 +74,6 @@
   },
   "peerDependencies": {
     "blockly": "^12.0.0"
-  },
-  "overrides": {
-    "@blockly/field-colour": {
-      "blockly": "^12.0.0"
-    }
   },
   "publishConfig": {
     "access": "public",


### PR DESCRIPTION
This allows us to remove the overrides section in package.json.
