### PR TITLE
release: bump version to 0.0.9

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@blockly/keyboard-experiment",
-  "version": "0.0.8",
+  "version": "0.0.9",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@blockly/keyboard-experiment",
-      "version": "0.0.8",
+      "version": "0.0.9",
       "license": "Apache-2.0",
       "devDependencies": {
         "@blockly/dev-scripts": "^4.0.8",

--- a/package-lock.json
+++ b/package-lock.json
@@ -34,7 +34,7 @@
         "webdriverio": "^9.12.1"
       },
       "peerDependencies": {
-        "blockly": "^12.0.0"
+        "blockly": "^12.0.1-beta.1"
       }
     },
     "node_modules/@asamuzakjp/css-color": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -18,7 +18,7 @@
         "@types/p5": "^1.7.6",
         "@typescript-eslint/eslint-plugin": "^6.7.2",
         "@typescript-eslint/parser": "^6.7.2",
-        "blockly": "^12.0.0",
+        "blockly": "^12.0.1-beta.1",
         "chai": "^5.2.0",
         "eslint": "^8.49.0",
         "eslint-config-google": "^0.14.0",
@@ -3047,9 +3047,9 @@
       }
     },
     "node_modules/blockly": {
-      "version": "12.0.0",
-      "resolved": "https://registry.npmjs.org/blockly/-/blockly-12.0.0.tgz",
-      "integrity": "sha512-CrwxGjbgCh/zGg46VTlp26NYblSi/82n4VFsamyW5b4W6t3HXaf/b3CbMuu4/YnFvqlyJs+8zR4OKNTbIc28EA==",
+      "version": "12.0.1-beta.1",
+      "resolved": "https://registry.npmjs.org/blockly/-/blockly-12.0.1-beta.1.tgz",
+      "integrity": "sha512-PPbLLBY/IJgZOXACnro5xNz2lcX5e2ZwkHkoqA4Y89ec86erpIa7QVf+CPbNmuAJLch+5kxqdVaZgA5qGrBrsg==",
       "dev": true,
       "dependencies": {
         "jsdom": "26.1.0"

--- a/package.json
+++ b/package.json
@@ -57,7 +57,7 @@
     "@types/p5": "^1.7.6",
     "@typescript-eslint/eslint-plugin": "^6.7.2",
     "@typescript-eslint/parser": "^6.7.2",
-    "blockly": "^12.0.0",
+    "blockly": "^12.0.1-beta.1",
     "chai": "^5.2.0",
     "eslint": "^8.49.0",
     "eslint-config-google": "^0.14.0",

--- a/package.json
+++ b/package.json
@@ -73,7 +73,12 @@
     "webdriverio": "^9.12.1"
   },
   "peerDependencies": {
-    "blockly": "^12.0.0"
+    "blockly": "^12.0.1-beta.1"
+  },
+  "overrides": {
+    "@blockly/field-colour": {
+      "blockly": "^12.0.1-beta.1"
+    }
   },
   "publishConfig": {
     "access": "public",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@blockly/keyboard-experiment",
-  "version": "0.0.8",
+  "version": "0.0.9",
   "description": "A plugin for keyboard navigation.",
   "scripts": {
     "audit:fix": "blockly-scripts auditFix",


### PR DESCRIPTION
Updates the dependency on Blockly to v12.0.1-beta.1 to pull in some recent Blockly fixes, and bumps the version.

Purpose: release another version for testing by MakeCode and Code.org/