### PR TITLE
fix: dont do keyboard shortcuts when field editors open

### DIFF
--- a/src/navigation.ts
+++ b/src/navigation.ts
@@ -825,7 +825,8 @@ export class Navigation {
       : workspace.keyboardAccessibilityMode;
     return (
       !!accessibilityMode &&
-      this.getState(workspace) !== Constants.STATE.NOWHERE
+      this.getState(workspace) !== Constants.STATE.NOWHERE &&
+      !Blockly.getFocusManager().ephemeralFocusTaken()
     );
   }
 

--- a/test/webdriverio/test/basic_test.ts
+++ b/test/webdriverio/test/basic_test.ts
@@ -349,4 +349,18 @@ suite('Keyboard navigation on Fields', function () {
       .expect(await getCurrentFocusedBlockId(this.browser))
       .equal('draw_emoji_1');
   });
+
+  test('Do not navigate while field editor is open', async function () {
+    // Open a field editor dropdown
+    await focusOnBlockField(this.browser, 'logic_boolean_1', 'BOOL');
+    await this.browser.pause(PAUSE_TIME);
+    await this.browser.keys(Key.Enter);
+    await this.browser.pause(PAUSE_TIME);
+
+    // Try to navigate to a different block
+    await keyRight(this.browser);
+
+    // The same field should still be focused
+    chai.assert.equal(await getFocusedFieldName(this.browser), 'BOOL');
+  });
 });

--- a/test/webdriverio/test/clipboard_test.ts
+++ b/test/webdriverio/test/clipboard_test.ts
@@ -15,6 +15,8 @@ import {
   ElementWithId,
   tabNavigateToWorkspace,
   focusOnBlock,
+  focusOnBlockField,
+  blockIsPresent,
 } from './test_setup.js';
 import {Key, KeyAction, PointerAction, WheelAction} from 'webdriverio';
 
@@ -109,6 +111,24 @@ suite('Clipboard test', function () {
       initialWsBlocks,
       await serializeWorkspaceBlocks(this.browser),
       'Blocks on the workspace should not have changed',
+    );
+  });
+
+  test('Do not cut block while field editor is open', async function () {
+    // Open a field editor
+    await focusOnBlockField(this.browser, 'draw_circle_1_color', 'COLOUR');
+    await this.browser.pause(PAUSE_TIME);
+    await this.browser.keys(Key.Enter);
+    await this.browser.pause(PAUSE_TIME);
+
+    // Try to cut block while field editor is open
+    await this.browser.keys(Key.Ctrl);
+    await this.browser.keys('x');
+    await this.browser.keys(Key.Ctrl); // release ctrl key
+
+    // Block is not deleted
+    chai.assert.isTrue(
+      await blockIsPresent(this.browser, 'draw_circle_1_color'),
     );
   });
 });

--- a/test/webdriverio/test/clipboard_test.ts
+++ b/test/webdriverio/test/clipboard_test.ts
@@ -122,9 +122,7 @@ suite('Clipboard test', function () {
     await this.browser.pause(PAUSE_TIME);
 
     // Try to cut block while field editor is open
-    await this.browser.keys(Key.Ctrl);
-    await this.browser.keys('x');
-    await this.browser.keys(Key.Ctrl); // release ctrl key
+    await this.browser.keys([Key.Ctrl, 'x']);
 
     // Block is not deleted
     chai.assert.isTrue(

--- a/test/webdriverio/test/delete_test.ts
+++ b/test/webdriverio/test/delete_test.ts
@@ -16,6 +16,7 @@ import {
   PAUSE_TIME,
   tabNavigateToWorkspace,
   keyRight,
+  focusOnBlockField,
 } from './test_setup.js';
 import {Key} from 'webdriverio';
 
@@ -217,5 +218,19 @@ suite('Deleting Blocks', function () {
       await getCurrentFocusedBlockId(this.browser),
       'p5_setup_1',
     );
+  });
+
+  test('Do not delete block while field editor is open', async function () {
+    // Open a field editor
+    await focusOnBlockField(this.browser, 'colour_picker_1', 'COLOUR');
+    await this.browser.pause(PAUSE_TIME);
+    await this.browser.keys(Key.Enter);
+    await this.browser.pause(PAUSE_TIME);
+
+    // Try to delete block while field editor is open
+    await this.browser.keys(Key.Backspace);
+
+    // Block is not deleted
+    chai.assert.isTrue(await blockIsPresent(this.browser, 'colour_picker_1'));
   });
 });

--- a/test/webdriverio/test/keyboard_mode_test.ts
+++ b/test/webdriverio/test/keyboard_mode_test.ts
@@ -80,9 +80,7 @@ suite(
       // Make sure we're on a copyable block so that copy occurs
       await focusOnBlock(this.browser, 'controls_if_2');
       await this.browser.pause(PAUSE_TIME);
-      await this.browser.keys(Key.Ctrl);
-      await this.browser.keys('c');
-      await this.browser.keys(Key.Ctrl); // release ctrl key
+      await this.browser.keys([Key.Ctrl, 'c']);
       await this.browser.pause(PAUSE_TIME);
 
       chai.assert.isFalse(await isKeyboardNavigating(this.browser));
@@ -92,9 +90,7 @@ suite(
       });
 
       await this.browser.pause(PAUSE_TIME);
-      await this.browser.keys(Key.Ctrl);
-      await this.browser.keys('c');
-      await this.browser.keys(Key.Ctrl); // release ctrl key
+      await this.browser.keys([Key.Ctrl, 'c']);
       await this.browser.pause(PAUSE_TIME);
 
       chai.assert.isTrue(await isKeyboardNavigating(this.browser));


### PR DESCRIPTION
Fixes https://github.com/google/blockly/issues/9101

Depends on https://github.com/google/blockly/pull/9110

Adds a check to the `canCurrentlyNavigate` function to make sure nothing has ephemeral focus.

This is safe to do because this function is only used by action preconditions.

It's even safe to do for the escape shortcut because that shortcut only applies when the flyout or toolbox is opened, and in that case it's not possible for a field editor to be open. The escape shortcut in core is the one that closes chaff generally (e.g. when field editors are open) and that one does not have this precondition, so it can still be used to close field editors.