### PR TITLE
fix: Fix bug that caused children of blocks to retain passive focus when their parent is moved.

### DIFF
--- a/src/actions/move.ts
+++ b/src/actions/move.ts
@@ -12,6 +12,7 @@ import {
   utils,
   WorkspaceSvg,
   keyboardNavigationController,
+  getFocusManager,
 } from 'blockly';
 import {Direction} from '../drag_direction';
 import {Mover} from './mover';
@@ -43,6 +44,11 @@ export class MoveActions {
         callback: (workspace) => {
           keyboardNavigationController.setIsActive(true);
           const startBlock = this.getCurrentBlock(workspace);
+          // Focus the start block in case one of its fields or a shadow block
+          // was focused when the move was triggered.
+          if (startBlock) {
+            getFocusManager().focusNode(startBlock);
+          }
           return (
             !!startBlock && this.mover.startMove(workspace, startBlock, null)
           );
@@ -168,6 +174,11 @@ export class MoveActions {
           const workspace = scope.block?.workspace as WorkspaceSvg | null;
           if (!workspace) return false;
           const startBlock = this.getCurrentBlock(workspace);
+          // Focus the start block in case one of its fields or a shadow block
+          // was focused when the move was triggered.
+          if (startBlock) {
+            getFocusManager().focusNode(startBlock);
+          }
           return (
             !!startBlock && this.mover.startMove(workspace, startBlock, null)
           );


### PR DESCRIPTION
This PR fixes https://github.com/google/blockly/issues/9112 by moving focus to the block being moved prior to starting the move. This prevents its child fields/shadow blocks/etc from visually retaining passive focus if they were the focused element when the move was initiated.