### PR TITLE
fix: Allow some things to handle the enter key on read only workspaces

### DIFF
--- a/src/actions/action_menu.ts
+++ b/src/actions/action_menu.ts
@@ -52,7 +52,7 @@ export class ActionMenu {
         );
       },
       callback: (workspace) => {
-        switch (this.navigation.getState(workspace)) {
+        switch (this.navigation.getState()) {
           case Constants.STATE.WORKSPACE:
           case Constants.STATE.FLYOUT:
             return this.openActionMenu(workspace);

--- a/src/actions/arrow_navigation.ts
+++ b/src/actions/arrow_navigation.ts
@@ -63,7 +63,7 @@ export class ArrowNavigation {
         ? workspace.targetWorkspace?.getFlyout()
         : workspace.getFlyout();
       let isHandled = false;
-      switch (this.navigation.getState(workspace)) {
+      switch (this.navigation.getState()) {
         case Constants.STATE.WORKSPACE:
           isHandled = this.fieldShortcutHandler(workspace, shortcut);
           if (!isHandled && workspace) {
@@ -97,7 +97,7 @@ export class ArrowNavigation {
         ? workspace.targetWorkspace?.getToolbox()
         : workspace.getToolbox();
       let isHandled = false;
-      switch (this.navigation.getState(workspace)) {
+      switch (this.navigation.getState()) {
         case Constants.STATE.WORKSPACE:
           isHandled = this.fieldShortcutHandler(workspace, shortcut);
           if (!isHandled && workspace) {
@@ -161,7 +161,7 @@ export class ArrowNavigation {
         callback: (workspace, e, shortcut) => {
           keyboardNavigationController.setIsActive(true);
           let isHandled = false;
-          switch (this.navigation.getState(workspace)) {
+          switch (this.navigation.getState()) {
             case Constants.STATE.WORKSPACE:
               isHandled = this.fieldShortcutHandler(workspace, shortcut);
               if (!isHandled && workspace) {
@@ -223,7 +223,7 @@ export class ArrowNavigation {
         callback: (workspace, e, shortcut) => {
           keyboardNavigationController.setIsActive(true);
           let isHandled = false;
-          switch (this.navigation.getState(workspace)) {
+          switch (this.navigation.getState()) {
             case Constants.STATE.WORKSPACE:
               isHandled = this.fieldShortcutHandler(workspace, shortcut);
               if (!isHandled) {

--- a/src/actions/clipboard.ts
+++ b/src/actions/clipboard.ts
@@ -207,7 +207,9 @@ export class Clipboard {
       !!this.oldCutShortcut?.callback &&
       this.oldCutShortcut.callback(workspace, e, shortcut, scope);
     if (didCut) {
-      this.copyWorkspace = workspace;
+      this.copyWorkspace = workspace.isFlyout
+        ? workspace.targetWorkspace
+        : workspace;
       showCutHint(workspace);
     }
     return didCut;
@@ -285,7 +287,9 @@ export class Clipboard {
       !!this.oldCopyShortcut?.callback &&
       this.oldCopyShortcut.callback(workspace, e, shortcut, scope);
     if (didCopy) {
-      this.copyWorkspace = workspace;
+      this.copyWorkspace = workspace.isFlyout
+        ? workspace.targetWorkspace
+        : workspace;
       showCopiedHint(workspace);
     }
     return didCopy;

--- a/src/actions/clipboard.ts
+++ b/src/actions/clipboard.ts
@@ -207,9 +207,7 @@ export class Clipboard {
       !!this.oldCutShortcut?.callback &&
       this.oldCutShortcut.callback(workspace, e, shortcut, scope);
     if (didCut) {
-      this.copyWorkspace = workspace.isFlyout
-        ? workspace.targetWorkspace
-        : workspace;
+      this.copyWorkspace = workspace;
       showCutHint(workspace);
     }
     return didCut;

--- a/src/actions/disconnect.ts
+++ b/src/actions/disconnect.ts
@@ -58,7 +58,7 @@ export class DisconnectAction {
         this.navigation.canCurrentlyEdit(workspace),
       callback: (workspace) => {
         keyboardNavigationController.setIsActive(true);
-        switch (this.navigation.getState(workspace)) {
+        switch (this.navigation.getState()) {
           case Constants.STATE.WORKSPACE:
             this.disconnectBlocks(workspace);
             return true;

--- a/src/actions/enter.ts
+++ b/src/actions/enter.ts
@@ -115,6 +115,12 @@ export class EnterAction {
     const curNode = cursor?.getCurNode();
     if (!curNode) return false;
     if (curNode instanceof Field && !curNode.isClickable()) return false;
+    if (
+      curNode instanceof RenderedConnection ||
+      curNode instanceof WorkspaceSvg
+    ) {
+      return !workspace.isReadOnly();
+    }
     // Returning true is sometimes incorrect for icons, but there's no API to check.
     return true;
   }
@@ -131,19 +137,23 @@ export class EnterAction {
     if (!curNode) return false;
     if (curNode instanceof Field) {
       curNode.showEditor();
+      return true;
     } else if (curNode instanceof BlockSvg) {
       if (!this.tryShowFullBlockFieldEditor(curNode)) {
         showHelpHint(workspace);
       }
+      return true;
     } else if (
       curNode instanceof RenderedConnection ||
       curNode instanceof WorkspaceSvg
     ) {
       this.navigation.openToolboxOrFlyout(workspace);
+      return true;
     } else if (curNode instanceof icons.Icon) {
       curNode.onClick();
+      return true;
     }
-    return true;
+    return false;
   }
 
   /**

--- a/src/actions/enter.ts
+++ b/src/actions/enter.ts
@@ -114,7 +114,7 @@ export class EnterAction {
     const cursor = workspace.getCursor();
     const curNode = cursor?.getCurNode();
     if (!curNode) return false;
-    if (curNode instanceof Field && !curNode.isClickable()) return false;
+    if (curNode instanceof Field) return curNode.isClickable();
     if (
       curNode instanceof RenderedConnection ||
       curNode instanceof WorkspaceSvg
@@ -122,7 +122,8 @@ export class EnterAction {
       return !workspace.isReadOnly();
     }
     // Returning true is sometimes incorrect for icons, but there's no API to check.
-    return true;
+    if (curNode instanceof icons.Icon) return true;
+    return false;
   }
 
   /**

--- a/src/actions/enter.ts
+++ b/src/actions/enter.ts
@@ -88,9 +88,7 @@ export class EnterAction {
             return this.handleEnterForWS(workspace);
           case Constants.STATE.FLYOUT:
             if (targetWorkspace.isReadOnly()) return false;
-            flyoutCursor = this.navigation.getFlyoutCursor(
-              targetWorkspace,
-            );
+            flyoutCursor = this.navigation.getFlyoutCursor(targetWorkspace);
             if (!flyoutCursor) {
               return false;
             }

--- a/src/actions/exit.ts
+++ b/src/actions/exit.ts
@@ -31,7 +31,7 @@ export class ExitAction {
       preconditionFn: (workspace) =>
         this.navigation.canCurrentlyNavigate(workspace),
       callback: (workspace) => {
-        switch (this.navigation.getState(workspace)) {
+        switch (this.navigation.getState()) {
           case Constants.STATE.FLYOUT:
           case Constants.STATE.TOOLBOX:
             getFocusManager().focusTree(workspace.targetWorkspace ?? workspace);

--- a/src/actions/mover.ts
+++ b/src/actions/mover.ts
@@ -85,7 +85,7 @@ export class Mover {
    */
   canMove(workspace: WorkspaceSvg, block: BlockSvg) {
     return !!(
-      this.navigation.getState(workspace) === Constants.STATE.WORKSPACE &&
+      this.navigation.getState() === Constants.STATE.WORKSPACE &&
       this.navigation.canCurrentlyEdit(workspace) &&
       !this.moves.has(workspace) && // No move in progress.
       block?.isMovable()

--- a/src/actions/ws_movement.ts
+++ b/src/actions/ws_movement.ts
@@ -68,11 +68,16 @@ export class WorkspaceMovement {
     /** Move the cursor to the workspace. */
     {
       name: Constants.SHORTCUT_NAMES.CREATE_WS_CURSOR,
-      preconditionFn: (workspace) =>
-        this.navigation.canCurrentlyEdit(workspace),
+      preconditionFn: (workspace) => {
+        return true;
+      },
       callback: (workspace) => {
+        const targetWorkspace = workspace.isFlyout
+          ? workspace.targetWorkspace
+          : workspace;
+        if (!targetWorkspace) return false;
         keyboardNavigationController.setIsActive(true);
-        return this.createWSCursor(workspace);
+        return this.createWSCursor(targetWorkspace);
       },
       keyCodes: [KeyCodes.W],
     },

--- a/src/navigation.ts
+++ b/src/navigation.ts
@@ -93,10 +93,9 @@ export class Navigation {
    * Note that this assumes a workspace with passive focus (including for its
    * toolbox or flyout) has a state of NOWHERE.
    *
-   * @param workspace The workspace to get the state of.
    * @returns The state of the given workspace.
    */
-  getState(workspace: Blockly.WorkspaceSvg): Constants.STATE {
+  getState(): Constants.STATE {
     const focusedTree = Blockly.getFocusManager().getFocusedTree();
     if (focusedTree instanceof Blockly.WorkspaceSvg) {
       if (focusedTree.isFlyout) {
@@ -105,9 +104,7 @@ export class Navigation {
         return Constants.STATE.WORKSPACE;
       }
     } else if (focusedTree instanceof Blockly.Toolbox) {
-      if (workspace === focusedTree.getWorkspace()) {
-        return Constants.STATE.TOOLBOX;
-      }
+      return Constants.STATE.TOOLBOX;
     } else if (focusedTree instanceof Blockly.Flyout) {
       return Constants.STATE.FLYOUT;
     }
@@ -222,7 +219,7 @@ export class Navigation {
       }
     } else if (
       e.type === Blockly.Events.BLOCK_CREATE &&
-      this.getState(mainWorkspace) === Constants.STATE.FLYOUT
+      this.getState() === Constants.STATE.FLYOUT
     ) {
       // When variables are created, that recreates the flyout contents, leaving the
       // cursor in an invalid state.
@@ -825,7 +822,7 @@ export class Navigation {
       : workspace.keyboardAccessibilityMode;
     return (
       !!accessibilityMode &&
-      this.getState(workspace) !== Constants.STATE.NOWHERE &&
+      this.getState() !== Constants.STATE.NOWHERE &&
       !Blockly.getFocusManager().ephemeralFocusTaken()
     );
   }

--- a/src/navigation_controller.ts
+++ b/src/navigation_controller.ts
@@ -200,7 +200,7 @@ export class NavigationController {
         !workspace.isDragging() && this.navigation.canCurrentlyEdit(workspace),
       callback: (workspace) => {
         keyboardNavigationController.setIsActive(true);
-        switch (this.navigation.getState(workspace)) {
+        switch (this.navigation.getState()) {
           case Constants.STATE.WORKSPACE:
             Blockly.getFocusManager().focusTree(
               workspace.getToolbox() ??

--- a/src/navigation_controller.ts
+++ b/src/navigation_controller.ts
@@ -197,7 +197,7 @@ export class NavigationController {
     focusToolbox: {
       name: Constants.SHORTCUT_NAMES.TOOLBOX,
       preconditionFn: (workspace) =>
-        !workspace.isDragging() && this.navigation.canCurrentlyEdit(workspace),
+        !workspace.isDragging(),
       callback: (workspace) => {
         keyboardNavigationController.setIsActive(true);
         switch (this.navigation.getState()) {

--- a/src/navigation_controller.ts
+++ b/src/navigation_controller.ts
@@ -196,8 +196,7 @@ export class NavigationController {
     /** Move focus to or from the toolbox. */
     focusToolbox: {
       name: Constants.SHORTCUT_NAMES.TOOLBOX,
-      preconditionFn: (workspace) =>
-        !workspace.isDragging(),
+      preconditionFn: (workspace) => !workspace.isDragging(),
       callback: (workspace) => {
         keyboardNavigationController.setIsActive(true);
         switch (this.navigation.getState()) {

--- a/test/webdriverio/test/keyboard_mode_test.ts
+++ b/test/webdriverio/test/keyboard_mode_test.ts
@@ -13,6 +13,7 @@ import {
   PAUSE_TIME,
   getBlockElementById,
   tabNavigateToWorkspace,
+  clickBlock,
 } from './test_setup.js';
 import {Key} from 'webdriverio';
 
@@ -125,8 +126,7 @@ suite(
 
       await this.browser.pause(PAUSE_TIME);
       // Right click a block
-      const element = await getBlockElementById(this.browser, 'controls_if_1');
-      await element.click({button: 'right'});
+      clickBlock(this.browser, 'controls_if_1', {button: 'right'});
       await this.browser.pause(PAUSE_TIME);
 
       chai.assert.isFalse(await isKeyboardNavigating(this.browser));
@@ -140,6 +140,15 @@ suite(
       await this.browser.pause(PAUSE_TIME);
       // Drag a block
       const element = await getBlockElementById(this.browser, 'controls_if_1');
+
+      await this.browser.execute(() => {
+        const ws = Blockly.getMainWorkspace() as Blockly.WorkspaceSvg;
+        const block = ws.getBlockById('controls_if_1') as Blockly.BlockSvg;
+        ws.scrollBoundsIntoView(
+          block.getBoundingRectangleWithoutChildren(),
+          10,
+        );
+      });
       await element.dragAndDrop({x: 10, y: 10});
       await this.browser.pause(PAUSE_TIME);
 


### PR DESCRIPTION
Fixes #585 

This updates the enter handler to do more selective checks when deciding whether or not to handle an enter key. Also simplifies getState() slightly to remove an unnecessary parameter.

In general, this is aiming to reach parity between mouse and keyboard behavior when on a read-only workspace. Specific changes to behavior:

- Enables creating a workspace cursor ('w' key) while in read-only mode.
- Enables enter key to "click" on icons while in read-only mode.
- Enabled navigating to the toolbox while in read-only mode.
- Factors out most of the checks for whether or not an enter will be handled to the precondition.
- Returns false from the precondition and callback more often when the shortcut isn't actually handled.

TODO for https://github.com/google/blockly/issues/8915 
Add additional tests for enter and click with a read-only workspace and ensure both modalities are consistent.