### PR TITLE
fix: Fix when the context menu is allowed to open

### DIFF
--- a/src/actions/action_menu.ts
+++ b/src/actions/action_menu.ts
@@ -45,12 +45,23 @@ export class ActionMenu {
   private registerShortcut() {
     const menuShortcut: ShortcutRegistry.KeyboardShortcut = {
       name: Constants.SHORTCUT_NAMES.MENU,
-      preconditionFn: (workspace) =>
-        this.navigation.canCurrentlyNavigate(workspace),
+      preconditionFn: (workspace) => {
+        return (
+          this.navigation.canCurrentlyNavigate(workspace) &&
+          !workspace.isDragging()
+        );
+      },
       callback: (workspace) => {
         switch (this.navigation.getState(workspace)) {
           case Constants.STATE.WORKSPACE:
             return this.openActionMenu(workspace);
+          case Constants.STATE.FLYOUT: {
+            const flyoutWorkspace = workspace.getFlyout()?.getWorkspace();
+            if (flyoutWorkspace) {
+              return this.openActionMenu(flyoutWorkspace);
+            }
+            return false;
+          }
           default:
             return false;
         }

--- a/src/navigation.ts
+++ b/src/navigation.ts
@@ -99,9 +99,9 @@ export class Navigation {
   getState(workspace: Blockly.WorkspaceSvg): Constants.STATE {
     const focusedTree = Blockly.getFocusManager().getFocusedTree();
     if (focusedTree instanceof Blockly.WorkspaceSvg) {
-      if (focusedTree.isFlyout && workspace === focusedTree.targetWorkspace) {
+      if (focusedTree.isFlyout) {
         return Constants.STATE.FLYOUT;
-      } else if (workspace === focusedTree) {
+      } else {
         return Constants.STATE.WORKSPACE;
       }
     } else if (focusedTree instanceof Blockly.Toolbox) {
@@ -109,9 +109,7 @@ export class Navigation {
         return Constants.STATE.TOOLBOX;
       }
     } else if (focusedTree instanceof Blockly.Flyout) {
-      if (workspace === focusedTree.targetWorkspace) {
-        return Constants.STATE.FLYOUT;
-      }
+      return Constants.STATE.FLYOUT;
     }
     // Either a non-Blockly element currently has DOM focus, or a different
     // workspace holds it.

--- a/src/navigation.ts
+++ b/src/navigation.ts
@@ -820,8 +820,11 @@ export class Navigation {
    * @returns whether keyboard navigation is currently allowed.
    */
   canCurrentlyNavigate(workspace: Blockly.WorkspaceSvg) {
+    const accessibilityMode = workspace.isFlyout
+      ? workspace.targetWorkspace?.keyboardAccessibilityMode
+      : workspace.keyboardAccessibilityMode;
     return (
-      workspace.keyboardAccessibilityMode &&
+      !!accessibilityMode &&
       this.getState(workspace) !== Constants.STATE.NOWHERE
     );
   }

--- a/test/webdriverio/test/actions_test.ts
+++ b/test/webdriverio/test/actions_test.ts
@@ -7,7 +7,7 @@
 import * as chai from 'chai';
 import {Key} from 'webdriverio';
 import {
-  checkActionPrecondition,
+  contextMenuExists,
   moveToToolboxCategory,
   PAUSE_TIME,
   setCurrentCursorNodeById,
@@ -26,12 +26,15 @@ suite('Menus test', function () {
     await this.browser.pause(PAUSE_TIME);
   });
 
-  test('Menu action returns true normally', async function () {
+  test('Menu action opens menu', async function () {
     // Navigate to draw_circle_1.
     await tabNavigateToWorkspace(this.browser);
     await setCurrentCursorNodeById(this.browser, 'draw_circle_1');
+    await this.browser.pause(PAUSE_TIME);
+    await this.browser.keys([Key.Ctrl, Key.Return]);
+    await this.browser.pause(PAUSE_TIME);
     chai.assert.isTrue(
-      await checkActionPrecondition(this.browser, 'menu'),
+      await contextMenuExists(this.browser, 'Duplicate'),
       'The menu should be openable on a block',
     );
   });
@@ -44,9 +47,11 @@ suite('Menus test', function () {
     await moveToToolboxCategory(this.browser, 'Functions');
     // Move to flyout.
     await this.browser.keys(Key.ArrowRight);
+    await this.browser.keys([Key.Ctrl, Key.Return]);
+    await this.browser.pause(PAUSE_TIME);
 
     chai.assert.isTrue(
-      await checkActionPrecondition(this.browser, 'menu'),
+      await contextMenuExists(this.browser, 'Help'),
       'The menu should be openable on a block in the toolbox',
     );
   });
@@ -57,8 +62,10 @@ suite('Menus test', function () {
     await setCurrentCursorNodeById(this.browser, 'draw_circle_1');
     // Start moving the block
     await this.browser.keys('m');
-    chai.assert.isFalse(
-      await checkActionPrecondition(this.browser, 'menu'),
+    await this.browser.keys([Key.Ctrl, Key.Return]);
+    await this.browser.pause(PAUSE_TIME);
+    chai.assert.isTrue(
+      await contextMenuExists(this.browser, 'Duplicate', true),
       'The menu should not be openable during a move',
     );
   });

--- a/test/webdriverio/test/actions_test.ts
+++ b/test/webdriverio/test/actions_test.ts
@@ -1,0 +1,66 @@
+/**
+ * @license
+ * Copyright 2025 Google LLC
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import * as chai from 'chai';
+import {Key} from 'webdriverio';
+import {
+  checkActionPrecondition,
+  getFocusedBlockType,
+  moveToToolboxCategory,
+  PAUSE_TIME,
+  setCurrentCursorNodeById,
+  tabNavigateToWorkspace,
+  testFileLocations,
+  testSetup,
+} from './test_setup.js';
+
+suite('Menus test', function () {
+  // Setting timeout to unlimited as these tests take longer time to run
+  this.timeout(0);
+
+  // Clear the workspace and load start blocks
+  setup(async function () {
+    this.browser = await testSetup(testFileLocations.BASE);
+    await this.browser.pause(PAUSE_TIME);
+  });
+
+  test('Menu action returns true normally', async function () {
+    // Navigate to draw_circle_1.
+    await tabNavigateToWorkspace(this.browser);
+    await setCurrentCursorNodeById(this.browser, 'draw_circle_1');
+    chai.assert.isTrue(
+      await checkActionPrecondition(this.browser, 'menu'),
+      'The menu should be openable on a block',
+    );
+  });
+
+  test('Menu action returns true in the toolbox', async function () {
+    // Navigate to draw_circle_1.
+    await tabNavigateToWorkspace(this.browser);
+    await setCurrentCursorNodeById(this.browser, 'draw_circle_1');
+    // Navigate to a toolbox category
+    await moveToToolboxCategory(this.browser, 'Functions');
+    // Move to flyout.
+    await this.browser.keys(Key.ArrowRight);
+
+    chai.assert.isTrue(
+      await checkActionPrecondition(this.browser, 'menu'),
+      'The menu should be openable on a block in the toolbox',
+    );
+  });
+
+  test('Menu action returns false during drag', async function () {
+    // Navigate to draw_circle_1.
+    await tabNavigateToWorkspace(this.browser);
+    await setCurrentCursorNodeById(this.browser, 'draw_circle_1');
+    // Start moving the block
+    await this.browser.keys('m');
+    chai.assert.isFalse(
+      await checkActionPrecondition(this.browser, 'menu'),
+      'The menu should not be openable during a move',
+    );
+  });
+});

--- a/test/webdriverio/test/actions_test.ts
+++ b/test/webdriverio/test/actions_test.ts
@@ -8,7 +8,6 @@ import * as chai from 'chai';
 import {Key} from 'webdriverio';
 import {
   checkActionPrecondition,
-  getFocusedBlockType,
   moveToToolboxCategory,
   PAUSE_TIME,
   setCurrentCursorNodeById,

--- a/test/webdriverio/test/test_setup.ts
+++ b/test/webdriverio/test/test_setup.ts
@@ -463,8 +463,7 @@ export async function checkActionPrecondition(
       );
     }
     return actionItem.preconditionFn(workspace, {
-      focusedNode:
-        Blockly.FocusManager.getFocusManager().getFocusedNode() ?? undefined,
+      focusedNode: node ?? undefined,
     });
   }, action);
 }

--- a/test/webdriverio/test/test_setup.ts
+++ b/test/webdriverio/test/test_setup.ts
@@ -468,3 +468,19 @@ export async function checkActionPrecondition(
     });
   }, action);
 }
+
+/**
+ * Wait for the specified context menu item to exist.
+ *
+ * @param browser The active WebdriverIO Browser object.
+ * @param itemText The display text of the context menu item to click.
+ * @return A Promise that resolves when the actions are completed.
+ */
+export async function contextMenuExists(
+  browser: WebdriverIO.Browser,
+  itemText: string,
+  reverse = false,
+): Promise<boolean> {
+  const item = await browser.$(`div=${itemText}`);
+  return await item.waitForExist({timeout: 200, reverse: reverse});
+}

--- a/test/webdriverio/test/test_setup.ts
+++ b/test/webdriverio/test/test_setup.ts
@@ -474,6 +474,7 @@ export async function checkActionPrecondition(
  *
  * @param browser The active WebdriverIO Browser object.
  * @param itemText The display text of the context menu item to click.
+ * @param reverse Whether to check for non-existence instead.
  * @return A Promise that resolves when the actions are completed.
  */
 export async function contextMenuExists(


### PR DESCRIPTION
Fixes #434 
Fixes #276

#546 is partly fixed by this change but may still need some work for shortcuts other than menu opening.

This fixes the precondition checks for showing the action menu and also enables the action menu to be shown in the flyout so that it's consistent with right click.