### PR TITLE
fix: context menu CSS is always needed

### DIFF
--- a/test/index.html
+++ b/test/index.html
@@ -162,33 +162,17 @@
         outline: none;
       }
 
-      .blocklyRTL
-        .blocklyKeyboardNavigation
-        .blocklyMenuItemContent
-        .blocklyShortcutContainer {
+      .blocklyRTL .blocklyMenuItemContent .blocklyShortcutContainer {
         flex-direction: row-reverse;
       }
-      .blocklyKeyboardNavigation
-        .blocklyMenuItemContent
-        .blocklyShortcutContainer {
+      .blocklyMenuItemContent .blocklyShortcutContainer {
         width: 100%;
         display: flex;
         justify-content: space-between;
+        gap: 16px;
       }
-      .blocklyKeyboardNavigation
-        .blocklyMenuItemContent
-        .blocklyShortcutContainer
-        .blocklyShortcut {
+      .blocklyMenuItemContent .blocklyShortcutContainer .blocklyShortcut {
         color: #ccc;
-        margin-left: 16px;
-      }
-      .blocklyRTL
-        .blocklyKeyboardNavigation
-        .blocklyMenuItemContent
-        .blocklyShortcutContainer
-        .blocklyShortcut {
-        margin-left: 0;
-        margin-right: 16px;
       }
     </style>
   </head>


### PR DESCRIPTION
Don't condition it on `.blocklyKeyboardNavigation`.

Simplify RTL handling with CSS flexbox [gap](https://caniuse.com/flexbox-gap).

`.blocklyKeyboardNavigation` is only set when the heuristic is enabled but the shortcut text is always there when the plugin is enabled. Avoids this scenario before arrow key use (or similar):

![image](https://github.com/user-attachments/assets/bef6cddb-ac6e-4cb7-987a-f98cde102493)

CC @gonfunko 