### PR TITLE
fix: Fix method signature of setCurNode.

### DIFF
--- a/src/flyout_cursor.ts
+++ b/src/flyout_cursor.ts
@@ -65,7 +65,7 @@ export class FlyoutCursor extends Blockly.LineCursor {
     return newNode;
   }
 
-  override setCurNode(node: Blockly.IFocusableNode | null) {
+  override setCurNode(node: Blockly.IFocusableNode) {
     super.setCurNode(node);
 
     let bounds: Blockly.utils.Rect | undefined;


### PR DESCRIPTION
This PR fixes the build after https://github.com/google/blockly/pull/9142 was merged and prevented setting the current node to null.