### PR TITLE
chore: Added context menu item tests.

### DIFF
--- a/test/loadTestBlocks.js
+++ b/test/loadTestBlocks.js
@@ -317,12 +317,12 @@ const moreBlocks = {
               'next': {
                 'block': {
                   'type': 'text_print',
-                  'id': 'J`*)bq?#`_Vq^X(DQF2t',
+                  'id': 'text_print_1',
                   'inputs': {
                     'TEXT': {
                       'shadow': {
                         'type': 'text',
-                        'id': '6fW_sIt1t|63j}nPE1ge',
+                        'id': 'text_print_shadow_text_1',
                         'fields': {
                           'TEXT': 'abc',
                         },

--- a/test/webdriverio/test/actions_test.ts
+++ b/test/webdriverio/test/actions_test.ts
@@ -22,6 +22,68 @@ import {
   contextMenuItems,
 } from './test_setup.js';
 
+const isDarwin = process.platform === 'darwin';
+const blockActionsViaKeyboard = [
+  {'text': 'Duplicate D'},
+  {'text': 'Add Comment'},
+  {'text': 'External Inputs'},
+  {'text': 'Collapse Block'},
+  {'text': 'Disable Block'},
+  {'text': 'Delete 2 Blocks Delete'},
+  {'text': 'Move Block M'},
+  {'text': 'Edit Block contents Right'},
+  {'text': isDarwin ? 'Cut ⌘ X' : 'Cut Ctrl + X'},
+  {'text': isDarwin ? 'Copy ⌘ C' : 'Copy Ctrl + C'},
+  {'disabled': true, 'text': isDarwin ? 'Paste ⌘ V' : 'Paste Ctrl + V'},
+];
+
+const blockActionsViaMouse = [
+  {'text': 'Duplicate D'},
+  {'text': 'Add Comment'},
+  {'text': 'External Inputs'},
+  {'text': 'Collapse Block'},
+  {'text': 'Disable Block'},
+  {'text': 'Delete 2 Blocks Delete'},
+  {'text': isDarwin ? 'Cut ⌘ X' : 'Cut Ctrl + X'},
+  {'text': isDarwin ? 'Copy ⌘ C' : 'Copy Ctrl + C'},
+  {'disabled': true, 'text': isDarwin ? 'Paste ⌘ V' : 'Paste Ctrl + V'},
+];
+
+const shadowBlockActionsViaKeyboard = [
+  {'text': 'Add Comment'},
+  {'text': 'Collapse Block'},
+  {'text': 'Disable Block'},
+  {'text': 'Help'},
+  {'text': 'Move Block M'},
+  {'disabled': true, 'text': isDarwin ? 'Cut ⌘ X' : 'Cut Ctrl + X'},
+  {'text': isDarwin ? 'Copy ⌘ C' : 'Copy Ctrl + C'},
+  {'disabled': true, 'text': isDarwin ? 'Paste ⌘ V' : 'Paste Ctrl + V'},
+];
+
+const toolboxBlockActionsViaKeyboard = [
+  {'text': 'Help'},
+  {'disabled': true, 'text': 'Move Block M'},
+  {'disabled': true, 'text': isDarwin ? 'Cut ⌘ X' : 'Cut Ctrl + X'},
+  {'text': isDarwin ? 'Copy ⌘ C' : 'Copy Ctrl + C'},
+];
+
+const flyoutBlockActionsViaMouse = [
+  {'text': 'Help'},
+  {'disabled': true, 'text': isDarwin ? 'Cut ⌘ X' : 'Cut Ctrl + X'},
+  {'text': isDarwin ? 'Copy ⌘ C' : 'Copy Ctrl + C'},
+];
+
+const workspaceActionsViaKeyboard = [
+  {'disabled': true, 'text': 'Undo'},
+  {'disabled': true, 'text': 'Redo'},
+  {'text': 'Clean up Blocks'},
+  {'text': 'Collapse Blocks'},
+  {'disabled': true, 'text': 'Expand Blocks'},
+  {'text': 'Delete 4 Blocks'},
+  {'text': 'Add Comment'},
+  {'disabled': true, 'text': isDarwin ? 'Paste ⌘ V' : 'Paste Ctrl + V'},
+];
+
 suite('Menus test', function () {
   // Disable timeouts when non-zero PAUSE_TIME is used to watch tests run.
   if (PAUSE_TIME) this.timeout(0);
@@ -45,33 +107,7 @@ suite('Menus test', function () {
 
     chai.assert.deepEqual(
       await contextMenuItems(this.browser),
-      process.platform === 'darwin'
-        ? [
-            {'text': 'Duplicate D'},
-            {'text': 'Add Comment'},
-            {'text': 'External Inputs'},
-            {'text': 'Collapse Block'},
-            {'text': 'Disable Block'},
-            {'text': 'Delete 2 Blocks Delete'},
-            {'text': 'Move Block M'},
-            {'text': 'Edit Block contents Right'},
-            {'text': 'Cut ⌘ X'},
-            {'text': 'Copy ⌘ C'},
-            {'disabled': true, 'text': 'Paste ⌘ V'},
-          ]
-        : [
-            {'text': 'Duplicate D'},
-            {'text': 'Add Comment'},
-            {'text': 'External Inputs'},
-            {'text': 'Collapse Block'},
-            {'text': 'Disable Block'},
-            {'text': 'Delete 2 Blocks Delete'},
-            {'text': 'Move Block M'},
-            {'text': 'Edit Block contents Right'},
-            {'text': 'Cut Ctrl + X'},
-            {'text': 'Copy Ctrl + C'},
-            {'disabled': true, 'text': 'Paste Ctrl + V'},
-          ],
+      blockActionsViaKeyboard,
     );
   });
 
@@ -81,29 +117,7 @@ suite('Menus test', function () {
 
     chai.assert.deepEqual(
       await contextMenuItems(this.browser),
-      process.platform === 'darwin'
-        ? [
-            {'text': 'Duplicate D'},
-            {'text': 'Add Comment'},
-            {'text': 'External Inputs'},
-            {'text': 'Collapse Block'},
-            {'text': 'Disable Block'},
-            {'text': 'Delete 2 Blocks Delete'},
-            {'text': 'Cut ⌘ X'},
-            {'text': 'Copy ⌘ C'},
-            {'disabled': true, 'text': 'Paste ⌘ V'},
-          ]
-        : [
-            {'text': 'Duplicate D'},
-            {'text': 'Add Comment'},
-            {'text': 'External Inputs'},
-            {'text': 'Collapse Block'},
-            {'text': 'Disable Block'},
-            {'text': 'Delete 2 Blocks Delete'},
-            {'text': 'Cut Ctrl + X'},
-            {'text': 'Copy Ctrl + C'},
-            {'disabled': true, 'text': 'Paste Ctrl + V'},
-          ],
+      blockActionsViaMouse,
     );
   });
 
@@ -115,27 +129,7 @@ suite('Menus test', function () {
 
     chai.assert.deepEqual(
       await contextMenuItems(this.browser),
-      process.platform === 'darwin'
-        ? [
-            {'text': 'Add Comment'},
-            {'text': 'Collapse Block'},
-            {'text': 'Disable Block'},
-            {'text': 'Help'},
-            {'text': 'Move Block M'},
-            {'disabled': true, 'text': 'Cut ⌘ X'},
-            {'text': 'Copy ⌘ C'},
-            {'disabled': true, 'text': 'Paste ⌘ V'},
-          ]
-        : [
-            {'text': 'Add Comment'},
-            {'text': 'Collapse Block'},
-            {'text': 'Disable Block'},
-            {'text': 'Help'},
-            {'text': 'Move Block M'},
-            {'disabled': true, 'text': 'Cut Ctrl + X'},
-            {'text': 'Copy Ctrl + C'},
-            {'disabled': true, 'text': 'Paste Ctrl + V'},
-          ],
+      shadowBlockActionsViaKeyboard,
     );
   });
 
@@ -148,20 +142,8 @@ suite('Menus test', function () {
     await sendKeyAndWait(this.browser, [Key.Ctrl, Key.Return]);
 
     chai.assert.deepEqual(
-      process.platform === 'darwin'
-        ? [
-            {'text': 'Help'},
-            {'disabled': true, 'text': 'Move Block M'},
-            {'disabled': true, 'text': 'Cut ⌘ X'},
-            {'text': 'Copy ⌘ C'},
-          ]
-        : [
-            {'text': 'Help'},
-            {'disabled': true, 'text': 'Move Block M'},
-            {'disabled': true, 'text': 'Cut Ctrl + X'},
-            {'text': 'Copy Ctrl + C'},
-          ],
       await contextMenuItems(this.browser),
+      toolboxBlockActionsViaKeyboard,
     );
   });
 
@@ -176,18 +158,8 @@ suite('Menus test', function () {
     await this.browser.pause(PAUSE_TIME);
 
     chai.assert.deepEqual(
-      process.platform === 'darwin'
-        ? [
-            {'text': 'Help'},
-            {'disabled': true, 'text': 'Cut ⌘ X'},
-            {'text': 'Copy ⌘ C'},
-          ]
-        : [
-            {'text': 'Help'},
-            {'disabled': true, 'text': 'Cut Ctrl + X'},
-            {'text': 'Copy Ctrl + C'},
-          ],
       await contextMenuItems(this.browser),
+      flyoutBlockActionsViaMouse,
     );
   });
 
@@ -198,28 +170,8 @@ suite('Menus test', function () {
     await sendKeyAndWait(this.browser, [Key.Ctrl, Key.Return]);
 
     chai.assert.deepEqual(
-      process.platform === 'darwin'
-        ? [
-            {'disabled': true, 'text': 'Undo'},
-            {'disabled': true, 'text': 'Redo'},
-            {'text': 'Clean up Blocks'},
-            {'text': 'Collapse Blocks'},
-            {'disabled': true, 'text': 'Expand Blocks'},
-            {'text': 'Delete 4 Blocks'},
-            {'text': 'Add Comment'},
-            {'disabled': true, 'text': 'Paste ⌘ V'},
-          ]
-        : [
-            {'disabled': true, 'text': 'Undo'},
-            {'disabled': true, 'text': 'Redo'},
-            {'text': 'Clean up Blocks'},
-            {'text': 'Collapse Blocks'},
-            {'disabled': true, 'text': 'Expand Blocks'},
-            {'text': 'Delete 4 Blocks'},
-            {'text': 'Add Comment'},
-            {'disabled': true, 'text': 'Paste Ctrl + V'},
-          ],
       await contextMenuItems(this.browser),
+      workspaceActionsViaKeyboard,
     );
   });
 

--- a/test/webdriverio/test/actions_test.ts
+++ b/test/webdriverio/test/actions_test.ts
@@ -23,6 +23,7 @@ import {
 } from './test_setup.js';
 
 const isDarwin = process.platform === 'darwin';
+
 const blockActionsViaKeyboard = [
   {'text': 'Duplicate D'},
   {'text': 'Add Comment'},
@@ -123,7 +124,8 @@ suite('Menus test', function () {
 
   test('Shadow block menu via keyboard displays expected items', async function () {
     await tabNavigateToWorkspace(this.browser);
-    await focusOnBlock(this.browser, 'draw_circle_1_color');
+    await focusOnBlock(this.browser, 'draw_circle_1');
+    await this.browser.keys(Key.ArrowRight);
     await this.browser.keys([Key.Ctrl, Key.Return]);
     await this.browser.pause(PAUSE_TIME);
 

--- a/test/webdriverio/test/actions_test.ts
+++ b/test/webdriverio/test/actions_test.ts
@@ -56,6 +56,7 @@ const shadowBlockActionsViaKeyboard = [
   {'text': 'Disable Block'},
   {'text': 'Help'},
   {'text': 'Move Block M'},
+  {'text': 'Edit Block contents Right'},
   {'disabled': true, 'text': isDarwin ? 'Cut ⌘ X' : 'Cut Ctrl + X'},
   {'text': isDarwin ? 'Copy ⌘ C' : 'Copy Ctrl + C'},
   {'disabled': true, 'text': isDarwin ? 'Paste ⌘ V' : 'Paste Ctrl + V'},
@@ -80,7 +81,7 @@ const workspaceActionsViaKeyboard = [
   {'text': 'Clean up Blocks'},
   {'text': 'Collapse Blocks'},
   {'disabled': true, 'text': 'Expand Blocks'},
-  {'text': 'Delete 4 Blocks'},
+  {'text': 'Delete 14 Blocks'},
   {'text': 'Add Comment'},
   {'disabled': true, 'text': isDarwin ? 'Paste ⌘ V' : 'Paste Ctrl + V'},
 ];
@@ -96,7 +97,7 @@ suite('Menus test', function () {
     // seconds.  Allow 30s just in case.
     this.timeout(30000);
 
-    this.browser = await testSetup(testFileLocations.BASE);
+    this.browser = await testSetup(testFileLocations.MORE_BLOCKS);
     await this.browser.pause(PAUSE_TIME);
   });
 
@@ -124,7 +125,7 @@ suite('Menus test', function () {
 
   test('Shadow block menu via keyboard displays expected items', async function () {
     await tabNavigateToWorkspace(this.browser);
-    await focusOnBlock(this.browser, 'draw_circle_1');
+    await focusOnBlock(this.browser, 'text_print_1');
     await this.browser.keys(Key.ArrowRight);
     await this.browser.keys([Key.Ctrl, Key.Return]);
     await this.browser.pause(PAUSE_TIME);

--- a/test/webdriverio/test/test_setup.ts
+++ b/test/webdriverio/test/test_setup.ts
@@ -188,7 +188,7 @@ export async function focusWorkspace(browser: WebdriverIO.Browser) {
   const workspaceElement = await browser.$(
     '#blocklyDiv > div > svg.blocklySvg > g',
   );
-  await workspaceElement.click();
+  await workspaceElement.click({x: 100});
 }
 
 /**

--- a/test/webdriverio/test/test_setup.ts
+++ b/test/webdriverio/test/test_setup.ts
@@ -153,6 +153,8 @@ export const testFileLocations = {
     new URLSearchParams({scenario: 'navigationTestBlocks'}),
   ),
   // eslint-disable-next-line @typescript-eslint/naming-convention
+  MORE_BLOCKS: createTestUrl(new URLSearchParams({scenario: 'moreBlocks'})),
+  // eslint-disable-next-line @typescript-eslint/naming-convention
   MOVE_TEST_BLOCKS: createTestUrl(
     new URLSearchParams({scenario: 'moveTestBlocks'}),
   ),

--- a/test/webdriverio/test/test_setup.ts
+++ b/test/webdriverio/test/test_setup.ts
@@ -573,7 +573,7 @@ export async function isDragging(
 }
 
 /**
- * Returns the result of the specificied action precondition.
+ * Returns the result of the specified action precondition.
  *
  * @param browser The active WebdriverIO Browser object.
  * @param action The action to check the precondition for.
@@ -709,4 +709,18 @@ export async function clickBlock(
   await browser.execute((elemId) => {
     document.getElementById(elemId)?.removeAttribute('id');
   }, findableId);
+}
+
+/**
+ * Right-clicks on a block with the provided type in the flyout.
+ *
+ * @param browser The active WebdriverIO Browser object.
+ * @param blockType The name of the type block to right click on.
+ */
+export async function rightClickOnFlyoutBlockType(
+  browser: WebdriverIO.Browser,
+  blockType: string,
+) {
+  const elem = await browser.$(`.blocklyFlyout .${blockType}`);
+  await elem.click({button: 'right'});
 }


### PR DESCRIPTION
Implements the unit tests described in https://docs.google.com/document/d/1pIIX5sKEG9f_NcWDIQJJEOMM7w7pQUf8eJoT3lrAElQ for context menu items in various situations.

The set of expected available context menu items depends on the focused object, whether it's in a flyout, and how the menu was opened. The tests are currently configured to expect the set of menu items that the currently implemented behavior produces.