### PR TITLE
feat: align disconnect with move + mouse behaviours

### DIFF
--- a/src/actions/disconnect.ts
+++ b/src/actions/disconnect.ts
@@ -6,12 +6,14 @@
 
 import {
   BlockSvg,
-  RenderedConnection,
+  Events,
   ShortcutRegistry,
   utils as BlocklyUtils,
+  Connection,
+  ConnectionType,
 } from 'blockly';
 import * as Constants from '../constants';
-import type {WorkspaceSvg, IFocusableNode} from 'blockly';
+import type {WorkspaceSvg} from 'blockly';
 import {Navigation} from '../navigation';
 
 const KeyCodes = BlocklyUtils.KeyCodes;
@@ -76,66 +78,15 @@ export class DisconnectAction {
    */
   disconnectBlocks(workspace: WorkspaceSvg) {
     const cursor = workspace.getCursor();
-    if (!cursor) {
-      return;
-    }
-    let curNode: IFocusableNode | null = cursor.getCurNode();
-    let wasVisitingConnection = true;
-    while (
-      curNode &&
-      !(curNode instanceof RenderedConnection && curNode.isConnected())
-    ) {
-      if (curNode instanceof BlockSvg) {
-        const previous = curNode.previousConnection;
-        const output = curNode.outputConnection;
-        if (previous?.isConnected()) {
-          curNode = previous;
-          break;
-        } else if (output?.isConnected()) {
-          curNode = output;
-          break;
-        }
-      }
+    if (!cursor) return;
+    const curNode = cursor.getCurNode();
+    if (!(curNode instanceof BlockSvg)) return;
 
-      curNode = workspace.getNavigator().getParent(curNode);
-      wasVisitingConnection = false;
-    }
-    if (!curNode) {
-      console.log('Unable to find a connection to disconnect');
-      return;
-    }
-    if (!(curNode instanceof RenderedConnection && curNode.isConnected())) {
-      return;
-    }
-    const targetConnection = curNode.targetConnection;
-    if (!targetConnection) {
-      throw new Error('Must have target if connected');
-    }
+    const healStack = !curNode.outputConnection?.isConnected();
+    Events.setGroup(true);
+    curNode.unplug(healStack);
 
-    const superiorConnection = curNode.isSuperior()
-      ? curNode
-      : targetConnection;
-
-    const inferiorConnection = curNode.isSuperior()
-      ? targetConnection
-      : curNode;
-
-    if (inferiorConnection.getSourceBlock().isShadow()) {
-      return;
-    }
-
-    if (!inferiorConnection.getSourceBlock().isMovable()) {
-      return;
-    }
-
-    superiorConnection.disconnect();
-    inferiorConnection.bumpAwayFrom(superiorConnection);
-
-    const rootBlock = superiorConnection.getSourceBlock().getRootBlock();
-    rootBlock.bringToFront();
-
-    if (wasVisitingConnection) {
-      workspace.getCursor()?.setCurNode(superiorConnection);
-    }
+    // Needed or we end up with passive focus.
+    cursor.setCurNode(curNode);
   }
 }

--- a/src/actions/disconnect.ts
+++ b/src/actions/disconnect.ts
@@ -85,6 +85,7 @@ export class DisconnectAction {
     const healStack = !curNode.outputConnection?.isConnected();
     Events.setGroup(true);
     curNode.unplug(healStack);
+    Events.setGroup(false);
 
     // Needed or we end up with passive focus.
     cursor.setCurNode(curNode);


### PR DESCRIPTION
- Single statement block to match move. Perhaps both could do multi-block with uppercase.
- Just call unplug like the drag strategy does.

This means the disconnected block ends up the current node. Previous (presumably accidental) behaviour was to select the connection in a way that can't normally be navigated to causing it to persist oddly.

You could make a case for move mode too but it's all tangled up with the insert/paste/heuristic discussion so not considering here.

Demo: https://simpler-disconnect.blockly-keyboard-experimentation.pages.dev/