### PR TITLE
chore: Introduce tests for flyout & toolbox

### DIFF
--- a/test/toolboxCategories.js
+++ b/test/toolboxCategories.js
@@ -17,6 +17,7 @@ export default {
         {
           type: 'controls_if',
           kind: 'block',
+          id: 'if_block',
         },
         {
           type: 'logic_compare',
@@ -374,6 +375,7 @@ export default {
           fields: {
             TEXT: '',
           },
+          id: 'text_block',
         },
         {
           type: 'text_join',
@@ -382,6 +384,7 @@ export default {
         {
           type: 'text_append',
           kind: 'block',
+          id: 'append_text_block',
           fields: {
             name: 'item',
           },

--- a/test/webdriverio/index.html
+++ b/test/webdriverio/index.html
@@ -62,6 +62,7 @@
 
   <body>
     <div id="root">
+      <div id="focusableDiv" tabindex="0">Simple div to focus.</div>
       <div id="blocklyDiv"></div>
       <div id="shortcuts"></div>
     </div>

--- a/test/webdriverio/test/actions_test.ts
+++ b/test/webdriverio/test/actions_test.ts
@@ -14,6 +14,7 @@ import {
   tabNavigateToWorkspace,
   testFileLocations,
   testSetup,
+  keyRight,
 } from './test_setup.js';
 
 suite('Menus test', function () {
@@ -46,7 +47,7 @@ suite('Menus test', function () {
     // Navigate to a toolbox category
     await moveToToolboxCategory(this.browser, 'Functions');
     // Move to flyout.
-    await this.browser.keys(Key.ArrowRight);
+    await keyRight(this.browser);
     await this.browser.keys([Key.Ctrl, Key.Return]);
     await this.browser.pause(PAUSE_TIME);
 

--- a/test/webdriverio/test/actions_test.ts
+++ b/test/webdriverio/test/actions_test.ts
@@ -10,7 +10,7 @@ import {
   contextMenuExists,
   moveToToolboxCategory,
   PAUSE_TIME,
-  setCurrentCursorNodeById,
+  focusOnBlock,
   tabNavigateToWorkspace,
   testFileLocations,
   testSetup,
@@ -29,7 +29,7 @@ suite('Menus test', function () {
   test('Menu action opens menu', async function () {
     // Navigate to draw_circle_1.
     await tabNavigateToWorkspace(this.browser);
-    await setCurrentCursorNodeById(this.browser, 'draw_circle_1');
+    await focusOnBlock(this.browser, 'draw_circle_1');
     await this.browser.pause(PAUSE_TIME);
     await this.browser.keys([Key.Ctrl, Key.Return]);
     await this.browser.pause(PAUSE_TIME);
@@ -42,7 +42,7 @@ suite('Menus test', function () {
   test('Menu action returns true in the toolbox', async function () {
     // Navigate to draw_circle_1.
     await tabNavigateToWorkspace(this.browser);
-    await setCurrentCursorNodeById(this.browser, 'draw_circle_1');
+    await focusOnBlock(this.browser, 'draw_circle_1');
     // Navigate to a toolbox category
     await moveToToolboxCategory(this.browser, 'Functions');
     // Move to flyout.
@@ -59,7 +59,7 @@ suite('Menus test', function () {
   test('Menu action returns false during drag', async function () {
     // Navigate to draw_circle_1.
     await tabNavigateToWorkspace(this.browser);
-    await setCurrentCursorNodeById(this.browser, 'draw_circle_1');
+    await focusOnBlock(this.browser, 'draw_circle_1');
     // Start moving the block
     await this.browser.keys('m');
     await this.browser.keys([Key.Ctrl, Key.Return]);

--- a/test/webdriverio/test/basic_test.ts
+++ b/test/webdriverio/test/basic_test.ts
@@ -262,11 +262,7 @@ suite('Keyboard navigation on Fields', function () {
   test('Up from first field selects block', async function () {
     await tabNavigateToWorkspace(this.browser);
     await this.browser.pause(PAUSE_TIME);
-    await focusOnBlockField(
-      this.browser,
-      'p5_canvas_1',
-      'WIDTH',
-    );
+    await focusOnBlockField(this.browser, 'p5_canvas_1', 'WIDTH');
     await this.browser.pause(PAUSE_TIME);
     await keyUp(this.browser);
 
@@ -279,11 +275,7 @@ suite('Keyboard navigation on Fields', function () {
   test('Left from first field selects block', async function () {
     await tabNavigateToWorkspace(this.browser);
     await this.browser.pause(PAUSE_TIME);
-    await focusOnBlockField(
-      this.browser,
-      'p5_canvas_1',
-      'WIDTH',
-    );
+    await focusOnBlockField(this.browser, 'p5_canvas_1', 'WIDTH');
     await this.browser.pause(PAUSE_TIME);
     await keyLeft(this.browser);
 
@@ -296,11 +288,7 @@ suite('Keyboard navigation on Fields', function () {
   test('Right from first field selects second field', async function () {
     await tabNavigateToWorkspace(this.browser);
     await this.browser.pause(PAUSE_TIME);
-    await focusOnBlockField(
-      this.browser,
-      'p5_canvas_1',
-      'WIDTH',
-    );
+    await focusOnBlockField(this.browser, 'p5_canvas_1', 'WIDTH');
     await this.browser.pause(PAUSE_TIME);
     await keyRight(this.browser);
 
@@ -314,11 +302,7 @@ suite('Keyboard navigation on Fields', function () {
   test('Left from second field selects first field', async function () {
     await tabNavigateToWorkspace(this.browser);
     await this.browser.pause(PAUSE_TIME);
-    await focusOnBlockField(
-      this.browser,
-      'p5_canvas_1',
-      'HEIGHT',
-    );
+    await focusOnBlockField(this.browser, 'p5_canvas_1', 'HEIGHT');
     await this.browser.pause(PAUSE_TIME);
     await keyLeft(this.browser);
 
@@ -332,11 +316,7 @@ suite('Keyboard navigation on Fields', function () {
   test('Right from second field selects next block', async function () {
     await tabNavigateToWorkspace(this.browser);
     await this.browser.pause(PAUSE_TIME);
-    await focusOnBlockField(
-      this.browser,
-      'p5_canvas_1',
-      'HEIGHT',
-    );
+    await focusOnBlockField(this.browser, 'p5_canvas_1', 'HEIGHT');
     await this.browser.pause(PAUSE_TIME);
     await keyRight(this.browser);
 
@@ -348,11 +328,7 @@ suite('Keyboard navigation on Fields', function () {
   test('Down from field selects next block', async function () {
     await tabNavigateToWorkspace(this.browser);
     await this.browser.pause(PAUSE_TIME);
-    await focusOnBlockField(
-      this.browser,
-      'p5_canvas_1',
-      'WIDTH',
-    );
+    await focusOnBlockField(this.browser, 'p5_canvas_1', 'WIDTH');
     await this.browser.pause(PAUSE_TIME);
     await keyDown(this.browser);
 
@@ -364,11 +340,7 @@ suite('Keyboard navigation on Fields', function () {
   test("Down from field selects block's child block", async function () {
     await tabNavigateToWorkspace(this.browser);
     await this.browser.pause(PAUSE_TIME);
-    await focusOnBlockField(
-      this.browser,
-      'controls_repeat_1',
-      'TIMES',
-    );
+    await focusOnBlockField(this.browser, 'controls_repeat_1', 'TIMES');
     await this.browser.pause(PAUSE_TIME);
     await keyDown(this.browser);
 

--- a/test/webdriverio/test/basic_test.ts
+++ b/test/webdriverio/test/basic_test.ts
@@ -17,6 +17,10 @@ import {
   testFileLocations,
   PAUSE_TIME,
   tabNavigateToWorkspace,
+  keyLeft,
+  keyRight,
+  keyUp,
+  keyDown,
 } from './test_setup.js';
 import {Key} from 'webdriverio';
 
@@ -40,10 +44,7 @@ suite('Keyboard navigation on Blocks', function () {
   test('Selected block', async function () {
     await tabNavigateToWorkspace(this.browser);
 
-    for (let i = 0; i < 14; i++) {
-      await this.browser.keys(Key.ArrowDown);
-      await this.browser.pause(PAUSE_TIME);
-    }
+    await keyDown(this.browser, 14);
 
     chai
       .expect(await getCurrentFocusedBlockId(this.browser))
@@ -55,8 +56,7 @@ suite('Keyboard navigation on Blocks', function () {
     await this.browser.pause(PAUSE_TIME);
     await focusOnBlock(this.browser, 'p5_canvas_1');
     await this.browser.pause(PAUSE_TIME);
-    await this.browser.keys(Key.ArrowDown);
-    await this.browser.pause(PAUSE_TIME);
+    await keyDown(this.browser);
 
     chai
       .expect(await getCurrentFocusedBlockId(this.browser))
@@ -68,8 +68,7 @@ suite('Keyboard navigation on Blocks', function () {
     await this.browser.pause(PAUSE_TIME);
     await focusOnBlock(this.browser, 'simple_circle_1');
     await this.browser.pause(PAUSE_TIME);
-    await this.browser.keys(Key.ArrowUp);
-    await this.browser.pause(PAUSE_TIME);
+    await keyUp(this.browser);
 
     chai
       .expect(await getCurrentFocusedBlockId(this.browser))
@@ -81,8 +80,7 @@ suite('Keyboard navigation on Blocks', function () {
     await this.browser.pause(PAUSE_TIME);
     await focusOnBlock(this.browser, 'p5_setup_1');
     await this.browser.pause(PAUSE_TIME);
-    await this.browser.keys(Key.ArrowDown);
-    await this.browser.pause(PAUSE_TIME);
+    await keyDown(this.browser);
     chai
       .expect(await getCurrentFocusedBlockId(this.browser))
       .equal('p5_canvas_1');
@@ -93,8 +91,7 @@ suite('Keyboard navigation on Blocks', function () {
     await this.browser.pause(PAUSE_TIME);
     await focusOnBlock(this.browser, 'p5_canvas_1');
     await this.browser.pause(PAUSE_TIME);
-    await this.browser.keys(Key.ArrowUp);
-    await this.browser.pause(PAUSE_TIME);
+    await keyUp(this.browser);
     chai
       .expect(await getCurrentFocusedBlockId(this.browser))
       .equal('p5_setup_1');
@@ -105,8 +102,7 @@ suite('Keyboard navigation on Blocks', function () {
     await this.browser.pause(PAUSE_TIME);
     await focusOnBlock(this.browser, 'p5_canvas_1');
     await this.browser.pause(PAUSE_TIME);
-    await this.browser.keys(Key.ArrowRight);
-    await this.browser.pause(PAUSE_TIME);
+    await keyRight(this.browser);
 
     chai
       .expect(await getCurrentFocusNodeId(this.browser))
@@ -120,8 +116,7 @@ suite('Keyboard navigation on Blocks', function () {
     await this.browser.pause(PAUSE_TIME);
     await focusOnBlock(this.browser, 'simple_circle_1');
     await this.browser.pause(PAUSE_TIME);
-    await this.browser.keys(Key.ArrowRight);
-    await this.browser.pause(PAUSE_TIME);
+    await keyRight(this.browser);
 
     chai.assert.equal(
       await getCurrentFocusedBlockId(this.browser),
@@ -134,8 +129,7 @@ suite('Keyboard navigation on Blocks', function () {
     await this.browser.pause(PAUSE_TIME);
     await focusOnBlock(this.browser, 'math_number_2');
     await this.browser.pause(PAUSE_TIME);
-    await this.browser.keys(Key.ArrowUp);
-    await this.browser.pause(PAUSE_TIME);
+    await keyUp(this.browser);
 
     chai.assert.equal(
       await getCurrentFocusedBlockId(this.browser),
@@ -148,8 +142,7 @@ suite('Keyboard navigation on Blocks', function () {
     await this.browser.pause(PAUSE_TIME);
     await focusOnBlock(this.browser, 'math_number_2');
     await this.browser.pause(PAUSE_TIME);
-    await this.browser.keys(Key.ArrowLeft);
-    await this.browser.pause(PAUSE_TIME);
+    await keyLeft(this.browser);
 
     chai.assert.equal(
       await getCurrentFocusedBlockId(this.browser),
@@ -162,8 +155,7 @@ suite('Keyboard navigation on Blocks', function () {
     await this.browser.pause(PAUSE_TIME);
     await focusOnBlock(this.browser, 'math_number_2');
     await this.browser.pause(PAUSE_TIME);
-    await this.browser.keys(Key.ArrowRight);
-    await this.browser.pause(PAUSE_TIME);
+    await keyRight(this.browser);
 
     chai.assert.equal(
       await getCurrentFocusedBlockId(this.browser),
@@ -176,8 +168,7 @@ suite('Keyboard navigation on Blocks', function () {
     await this.browser.pause(PAUSE_TIME);
     await focusOnBlock(this.browser, 'math_number_3');
     await this.browser.pause(PAUSE_TIME);
-    await this.browser.keys(Key.ArrowLeft);
-    await this.browser.pause(PAUSE_TIME);
+    await keyLeft(this.browser);
 
     chai.assert.equal(
       await getCurrentFocusedBlockId(this.browser),
@@ -190,8 +181,7 @@ suite('Keyboard navigation on Blocks', function () {
     await this.browser.pause(PAUSE_TIME);
     await focusOnBlock(this.browser, 'colour_picker_1');
     await this.browser.pause(PAUSE_TIME);
-    await this.browser.keys(Key.ArrowRight);
-    await this.browser.pause(PAUSE_TIME);
+    await keyRight(this.browser);
 
     chai
       .expect(await getCurrentFocusedBlockId(this.browser))
@@ -203,8 +193,7 @@ suite('Keyboard navigation on Blocks', function () {
     await this.browser.pause(PAUSE_TIME);
     await focusOnBlock(this.browser, 'colour_picker_1');
     await this.browser.pause(PAUSE_TIME);
-    await this.browser.keys(Key.ArrowDown);
-    await this.browser.pause(PAUSE_TIME);
+    await keyDown(this.browser);
 
     chai
       .expect(await getCurrentFocusedBlockId(this.browser))
@@ -216,8 +205,7 @@ suite('Keyboard navigation on Blocks', function () {
     await this.browser.pause(PAUSE_TIME);
     await focusOnBlock(this.browser, 'logic_boolean_1');
     await this.browser.pause(PAUSE_TIME);
-    await this.browser.keys(Key.ArrowDown);
-    await this.browser.pause(PAUSE_TIME);
+    await keyDown(this.browser);
 
     chai
       .expect(await getCurrentFocusedBlockId(this.browser))
@@ -229,20 +217,17 @@ suite('Keyboard navigation on Blocks', function () {
     await this.browser.pause(PAUSE_TIME);
     await focusOnBlock(this.browser, 'text_print_1');
     await this.browser.pause(PAUSE_TIME);
-    await this.browser.keys(Key.ArrowRight);
-    await this.browser.pause(PAUSE_TIME);
+    await keyRight(this.browser);
 
     chai.assert.equal(await getCurrentFocusedBlockId(this.browser), 'text_1');
 
-    await this.browser.keys(Key.ArrowRight);
-    await this.browser.pause(PAUSE_TIME);
+    await keyRight(this.browser);
 
     chai
       .expect(await getCurrentFocusNodeId(this.browser))
       .to.include('text_1_field_');
 
-    await this.browser.keys(Key.ArrowRight);
-    await this.browser.pause(PAUSE_TIME);
+    await keyRight(this.browser);
 
     chai
       .expect(await getCurrentFocusedBlockId(this.browser))
@@ -283,8 +268,7 @@ suite('Keyboard navigation on Fields', function () {
       'WIDTH',
     );
     await this.browser.pause(PAUSE_TIME);
-    await this.browser.keys(Key.ArrowUp);
-    await this.browser.pause(PAUSE_TIME);
+    await keyUp(this.browser);
 
     chai.assert.equal(
       await getCurrentFocusedBlockId(this.browser),
@@ -301,8 +285,7 @@ suite('Keyboard navigation on Fields', function () {
       'WIDTH',
     );
     await this.browser.pause(PAUSE_TIME);
-    await this.browser.keys(Key.ArrowLeft);
-    await this.browser.pause(PAUSE_TIME);
+    await keyLeft(this.browser);
 
     chai.assert.equal(
       await getCurrentFocusedBlockId(this.browser),
@@ -319,8 +302,7 @@ suite('Keyboard navigation on Fields', function () {
       'WIDTH',
     );
     await this.browser.pause(PAUSE_TIME);
-    await this.browser.keys(Key.ArrowRight);
-    await this.browser.pause(PAUSE_TIME);
+    await keyRight(this.browser);
 
     chai
       .expect(await getCurrentFocusNodeId(this.browser))
@@ -338,8 +320,7 @@ suite('Keyboard navigation on Fields', function () {
       'HEIGHT',
     );
     await this.browser.pause(PAUSE_TIME);
-    await this.browser.keys(Key.ArrowLeft);
-    await this.browser.pause(PAUSE_TIME);
+    await keyLeft(this.browser);
 
     chai
       .expect(await getCurrentFocusNodeId(this.browser))
@@ -357,8 +338,7 @@ suite('Keyboard navigation on Fields', function () {
       'HEIGHT',
     );
     await this.browser.pause(PAUSE_TIME);
-    await this.browser.keys(Key.ArrowRight);
-    await this.browser.pause(PAUSE_TIME);
+    await keyRight(this.browser);
 
     chai
       .expect(await getCurrentFocusedBlockId(this.browser))
@@ -374,8 +354,7 @@ suite('Keyboard navigation on Fields', function () {
       'WIDTH',
     );
     await this.browser.pause(PAUSE_TIME);
-    await this.browser.keys(Key.ArrowDown);
-    await this.browser.pause(PAUSE_TIME);
+    await keyDown(this.browser);
 
     chai
       .expect(await getCurrentFocusedBlockId(this.browser))
@@ -391,8 +370,7 @@ suite('Keyboard navigation on Fields', function () {
       'TIMES',
     );
     await this.browser.pause(PAUSE_TIME);
-    await this.browser.keys(Key.ArrowDown);
-    await this.browser.pause(PAUSE_TIME);
+    await keyDown(this.browser);
 
     chai
       .expect(await getCurrentFocusedBlockId(this.browser))

--- a/test/webdriverio/test/basic_test.ts
+++ b/test/webdriverio/test/basic_test.ts
@@ -8,8 +8,8 @@ import * as chai from 'chai';
 import * as Blockly from 'blockly';
 import {
   isDragging,
-  setCurrentCursorNodeById,
-  setCurrentCursorNodeByIdAndFieldName,
+  focusOnBlock,
+  focusOnBlockField,
   getCurrentFocusNodeId,
   getCurrentFocusedBlockId,
   getFocusedFieldName,
@@ -53,7 +53,7 @@ suite('Keyboard navigation on Blocks', function () {
   test('Down from statement block selects next block across stacks', async function () {
     await tabNavigateToWorkspace(this.browser);
     await this.browser.pause(PAUSE_TIME);
-    await setCurrentCursorNodeById(this.browser, 'p5_canvas_1');
+    await focusOnBlock(this.browser, 'p5_canvas_1');
     await this.browser.pause(PAUSE_TIME);
     await this.browser.keys(Key.ArrowDown);
     await this.browser.pause(PAUSE_TIME);
@@ -66,7 +66,7 @@ suite('Keyboard navigation on Blocks', function () {
   test('Up from statement block selects previous block', async function () {
     await tabNavigateToWorkspace(this.browser);
     await this.browser.pause(PAUSE_TIME);
-    await setCurrentCursorNodeById(this.browser, 'simple_circle_1');
+    await focusOnBlock(this.browser, 'simple_circle_1');
     await this.browser.pause(PAUSE_TIME);
     await this.browser.keys(Key.ArrowUp);
     await this.browser.pause(PAUSE_TIME);
@@ -79,7 +79,7 @@ suite('Keyboard navigation on Blocks', function () {
   test('Down from parent block selects first child block', async function () {
     await tabNavigateToWorkspace(this.browser);
     await this.browser.pause(PAUSE_TIME);
-    await setCurrentCursorNodeById(this.browser, 'p5_setup_1');
+    await focusOnBlock(this.browser, 'p5_setup_1');
     await this.browser.pause(PAUSE_TIME);
     await this.browser.keys(Key.ArrowDown);
     await this.browser.pause(PAUSE_TIME);
@@ -91,7 +91,7 @@ suite('Keyboard navigation on Blocks', function () {
   test('Up from child block selects parent block', async function () {
     await tabNavigateToWorkspace(this.browser);
     await this.browser.pause(PAUSE_TIME);
-    await setCurrentCursorNodeById(this.browser, 'p5_canvas_1');
+    await focusOnBlock(this.browser, 'p5_canvas_1');
     await this.browser.pause(PAUSE_TIME);
     await this.browser.keys(Key.ArrowUp);
     await this.browser.pause(PAUSE_TIME);
@@ -103,7 +103,7 @@ suite('Keyboard navigation on Blocks', function () {
   test('Right from block selects first field', async function () {
     await tabNavigateToWorkspace(this.browser);
     await this.browser.pause(PAUSE_TIME);
-    await setCurrentCursorNodeById(this.browser, 'p5_canvas_1');
+    await focusOnBlock(this.browser, 'p5_canvas_1');
     await this.browser.pause(PAUSE_TIME);
     await this.browser.keys(Key.ArrowRight);
     await this.browser.pause(PAUSE_TIME);
@@ -118,7 +118,7 @@ suite('Keyboard navigation on Blocks', function () {
   test('Right from block selects first inline input', async function () {
     await tabNavigateToWorkspace(this.browser);
     await this.browser.pause(PAUSE_TIME);
-    await setCurrentCursorNodeById(this.browser, 'simple_circle_1');
+    await focusOnBlock(this.browser, 'simple_circle_1');
     await this.browser.pause(PAUSE_TIME);
     await this.browser.keys(Key.ArrowRight);
     await this.browser.pause(PAUSE_TIME);
@@ -132,7 +132,7 @@ suite('Keyboard navigation on Blocks', function () {
   test('Up from inline input selects statement block', async function () {
     await tabNavigateToWorkspace(this.browser);
     await this.browser.pause(PAUSE_TIME);
-    await setCurrentCursorNodeById(this.browser, 'math_number_2');
+    await focusOnBlock(this.browser, 'math_number_2');
     await this.browser.pause(PAUSE_TIME);
     await this.browser.keys(Key.ArrowUp);
     await this.browser.pause(PAUSE_TIME);
@@ -146,7 +146,7 @@ suite('Keyboard navigation on Blocks', function () {
   test('Left from first inline input selects block', async function () {
     await tabNavigateToWorkspace(this.browser);
     await this.browser.pause(PAUSE_TIME);
-    await setCurrentCursorNodeById(this.browser, 'math_number_2');
+    await focusOnBlock(this.browser, 'math_number_2');
     await this.browser.pause(PAUSE_TIME);
     await this.browser.keys(Key.ArrowLeft);
     await this.browser.pause(PAUSE_TIME);
@@ -160,7 +160,7 @@ suite('Keyboard navigation on Blocks', function () {
   test('Right from first inline input selects second inline input', async function () {
     await tabNavigateToWorkspace(this.browser);
     await this.browser.pause(PAUSE_TIME);
-    await setCurrentCursorNodeById(this.browser, 'math_number_2');
+    await focusOnBlock(this.browser, 'math_number_2');
     await this.browser.pause(PAUSE_TIME);
     await this.browser.keys(Key.ArrowRight);
     await this.browser.pause(PAUSE_TIME);
@@ -174,7 +174,7 @@ suite('Keyboard navigation on Blocks', function () {
   test('Left from second inline input selects first inline input', async function () {
     await tabNavigateToWorkspace(this.browser);
     await this.browser.pause(PAUSE_TIME);
-    await setCurrentCursorNodeById(this.browser, 'math_number_3');
+    await focusOnBlock(this.browser, 'math_number_3');
     await this.browser.pause(PAUSE_TIME);
     await this.browser.keys(Key.ArrowLeft);
     await this.browser.pause(PAUSE_TIME);
@@ -188,7 +188,7 @@ suite('Keyboard navigation on Blocks', function () {
   test('Right from last inline input selects next block', async function () {
     await tabNavigateToWorkspace(this.browser);
     await this.browser.pause(PAUSE_TIME);
-    await setCurrentCursorNodeById(this.browser, 'colour_picker_1');
+    await focusOnBlock(this.browser, 'colour_picker_1');
     await this.browser.pause(PAUSE_TIME);
     await this.browser.keys(Key.ArrowRight);
     await this.browser.pause(PAUSE_TIME);
@@ -201,7 +201,7 @@ suite('Keyboard navigation on Blocks', function () {
   test('Down from inline input selects next block', async function () {
     await tabNavigateToWorkspace(this.browser);
     await this.browser.pause(PAUSE_TIME);
-    await setCurrentCursorNodeById(this.browser, 'colour_picker_1');
+    await focusOnBlock(this.browser, 'colour_picker_1');
     await this.browser.pause(PAUSE_TIME);
     await this.browser.keys(Key.ArrowDown);
     await this.browser.pause(PAUSE_TIME);
@@ -214,7 +214,7 @@ suite('Keyboard navigation on Blocks', function () {
   test("Down from inline input selects block's child block", async function () {
     await tabNavigateToWorkspace(this.browser);
     await this.browser.pause(PAUSE_TIME);
-    await setCurrentCursorNodeById(this.browser, 'logic_boolean_1');
+    await focusOnBlock(this.browser, 'logic_boolean_1');
     await this.browser.pause(PAUSE_TIME);
     await this.browser.keys(Key.ArrowDown);
     await this.browser.pause(PAUSE_TIME);
@@ -227,7 +227,7 @@ suite('Keyboard navigation on Blocks', function () {
   test('Right from text block selects shadow block then field', async function () {
     await tabNavigateToWorkspace(this.browser);
     await this.browser.pause(PAUSE_TIME);
-    await setCurrentCursorNodeById(this.browser, 'text_print_1');
+    await focusOnBlock(this.browser, 'text_print_1');
     await this.browser.pause(PAUSE_TIME);
     await this.browser.keys(Key.ArrowRight);
     await this.browser.pause(PAUSE_TIME);
@@ -252,7 +252,7 @@ suite('Keyboard navigation on Blocks', function () {
   test('Losing focus cancels move', async function () {
     await tabNavigateToWorkspace(this.browser);
     await this.browser.pause(PAUSE_TIME);
-    await setCurrentCursorNodeById(this.browser, 'text_print_1');
+    await focusOnBlock(this.browser, 'text_print_1');
     await this.browser.keys('m');
     await this.browser.pause(PAUSE_TIME);
 
@@ -265,7 +265,6 @@ suite('Keyboard navigation on Blocks', function () {
   });
 });
 
-// TODO(#499) These tests fail because focusing on a field doesn't update the cursor
 suite('Keyboard navigation on Fields', function () {
   // Setting timeout to unlimited as these tests take a longer time to run than most mocha test
   this.timeout(0);
@@ -278,7 +277,7 @@ suite('Keyboard navigation on Fields', function () {
   test('Up from first field selects block', async function () {
     await tabNavigateToWorkspace(this.browser);
     await this.browser.pause(PAUSE_TIME);
-    await setCurrentCursorNodeByIdAndFieldName(
+    await focusOnBlockField(
       this.browser,
       'p5_canvas_1',
       'WIDTH',
@@ -296,7 +295,7 @@ suite('Keyboard navigation on Fields', function () {
   test('Left from first field selects block', async function () {
     await tabNavigateToWorkspace(this.browser);
     await this.browser.pause(PAUSE_TIME);
-    await setCurrentCursorNodeByIdAndFieldName(
+    await focusOnBlockField(
       this.browser,
       'p5_canvas_1',
       'WIDTH',
@@ -314,7 +313,7 @@ suite('Keyboard navigation on Fields', function () {
   test('Right from first field selects second field', async function () {
     await tabNavigateToWorkspace(this.browser);
     await this.browser.pause(PAUSE_TIME);
-    await setCurrentCursorNodeByIdAndFieldName(
+    await focusOnBlockField(
       this.browser,
       'p5_canvas_1',
       'WIDTH',
@@ -333,7 +332,7 @@ suite('Keyboard navigation on Fields', function () {
   test('Left from second field selects first field', async function () {
     await tabNavigateToWorkspace(this.browser);
     await this.browser.pause(PAUSE_TIME);
-    await setCurrentCursorNodeByIdAndFieldName(
+    await focusOnBlockField(
       this.browser,
       'p5_canvas_1',
       'HEIGHT',
@@ -352,7 +351,7 @@ suite('Keyboard navigation on Fields', function () {
   test('Right from second field selects next block', async function () {
     await tabNavigateToWorkspace(this.browser);
     await this.browser.pause(PAUSE_TIME);
-    await setCurrentCursorNodeByIdAndFieldName(
+    await focusOnBlockField(
       this.browser,
       'p5_canvas_1',
       'HEIGHT',
@@ -369,7 +368,7 @@ suite('Keyboard navigation on Fields', function () {
   test('Down from field selects next block', async function () {
     await tabNavigateToWorkspace(this.browser);
     await this.browser.pause(PAUSE_TIME);
-    await setCurrentCursorNodeByIdAndFieldName(
+    await focusOnBlockField(
       this.browser,
       'p5_canvas_1',
       'WIDTH',
@@ -386,7 +385,7 @@ suite('Keyboard navigation on Fields', function () {
   test("Down from field selects block's child block", async function () {
     await tabNavigateToWorkspace(this.browser);
     await this.browser.pause(PAUSE_TIME);
-    await setCurrentCursorNodeByIdAndFieldName(
+    await focusOnBlockField(
       this.browser,
       'controls_repeat_1',
       'TIMES',

--- a/test/webdriverio/test/clipboard_test.ts
+++ b/test/webdriverio/test/clipboard_test.ts
@@ -14,7 +14,7 @@ import {
   getSelectedBlockId,
   ElementWithId,
   tabNavigateToWorkspace,
-  setCurrentCursorNodeById,
+  focusOnBlock,
 } from './test_setup.js';
 import {Key, KeyAction, PointerAction, WheelAction} from 'webdriverio';
 
@@ -31,7 +31,7 @@ suite('Clipboard test', function () {
   test('Copy and paste while block selected', async function () {
     // Navigate to draw_circle_1.
     await tabNavigateToWorkspace(this.browser);
-    await setCurrentCursorNodeById(this.browser, 'draw_circle_1');
+    await focusOnBlock(this.browser, 'draw_circle_1');
 
     // Copy and paste
     await this.browser.keys([Key.Ctrl, 'c']);
@@ -52,7 +52,7 @@ suite('Clipboard test', function () {
   test('Cut and paste while block selected', async function () {
     // Navigate to draw_circle_1.
     await tabNavigateToWorkspace(this.browser);
-    await setCurrentCursorNodeById(this.browser, 'draw_circle_1');
+    await focusOnBlock(this.browser, 'draw_circle_1');
     const block = await getBlockElementById(this.browser, 'draw_circle_1');
 
     // Cut and paste

--- a/test/webdriverio/test/delete_test.ts
+++ b/test/webdriverio/test/delete_test.ts
@@ -15,6 +15,7 @@ import {
   testFileLocations,
   PAUSE_TIME,
   tabNavigateToWorkspace,
+  keyRight,
 } from './test_setup.js';
 import {Key} from 'webdriverio';
 
@@ -172,8 +173,7 @@ suite('Deleting Blocks', function () {
     await moveToToolboxCategory(this.browser, 'Math');
     await this.browser.pause(PAUSE_TIME);
     // Move to flyout.
-    await this.browser.keys(Key.ArrowRight);
-    await this.browser.pause(PAUSE_TIME);
+    await keyRight(this.browser);
     // Select number block.
     await this.browser.keys(Key.Enter);
     await this.browser.pause(PAUSE_TIME);
@@ -200,8 +200,7 @@ suite('Deleting Blocks', function () {
     await moveToToolboxCategory(this.browser, 'Math');
     await this.browser.pause(PAUSE_TIME);
     // Move to flyout.
-    await this.browser.keys(Key.ArrowRight);
-    await this.browser.pause(PAUSE_TIME);
+    await keyRight(this.browser);
     // Select number block.
     await this.browser.keys(Key.Enter);
     await this.browser.pause(PAUSE_TIME);

--- a/test/webdriverio/test/delete_test.ts
+++ b/test/webdriverio/test/delete_test.ts
@@ -7,7 +7,7 @@
 import * as chai from 'chai';
 import {
   blockIsPresent,
-  setCurrentCursorNodeById,
+  focusOnBlock,
   getCurrentFocusedBlockId,
   getFocusedBlockType,
   moveToToolboxCategory,
@@ -30,7 +30,7 @@ suite('Deleting Blocks', function () {
   test('Deleting block selects parent block', async function () {
     await tabNavigateToWorkspace(this.browser);
     await this.browser.pause(PAUSE_TIME);
-    await setCurrentCursorNodeById(this.browser, 'controls_if_2');
+    await focusOnBlock(this.browser, 'controls_if_2');
     await this.browser.pause(PAUSE_TIME);
 
     chai
@@ -52,7 +52,7 @@ suite('Deleting Blocks', function () {
   test('Cutting block selects parent block', async function () {
     await tabNavigateToWorkspace(this.browser);
     await this.browser.pause(PAUSE_TIME);
-    await setCurrentCursorNodeById(this.browser, 'controls_if_2');
+    await focusOnBlock(this.browser, 'controls_if_2');
     await this.browser.pause(PAUSE_TIME);
 
     chai
@@ -74,7 +74,7 @@ suite('Deleting Blocks', function () {
   test('Deleting block also deletes children and inputs', async function () {
     await tabNavigateToWorkspace(this.browser);
     await this.browser.pause(PAUSE_TIME);
-    await setCurrentCursorNodeById(this.browser, 'controls_if_2');
+    await focusOnBlock(this.browser, 'controls_if_2');
     await this.browser.pause(PAUSE_TIME);
 
     chai
@@ -96,7 +96,7 @@ suite('Deleting Blocks', function () {
   test('Cutting block also removes children and inputs', async function () {
     await tabNavigateToWorkspace(this.browser);
     await this.browser.pause(PAUSE_TIME);
-    await setCurrentCursorNodeById(this.browser, 'controls_if_2');
+    await focusOnBlock(this.browser, 'controls_if_2');
     await this.browser.pause(PAUSE_TIME);
 
     chai
@@ -118,7 +118,7 @@ suite('Deleting Blocks', function () {
   test('Deleting inline input selects parent block', async function () {
     await tabNavigateToWorkspace(this.browser);
     await this.browser.pause(PAUSE_TIME);
-    await setCurrentCursorNodeById(this.browser, 'logic_boolean_1');
+    await focusOnBlock(this.browser, 'logic_boolean_1');
     await this.browser.pause(PAUSE_TIME);
 
     chai
@@ -140,7 +140,7 @@ suite('Deleting Blocks', function () {
   test('Cutting inline input selects parent block', async function () {
     await tabNavigateToWorkspace(this.browser);
     await this.browser.pause(PAUSE_TIME);
-    await setCurrentCursorNodeById(this.browser, 'logic_boolean_1');
+    await focusOnBlock(this.browser, 'logic_boolean_1');
     await this.browser.pause(PAUSE_TIME);
 
     chai

--- a/test/webdriverio/test/flyout_test.ts
+++ b/test/webdriverio/test/flyout_test.ts
@@ -18,7 +18,7 @@ import {
   keyRight,
 } from './test_setup.js';
 
-suite.only('Toolbox and flyout test', function () {
+suite('Toolbox and flyout test', function () {
   // Clear the workspace and load start blocks
   setup(async function () {
     this.browser = await testSetup(testFileLocations.BASE);

--- a/test/webdriverio/test/flyout_test.ts
+++ b/test/webdriverio/test/flyout_test.ts
@@ -11,15 +11,15 @@ import {
   testFileLocations,
   PAUSE_TIME,
   tabNavigateForward,
-  getFocusedBlockType,
   keyDown,
   tabNavigateBackward,
   tabNavigateToWorkspace,
   keyRight,
   getCurrentFocusNodeId,
+  getCurrentFocusedBlockId,
 } from './test_setup.js';
 
-suite('Toolbox and flyout test', function () {
+suite.only('Toolbox and flyout test', function () {
   // Clear the workspace and load start blocks
   setup(async function () {
     this.browser = await testSetup(testFileLocations.BASE);
@@ -46,8 +46,8 @@ suite('Toolbox and flyout test', function () {
 
     // The top block of the category should be automatically selected. See:
     // https://github.com/google/blockly/issues/8978.
-    const blockType = await getFocusedBlockType(this.browser);
-    chai.assert.strictEqual(blockType, 'controls_if');
+    const blockId = await getCurrentFocusedBlockId(this.browser);
+    chai.assert.strictEqual(blockId, 'if_block');
   });
 
   test('Tab navigating to toolbox then right arrow key should auto-select first block in flyout', async function () {
@@ -60,8 +60,8 @@ suite('Toolbox and flyout test', function () {
 
     // The top block of the category should be automatically selected. See:
     // https://github.com/google/blockly/issues/8978.
-    const blockType = await getFocusedBlockType(this.browser);
-    chai.assert.strictEqual(blockType, 'controls_if');
+    const blockId = await getCurrentFocusedBlockId(this.browser);
+    chai.assert.strictEqual(blockId, 'if_block');
   });
 
   test('Keyboard nav to different toolbox category should auto-select first block', async function () {
@@ -74,8 +74,8 @@ suite('Toolbox and flyout test', function () {
     await tabNavigateForward(this.browser);
 
     // The top block of the category should be automatically selected.
-    const blockType = await getFocusedBlockType(this.browser);
-    chai.assert.strictEqual(blockType, 'text');
+    const blockId = await getCurrentFocusedBlockId(this.browser);
+    chai.assert.strictEqual(blockId, 'text_block');
   });
 
   test('Keyboard nav to different toolbox category and block should select different block', async function () {
@@ -90,8 +90,8 @@ suite('Toolbox and flyout test', function () {
     await keyDown(this.browser, 2);
 
     // A non-top blockshould be manually selected.
-    const blockType = await getFocusedBlockType(this.browser);
-    chai.assert.strictEqual(blockType, 'text_append');
+    const blockId = await getCurrentFocusedBlockId(this.browser);
+    chai.assert.strictEqual(blockId, 'append_text_block');
   });
 
   test('Tab navigate away from toolbox restores focus to initial element', async function () {
@@ -196,8 +196,8 @@ suite('Toolbox and flyout test', function () {
 
     // The previously selected block should be retained upon returning. See:
     // https://github.com/google/blockly/issues/8965#issuecomment-2900479280.
-    const blockType = await getFocusedBlockType(this.browser);
-    chai.assert.strictEqual(blockType, 'p5_draw');
+    const blockId = await getCurrentFocusedBlockId(this.browser);
+    chai.assert.strictEqual(blockId, 'p5_draw_1');
   });
 
   test('Clicking outside Blockly with focused toolbox closes the flyout', async function () {

--- a/test/webdriverio/test/flyout_test.ts
+++ b/test/webdriverio/test/flyout_test.ts
@@ -1,0 +1,239 @@
+/**
+ * @license
+ * Copyright 2025 Google LLC
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import * as chai from 'chai';
+import * as Blockly from 'blockly';
+import {
+  testSetup,
+  testFileLocations,
+  PAUSE_TIME,
+  tabNavigateForward,
+  getFocusedBlockType,
+  keyDown,
+  tabNavigateBackward,
+  tabNavigateToWorkspace,
+  keyRight,
+} from './test_setup.js';
+
+suite.only('Toolbox and flyout test', function () {
+  // Clear the workspace and load start blocks
+  setup(async function () {
+    this.browser = await testSetup(testFileLocations.BASE);
+    await this.browser.pause(PAUSE_TIME);
+  });
+
+  test('Tab navigating to toolbox should open flyout', async function () {
+    // Two tabs should navigate to the toolbox (initial element is skipped).
+    await tabNavigateForward(this.browser);
+
+    await tabNavigateForward(this.browser);
+
+    // The flyout should now be open.
+    const flyoutIsOpen = await checkIfFlyoutIsOpen(this.browser);
+    chai.assert.isTrue(flyoutIsOpen);
+  });
+
+  test('Tab navigating to flyout should auto-select first block', async function () {
+    // Three tabs should navigate to the flyout (initial element is skipped).
+    await tabNavigateForward(this.browser);
+    await tabNavigateForward(this.browser);
+
+    await tabNavigateForward(this.browser);
+
+    // The top block of the category should be automatically selected. See:
+    // https://github.com/google/blockly/issues/8978.
+    const blockType = await getFocusedBlockType(this.browser);
+    chai.assert.strictEqual(blockType, 'controls_if');
+  });
+
+  test('Tab navigating to toolbox then right arrow key should auto-select first block in flyout', async function () {
+    // Two tabs should navigate to the toolbox (initial element is skipped). One
+    // right arrow key should select a block on the flyout.
+    await tabNavigateForward(this.browser);
+    await tabNavigateForward(this.browser);
+
+    await keyRight(this.browser);
+
+    // The top block of the category should be automatically selected. See:
+    // https://github.com/google/blockly/issues/8978.
+    const blockType = await getFocusedBlockType(this.browser);
+    chai.assert.strictEqual(blockType, 'controls_if');
+  });
+
+  test('Keyboard nav to different toolbox category should auto-select first block', async function () {
+    // Two tabs should navigate to the toolbox (initial element is skipped),
+    // then keys for a different category with a tab to select the flyout.
+    await tabNavigateForward(this.browser);
+    await tabNavigateForward(this.browser);
+
+    await keyDown(this.browser, 3);
+    await tabNavigateForward(this.browser);
+
+    // The top block of the category should be automatically selected.
+    const blockType = await getFocusedBlockType(this.browser);
+    chai.assert.strictEqual(blockType, 'text');
+  });
+
+  test('Keyboard nav to different toolbox category and block should select different block', async function () {
+    // Two tabs should navigate to the toolbox (initial element is skipped),
+    // then keys for a different category with a tab to select the flyout and
+    // finally keys to select a different block.
+    await tabNavigateForward(this.browser);
+    await tabNavigateForward(this.browser);
+
+    await keyDown(this.browser, 3);
+    await tabNavigateForward(this.browser);
+    await keyDown(this.browser, 2);
+
+    // A non-top blockshould be manually selected.
+    const blockType = await getFocusedBlockType(this.browser);
+    chai.assert.strictEqual(blockType, 'text_append');
+  });
+
+  test('Tab navigate away from toolbox restores focus to initial element', async function () {
+    // Two tabs should navigate to the toolbox. One tab back should leave it.
+    await tabNavigateForward(this.browser);
+    await tabNavigateForward(this.browser);
+
+    await tabNavigateBackward(this.browser);
+
+    // Focus should restore to the initial div element. See:
+    // https://github.com/google/blockly-keyboard-experimentation/issues/523.
+    const activeElementId = await this.browser.execute(
+      () => document.activeElement?.id);
+    chai.assert.strictEqual(activeElementId, 'focusableDiv');
+  });
+
+  test('Tab navigate away from toolbox closes flyout', async function () {
+    // Two tabs should navigate to the toolbox. One tab back should leave it.
+    await tabNavigateForward(this.browser);
+    await tabNavigateForward(this.browser);
+
+    await tabNavigateBackward(this.browser);
+
+    // The flyout should be closed since the toolbox lost focus. See:
+    // https://github.com/google/blockly/issues/8970.
+    const flyoutIsOpen = await checkIfFlyoutIsOpen(this.browser);
+    chai.assert.isFalse(flyoutIsOpen);
+  });
+
+  test('Tab navigate away from flyout to toolbox and away closes flyout', async function () {
+    // Three tabs should navigate to the flyout, and two tabs back should close.
+    await tabNavigateForward(this.browser);
+    await tabNavigateForward(this.browser);
+    await tabNavigateForward(this.browser);
+
+    await tabNavigateBackward(this.browser);
+    await tabNavigateBackward(this.browser);
+
+    // The flyout should be closed since the toolbox lost focus.
+    const flyoutIsOpen = await checkIfFlyoutIsOpen(this.browser);
+    chai.assert.isFalse(flyoutIsOpen);
+  });
+
+  test('Tabbing to the workspace should close the flyout', async function () {
+    await tabNavigateToWorkspace(this.browser);
+
+    // The flyout should be closed since it lost focus.
+    const flyoutIsOpen = await checkIfFlyoutIsOpen(this.browser);
+    chai.assert.isFalse(flyoutIsOpen);
+  });
+
+  test('Tabbing to the workspace after selecting flyout block should close the flyout', async function () {
+    // Two tabs should navigate to the toolbox (initial element is skipped),
+    // then use right key to specifically navigate into the flyout before
+    // navigating to the workspace.
+    await tabNavigateForward(this.browser);
+    await tabNavigateForward(this.browser);
+
+    await keyRight(this.browser);
+    await tabNavigateForward(this.browser);
+
+    // The flyout should be closed since it lost focus. See:
+    // https://github.com/google/blockly-keyboard-experimentation/issues/547.
+    const flyoutIsOpen = await checkIfFlyoutIsOpen(this.browser);
+    chai.assert.isFalse(flyoutIsOpen);
+  });
+
+  test('Tabbing to the workspace after selecting flyout block via workspace toolbox shortcut should close the flyout', async function () {
+    await tabNavigateToWorkspace(this.browser);
+
+    await this.browser.keys('t');
+    await keyRight(this.browser);
+    await tabNavigateForward(this.browser);
+
+    // The flyout should now be closed and unfocused. See:
+    // https://github.com/google/blockly/pull/9079#issuecomment-2913759646.
+    const flyoutIsOpen = await checkIfFlyoutIsOpen(this.browser);
+    chai.assert.isFalse(flyoutIsOpen);
+  });
+
+  test('Tabbing back from workspace should reopen the flyout', async function () {
+    await tabNavigateToWorkspace(this.browser);
+
+    await tabNavigateBackward(this.browser);
+
+    // The flyout should be open again since the toolbox is again focused. See:
+    // https://github.com/google/blockly/issues/8965.
+    const flyoutIsOpen = await checkIfFlyoutIsOpen(this.browser);
+    chai.assert.isTrue(flyoutIsOpen);
+  });
+
+  test('Navigation position in workspace should be retained when tabbing to flyout and back', async function () {
+    // Navigate to the workspace and select a non-default block.
+    await tabNavigateToWorkspace(this.browser);
+
+    // Note that two tabs are needed here to move past the flyout.
+    await keyDown(this.browser, 3);
+    await tabNavigateBackward(this.browser);
+    await tabNavigateForward(this.browser);
+    await tabNavigateForward(this.browser);
+
+    // The previously selected block should be retained upon returning. See:
+    // https://github.com/google/blockly/issues/8965#issuecomment-2900479280.
+    const blockType = await getFocusedBlockType(this.browser);
+    chai.assert.strictEqual(blockType, 'p5_draw');
+  });
+
+  test('Clicking outside Blockly with focused toolbox closes the flyout', async function () {
+    // Two tabs should navigate to the toolbox. One click to unfocus.
+    await tabNavigateForward(this.browser);
+    await tabNavigateForward(this.browser);
+
+    const elem = this.browser.$('#focusableDiv');
+    await elem.click();
+
+    // The flyout should be closed due to clicking an outside element.
+    const flyoutIsOpen = await checkIfFlyoutIsOpen(this.browser);
+    chai.assert.isFalse(flyoutIsOpen);
+  });
+
+  test('Clicking outside Blockly with focused flyout closes the flyout', async function () {
+    // Two tabs should navigate to the toolbox. One key to select the flyout.
+    await tabNavigateForward(this.browser);
+    await tabNavigateForward(this.browser);
+    await keyRight(this.browser);
+
+    const elem = this.browser.$('#focusableDiv');
+    await elem.click();
+
+    // The flyout should be closed due to clicking an outside element. See:
+    // https://github.com/google/blockly/pull/9079#issuecomment-2914628810.
+    const flyoutIsOpen = await checkIfFlyoutIsOpen(this.browser);
+    chai.assert.isFalse(flyoutIsOpen);
+  });
+});
+
+async function checkIfFlyoutIsOpen(
+  browser: WebdriverIO.Browser,
+): Promise<boolean> {
+  return await browser.execute(() => {
+    const workspaceSvg = Blockly.getMainWorkspace() as Blockly.WorkspaceSvg;
+    const flyout = workspaceSvg.getFlyout();
+    if (!flyout) throw new Error('Workspace has no flyout.');
+    return flyout.isVisible();
+  });
+}

--- a/test/webdriverio/test/flyout_test.ts
+++ b/test/webdriverio/test/flyout_test.ts
@@ -103,7 +103,8 @@ suite.only('Toolbox and flyout test', function () {
     // Focus should restore to the initial div element. See:
     // https://github.com/google/blockly-keyboard-experimentation/issues/523.
     const activeElementId = await this.browser.execute(
-      () => document.activeElement?.id);
+      () => document.activeElement?.id,
+    );
     chai.assert.strictEqual(activeElementId, 'focusableDiv');
   });
 
@@ -227,6 +228,14 @@ suite.only('Toolbox and flyout test', function () {
   });
 });
 
+/**
+ * Checks if the flyout is currently open.
+ *
+ * This throws an error if the current main workspace has no flyout.
+ *
+ * @param browser The active WebdriverIO Browser object.
+ * @returns A promise indicating whether the flyout is currently open.
+ */
 async function checkIfFlyoutIsOpen(
   browser: WebdriverIO.Browser,
 ): Promise<boolean> {

--- a/test/webdriverio/test/flyout_test.ts
+++ b/test/webdriverio/test/flyout_test.ts
@@ -19,7 +19,7 @@ import {
   getCurrentFocusedBlockId,
 } from './test_setup.js';
 
-suite.only('Toolbox and flyout test', function () {
+suite('Toolbox and flyout test', function () {
   // Clear the workspace and load start blocks
   setup(async function () {
     this.browser = await testSetup(testFileLocations.BASE);

--- a/test/webdriverio/test/insert_test.ts
+++ b/test/webdriverio/test/insert_test.ts
@@ -10,7 +10,7 @@ import {
   getFocusedBlockType,
   moveToToolboxCategory,
   PAUSE_TIME,
-  setCurrentCursorNodeById,
+  focusOnBlock,
   tabNavigateToWorkspace,
   testFileLocations,
   testSetup,
@@ -29,7 +29,7 @@ suite('Insert test', function () {
   test('Insert C-shaped block with statement block selected', async function () {
     // Navigate to draw_circle_1.
     await tabNavigateToWorkspace(this.browser);
-    await setCurrentCursorNodeById(this.browser, 'draw_circle_1');
+    await focusOnBlock(this.browser, 'draw_circle_1');
 
     await moveToToolboxCategory(this.browser, 'Functions');
     // Move to flyout.

--- a/test/webdriverio/test/insert_test.ts
+++ b/test/webdriverio/test/insert_test.ts
@@ -14,6 +14,7 @@ import {
   tabNavigateToWorkspace,
   testFileLocations,
   testSetup,
+  keyRight,
 } from './test_setup.js';
 
 suite('Insert test', function () {
@@ -33,7 +34,7 @@ suite('Insert test', function () {
 
     await moveToToolboxCategory(this.browser, 'Functions');
     // Move to flyout.
-    await this.browser.keys(Key.ArrowRight);
+    await keyRight(this.browser);
     // Select Function block.
     await this.browser.keys(Key.Enter);
     // Confirm move.

--- a/test/webdriverio/test/move_test.ts
+++ b/test/webdriverio/test/move_test.ts
@@ -9,7 +9,7 @@ import * as chai from 'chai';
 import {Browser, Key} from 'webdriverio';
 import {
   PAUSE_TIME,
-  setCurrentCursorNodeById,
+  focusOnBlock,
   tabNavigateToWorkspace,
   testFileLocations,
   testSetup,
@@ -34,7 +34,7 @@ suite('Move tests', function () {
     for (let i = 1; i < 7; i++) {
       // Navigate to statement_<i>.
       await tabNavigateToWorkspace(this.browser);
-      await setCurrentCursorNodeById(this.browser, `statement_${i}`);
+      await focusOnBlock(this.browser, `statement_${i}`);
 
       // Get information about parent connection of selected block,
       // and block connected to selected block's next connection.
@@ -94,7 +94,7 @@ suite('Move tests', function () {
     for (let i = 1; i < 7; i++) {
       // Navigate to statement_<i>.
       await tabNavigateToWorkspace(this.browser);
-      await setCurrentCursorNodeById(this.browser, `value_${i}`);
+      await focusOnBlock(this.browser, `value_${i}`);
 
       // Get information about parent connection of selected block,
       // and block connected to selected block's value input.

--- a/test/webdriverio/test/test_setup.ts
+++ b/test/webdriverio/test/test_setup.ts
@@ -195,9 +195,7 @@ export async function moveToToolboxCategory(
   if (categoryIndex < 0) {
     throw new Error(`No category found: ${category}`);
   }
-  if (categoryIndex > 0) {
-    await browser.keys(webdriverio.Key.ArrowDown.repeat(categoryIndex));
-  }
+  if (categoryIndex > 0) await keyDown(browser, categoryIndex);
 }
 
 /**
@@ -400,6 +398,8 @@ export async function tabNavigateToWorkspace(
   hasToolbox = true,
   hasFlyout = true,
 ) {
+  // Navigate past the initial pre-injection focusable div element.
+  tabNavigateForward(browser);
   if (hasToolbox) tabNavigateForward(browser);
   if (hasFlyout) tabNavigateForward(browser);
   tabNavigateForward(browser); // Tab to the workspace itself.
@@ -413,6 +413,36 @@ export async function tabNavigateToWorkspace(
 export async function tabNavigateForward(browser: WebdriverIO.Browser) {
   await browser.keys(webdriverio.Key.Tab);
   await browser.pause(PAUSE_TIME);
+}
+
+export async function tabNavigateBackward(browser: WebdriverIO.Browser) {
+  await browser.keys([webdriverio.Key.Shift, webdriverio.Key.Tab]);
+  await browser.pause(PAUSE_TIME);
+}
+
+export async function keyLeft(browser: WebdriverIO.Browser, times: number = 1) {
+  await sendKeyAndWait(browser, webdriverio.Key.ArrowLeft, times);
+}
+
+export async function keyRight(
+  browser: WebdriverIO.Browser, times: number = 1) {
+  await sendKeyAndWait(browser, webdriverio.Key.ArrowRight, times);
+}
+
+export async function keyUp(browser: WebdriverIO.Browser, times: number = 1) {
+  await sendKeyAndWait(browser, webdriverio.Key.ArrowUp, times);
+}
+
+export async function keyDown(browser: WebdriverIO.Browser, times: number = 1) {
+  await sendKeyAndWait(browser, webdriverio.Key.ArrowDown, times);
+}
+
+export async function sendKeyAndWait(
+  browser: WebdriverIO.Browser, key: string, times: number) {
+  for (let i = 0; i < times; i++) {
+    await browser.keys(key);
+    await browser.pause(PAUSE_TIME);
+  }
 }
 
 /**

--- a/test/webdriverio/test/test_setup.ts
+++ b/test/webdriverio/test/test_setup.ts
@@ -95,7 +95,7 @@ export async function driverTeardown() {
 export async function testSetup(
   playgroundUrl: string,
 ): Promise<webdriverio.Browser> {
-if (!driver) {
+  if (!driver) {
     driver = await driverSetup();
   }
   await driver.url(playgroundUrl);
@@ -232,6 +232,8 @@ export async function currentFocusIsMainWorkspace(
 /**
  * Focuses and selects a block with the provided ID.
  *
+ * This throws an error if no block exists for the specified ID.
+ *
  * @param browser The active WebdriverIO Browser object.
  * @param blockId The ID of the block to select.
  */
@@ -249,6 +251,9 @@ export async function focusOnBlock(
 
 /**
  * Focuses and selects the field of a block given a block ID and field name.
+ *
+ * This throws an error if no block exists for the specified ID, or if the block
+ * corresponding to the specified ID has no field with the provided name.
  *
  * @param browser The active WebdriverIO Browser object.
  * @param blockId The ID of the block to select.
@@ -415,30 +420,69 @@ export async function tabNavigateForward(browser: WebdriverIO.Browser) {
   await browser.pause(PAUSE_TIME);
 }
 
+/**
+ * Navigates backward to the test page's previous tab stop.
+ *
+ * @param browser The active WebdriverIO Browser object.
+ */
 export async function tabNavigateBackward(browser: WebdriverIO.Browser) {
   await browser.keys([webdriverio.Key.Shift, webdriverio.Key.Tab]);
   await browser.pause(PAUSE_TIME);
 }
 
-export async function keyLeft(browser: WebdriverIO.Browser, times: number = 1) {
+/**
+ * Sends the keyboard event for arrow key left.
+ *
+ * @param browser The active WebdriverIO Browser object.
+ * @param times The number of times to repeat the key press (default is 1).
+ */
+export async function keyLeft(browser: WebdriverIO.Browser, times = 1) {
   await sendKeyAndWait(browser, webdriverio.Key.ArrowLeft, times);
 }
 
-export async function keyRight(
-  browser: WebdriverIO.Browser, times: number = 1) {
+/**
+ * Sends the keyboard event for arrow key right.
+ *
+ * @param browser The active WebdriverIO Browser object.
+ * @param times The number of times to repeat the key press (default is 1).
+ */
+export async function keyRight(browser: WebdriverIO.Browser, times = 1) {
   await sendKeyAndWait(browser, webdriverio.Key.ArrowRight, times);
 }
 
-export async function keyUp(browser: WebdriverIO.Browser, times: number = 1) {
+/**
+ * Sends the keyboard event for arrow key up.
+ *
+ * @param browser The active WebdriverIO Browser object.
+ * @param times The number of times to repeat the key press (default is 1).
+ */
+export async function keyUp(browser: WebdriverIO.Browser, times = 1) {
   await sendKeyAndWait(browser, webdriverio.Key.ArrowUp, times);
 }
 
-export async function keyDown(browser: WebdriverIO.Browser, times: number = 1) {
+/**
+ * Sends the keyboard event for arrow key down.
+ *
+ * @param browser The active WebdriverIO Browser object.
+ * @param times The number of times to repeat the key press (default is 1).
+ */
+export async function keyDown(browser: WebdriverIO.Browser, times = 1) {
   await sendKeyAndWait(browser, webdriverio.Key.ArrowDown, times);
 }
 
-export async function sendKeyAndWait(
-  browser: WebdriverIO.Browser, key: string, times: number) {
+/**
+ * Sends the specified key for the specified number of times, waiting between
+ * each key press to allow changes to keep up.
+ *
+ * @param browser The active WebdriverIO Browser object.
+ * @param key The WebdriverIO representative key value to press.
+ * @param times The number of times to repeat the key press.
+ */
+async function sendKeyAndWait(
+  browser: WebdriverIO.Browser,
+  key: string,
+  times: number,
+) {
   for (let i = 0; i < times; i++) {
     await browser.keys(key);
     await browser.pause(PAUSE_TIME);

--- a/test/webdriverio/test/test_setup.ts
+++ b/test/webdriverio/test/test_setup.ts
@@ -95,7 +95,7 @@ export async function driverTeardown() {
 export async function testSetup(
   playgroundUrl: string,
 ): Promise<webdriverio.Browser> {
-  if (!driver) {
+if (!driver) {
     driver = await driverSetup();
   }
   await driver.url(playgroundUrl);
@@ -232,32 +232,31 @@ export async function currentFocusIsMainWorkspace(
 }
 
 /**
- * Select a block with the given id as the current cursor node.
+ * Focuses and selects a block with the provided ID.
  *
  * @param browser The active WebdriverIO Browser object.
- * @param blockId The id of the block to select.
+ * @param blockId The ID of the block to select.
  */
-export async function setCurrentCursorNodeById(
+export async function focusOnBlock(
   browser: WebdriverIO.Browser,
   blockId: string,
 ) {
   return await browser.execute((blockId) => {
     const workspaceSvg = Blockly.getMainWorkspace() as Blockly.WorkspaceSvg;
     const block = workspaceSvg.getBlockById(blockId);
-    if (block) {
-      block.getFocusableElement()?.focus();
-    }
+    if (!block) throw new Error(`No block found with ID: ${blockId}.`);
+    Blockly.getFocusManager().focusNode(block);
   }, blockId);
 }
 
 /**
- * Select a block's field with the given block id and field name.
+ * Focuses and selects the field of a block given a block ID and field name.
  *
  * @param browser The active WebdriverIO Browser object.
- * @param blockId The id of the block to select.
+ * @param blockId The ID of the block to select.
  * @param fieldName The name of the field on the block to select.
  */
-export async function setCurrentCursorNodeByIdAndFieldName(
+export async function focusOnBlockField(
   browser: WebdriverIO.Browser,
   blockId: string,
   fieldName: string,
@@ -266,14 +265,12 @@ export async function setCurrentCursorNodeByIdAndFieldName(
     (blockId, fieldName) => {
       const workspaceSvg = Blockly.getMainWorkspace() as Blockly.WorkspaceSvg;
       const block = workspaceSvg.getBlockById(blockId);
-      const field = block?.getField(fieldName);
-      if (field) {
-        // TODO: Stop referencing getCursor() and use focus() instead.
-        // getCursor().setCurNode() calls Marker.setCurNode(), but focus() does
-        // not accomplish the same goal yet.
-        workspaceSvg.getCursor()?.setCurNode(field);
-        // field.getFocusableElement()?.focus();
+      if (!block) throw new Error(`No block found with ID: ${blockId}.`);
+      const field = block.getField(fieldName);
+      if (!field) {
+        throw new Error(`No field found: ${fieldName} (block ${blockId}).`);
       }
+      Blockly.getFocusManager().focusNode(field);
     },
     blockId,
     fieldName,


### PR DESCRIPTION
Fixes part of https://github.com/google/blockly/issues/8915
Fixes part of https://github.com/google/blockly/issues/9020

This PR does a few things:
- It introduces some new helpers to simplify arrow key inputs across all of the webdriver tests.
- It introduces a new focusable div element that exists in the tab order before toolbox (so that back navigation can be tested).
- It renames a few functions for clarity: `setCurrentCursorNodeById` -> `focusOnBlock` and `setCurrentCursorNodeByIdAndFieldName` -> `focusOnBlockField`. This is closer to what the functions are actually doing, and it moves away from cursor verbiage (which could become confusing in the future once the cursor is removed).
- It introduces some robustness sanity checks for test utility functions. These should fail if an assumption isn't met rather than return null or undefined--failing fast is really useful in tests to avoid hiding legitimate failures.
- It introduces a whole test suite for toolbox and flyout (though a lot more tests can be added). This specifically emphasizes regressions fixed by https://github.com/google/blockly/pull/9079.