### PR TITLE
feat: Add support for navigating in mutator workspaces.

### DIFF
--- a/src/actions/enter.ts
+++ b/src/actions/enter.ts
@@ -154,7 +154,7 @@ export class EnterAction {
     } else if (curNode instanceof icons.Icon) {
       curNode.onClick();
       renderManagement.finishQueuedRenders().then(() => {
-        cursor.in();
+        cursor?.in();
       });
       return true;
     }

--- a/src/actions/enter.ts
+++ b/src/actions/enter.ts
@@ -152,6 +152,9 @@ export class EnterAction {
       this.navigation.openToolboxOrFlyout(workspace);
       return true;
     } else if (curNode instanceof icons.Icon) {
+      // Calling the icon's click handler will trigger its action, generally
+      // opening a bubble of some sort. We then need to wait for the bubble to
+      // appear before attempting to navigate into it.
       curNode.onClick();
       renderManagement.finishQueuedRenders().then(() => {
         cursor?.in();

--- a/src/actions/enter.ts
+++ b/src/actions/enter.ts
@@ -17,6 +17,7 @@ import {
   Field,
   icons,
   FocusableTreeTraverser,
+  renderManagement,
 } from 'blockly/core';
 
 import type {Block} from 'blockly/core';
@@ -113,6 +114,9 @@ export class EnterAction {
       this.navigation.openToolboxOrFlyout(workspace);
     } else if (curNode instanceof icons.Icon) {
       curNode.onClick();
+      renderManagement.finishQueuedRenders().then(() => {
+        cursor.in();
+      });
     }
   }
 

--- a/src/actions/exit.ts
+++ b/src/actions/exit.ts
@@ -58,6 +58,7 @@ export class ExitAction {
                 return true;
               }
             }
+            return false;
           }
           default:
             return false;

--- a/src/actions/exit.ts
+++ b/src/actions/exit.ts
@@ -9,6 +9,7 @@ import {
   utils as BlocklyUtils,
   getFocusManager,
   Gesture,
+  icons,
 } from 'blockly/core';
 
 import * as Constants from '../constants';
@@ -39,6 +40,25 @@ export class ExitAction {
               workspace.hideChaff();
             }
             return true;
+          case Constants.STATE.WORKSPACE: {
+            if (workspace.isMutator) {
+              const parent = workspace.options.parentWorkspace
+                ?.getAllBlocks()
+                .map((block) => block.getIcons())
+                .flat()
+                .find(
+                  (icon): icon is icons.MutatorIcon =>
+                    icon instanceof icons.MutatorIcon &&
+                    icon.bubbleIsVisible() &&
+                    icon.getBubble()?.getWorkspace() === workspace,
+                );
+              if (parent) {
+                parent.setBubbleVisible(false);
+                getFocusManager().focusNode(parent);
+                return true;
+              }
+            }
+          }
           default:
             return false;
         }

--- a/src/navigation.ts
+++ b/src/navigation.ts
@@ -824,6 +824,13 @@ export class Navigation {
    * @returns whether keyboard navigation is currently allowed.
    */
   canCurrentlyNavigate(workspace: Blockly.WorkspaceSvg) {
+    // Only the main/root workspace has the accessibility mode bit set; for
+    // nested workspaces (mutators or flyouts) we need to walk up the tree.
+    // Default to the root workspace if present. Flyouts don't consider
+    // their workspaces to have a root workspace/be a nested child, so fall
+    // back to checking the target workspace's root (`.targetWorkspace` only
+    // exists on flyout workspaces) and then fall back to the target/main
+    // workspace itself.
     const accessibilityMode = (
       workspace.getRootWorkspace() ??
       workspace.targetWorkspace?.getRootWorkspace() ??

--- a/src/navigation.ts
+++ b/src/navigation.ts
@@ -820,9 +820,12 @@ export class Navigation {
    * @returns whether keyboard navigation is currently allowed.
    */
   canCurrentlyNavigate(workspace: Blockly.WorkspaceSvg) {
-    const accessibilityMode = workspace.isFlyout
-      ? workspace.targetWorkspace?.keyboardAccessibilityMode
-      : workspace.keyboardAccessibilityMode;
+    const accessibilityMode = (
+      workspace.getRootWorkspace() ??
+      workspace.targetWorkspace?.getRootWorkspace() ??
+      workspace.targetWorkspace ??
+      workspace
+    ).keyboardAccessibilityMode;
     return (
       !!accessibilityMode &&
       this.getState(workspace) !== Constants.STATE.NOWHERE &&

--- a/test/webdriverio/test/mutator_test.ts
+++ b/test/webdriverio/test/mutator_test.ts
@@ -72,6 +72,19 @@ suite('Mutator navigation', function () {
     chai.assert.equal(mutatorIconId, focusedNodeId);
   });
 
+  test('Escape in the mutator flyout focuses the mutator workspace', async function () {
+    await this.openMutator();
+    // Focus the flyout
+    await this.browser.keys('t');
+    await this.browser.pause(PAUSE_TIME);
+    // Hit escape to return focus to the mutator workspace
+    await this.browser.keys(Key.Escape);
+    await this.browser.pause(PAUSE_TIME);
+    // The "if" placeholder block in the mutator should be focused
+    const focusedBlockType = await getFocusedBlockType(this.browser);
+    chai.assert.equal(focusedBlockType, 'controls_if_if');
+  });
+
   test('T focuses the mutator flyout', async function () {
     await this.openMutator();
     await this.browser.keys('t');
@@ -97,7 +110,9 @@ suite('Mutator navigation', function () {
 
     const topBlocks = await this.browser.execute(() => {
       const focusedTree = Blockly.getFocusManager().getFocusedTree();
-      if (!(focusedTree instanceof Blockly.WorkspaceSvg)) return [];
+      if (!(focusedTree instanceof Blockly.WorkspaceSvg)) {
+        throw new Error('Focused tree is not a workspace.');
+      }
 
       return focusedTree.getAllBlocks(true).map((block) => block.type);
     });

--- a/test/webdriverio/test/mutator_test.ts
+++ b/test/webdriverio/test/mutator_test.ts
@@ -1,0 +1,113 @@
+/**
+ * @license
+ * Copyright 2025 Google LLC
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import * as chai from 'chai';
+import * as Blockly from 'blockly';
+import {
+  focusedTreeIsMainWorkspace,
+  isDragging,
+  focusOnBlock,
+  focusOnBlockField,
+  getCurrentFocusNodeId,
+  getCurrentFocusedBlockId,
+  getFocusedBlockType,
+  getFocusedFieldName,
+  testSetup,
+  testFileLocations,
+  PAUSE_TIME,
+  tabNavigateToWorkspace,
+  keyLeft,
+  keyRight,
+  keyUp,
+  keyDown,
+} from './test_setup.js';
+import {Key} from 'webdriverio';
+
+suite.only('Mutator navigation', function () {
+  // Setting timeout to unlimited as these tests take a longer time to run than most mocha test
+  this.timeout(0);
+
+  // Setup Selenium for all of the tests
+  setup(async function () {
+    this.browser = await testSetup(testFileLocations.NAVIGATION_TEST_BLOCKS);
+    this.openMutator = async () => {
+      await tabNavigateToWorkspace(this.browser);
+      await this.browser.pause(PAUSE_TIME);
+      await focusOnBlock(this.browser, 'controls_if_1');
+      await this.browser.pause(PAUSE_TIME);
+      // Navigate to the mutator icon
+      await keyRight(this.browser);
+      // Activate the icon
+      await this.browser.keys(Key.Enter);
+      await this.browser.pause(PAUSE_TIME);
+    };
+  });
+
+  test('Enter opens mutator', async function () {
+    await this.openMutator();
+
+    // Main workspace should not be focused (because mutator workspace is)
+    const mainWorkspaceFocused = await focusedTreeIsMainWorkspace(this.browser);
+    chai.assert.isFalse(mainWorkspaceFocused);
+
+    // The "if" placeholder block in the mutator should be focused
+    const focusedBlockType = await getFocusedBlockType(this.browser);
+    chai.assert.equal(focusedBlockType, 'controls_if_if');
+  });
+
+  test('Escape dismisses mutator', async function () {
+    await this.openMutator();
+    await this.browser.keys(Key.Escape);
+    await this.browser.pause(PAUSE_TIME);
+
+    // Main workspace should be the focused tree (since mutator workspace is gone)
+    const mainWorkspaceFocused = await focusedTreeIsMainWorkspace(this.browser);
+    chai.assert.isTrue(mainWorkspaceFocused);
+
+    const mutatorIconId = await this.browser.execute(() => {
+      const block = Blockly.getMainWorkspace().getBlockById('controls_if_1');
+      const icon = block?.getIcon(Blockly.icons.IconType.MUTATOR);
+      return icon?.getFocusableElement().id;
+    });
+
+    // Mutator icon should now be focused
+    const focusedNodeId = await getCurrentFocusNodeId(this.browser);
+    chai.assert.equal(mutatorIconId, focusedNodeId);
+  });
+
+  test('T focuses the mutator flyout', async function () {
+    await this.openMutator();
+    await this.browser.keys('t');
+    await this.browser.pause(PAUSE_TIME);
+
+    // The "else if" block in the mutator flyout should be focused
+    const focusedBlockType = await getFocusedBlockType(this.browser);
+    chai.assert.equal(focusedBlockType, 'controls_if_elseif');
+  });
+
+  test('Blocks can be inserted from the mutator flyout', async function () {
+    await this.openMutator();
+    await this.browser.keys('t');
+    await this.browser.pause(PAUSE_TIME);
+    // Navigate down to the second block in the flyout
+    await keyDown(this.browser);
+    await this.browser.pause(PAUSE_TIME);
+    // Hit enter to enter insert mode
+    await this.browser.keys(Key.Enter);
+    await this.browser.pause(PAUSE_TIME);
+    // Hit enter again to lock it into place on the connection
+    await this.browser.keys(Key.Enter);
+
+    const topBlocks = await this.browser.execute(() => {
+      const focusedTree = Blockly.getFocusManager().getFocusedTree();
+      if (!(focusedTree instanceof Blockly.WorkspaceSvg)) return [];
+
+      return focusedTree.getAllBlocks(true).map((block) => block.type);
+    });
+
+    chai.assert.deepEqual(topBlocks, ['controls_if_if', 'controls_if_else']);
+  });
+});

--- a/test/webdriverio/test/mutator_test.ts
+++ b/test/webdriverio/test/mutator_test.ts
@@ -20,7 +20,7 @@ import {
 } from './test_setup.js';
 import {Key} from 'webdriverio';
 
-suite.only('Mutator navigation', function () {
+suite('Mutator navigation', function () {
   // Setting timeout to unlimited as these tests take a longer time to run than most mocha test
   this.timeout(0);
 

--- a/test/webdriverio/test/mutator_test.ts
+++ b/test/webdriverio/test/mutator_test.ts
@@ -8,20 +8,14 @@ import * as chai from 'chai';
 import * as Blockly from 'blockly';
 import {
   focusedTreeIsMainWorkspace,
-  isDragging,
   focusOnBlock,
-  focusOnBlockField,
   getCurrentFocusNodeId,
-  getCurrentFocusedBlockId,
   getFocusedBlockType,
-  getFocusedFieldName,
   testSetup,
   testFileLocations,
   PAUSE_TIME,
   tabNavigateToWorkspace,
-  keyLeft,
   keyRight,
-  keyUp,
   keyDown,
 } from './test_setup.js';
 import {Key} from 'webdriverio';

--- a/test/webdriverio/test/test_setup.ts
+++ b/test/webdriverio/test/test_setup.ts
@@ -230,6 +230,20 @@ export async function currentFocusIsMainWorkspace(
 }
 
 /**
+ * Returns whether the currently focused tree is the main workspace.
+ *
+ * @param browser The active WebdriverIO Browser object.
+ */
+export async function focusedTreeIsMainWorkspace(
+  browser: WebdriverIO.Browser,
+): Promise<boolean> {
+  return await browser.execute(() => {
+    const workspaceSvg = Blockly.getMainWorkspace() as Blockly.WorkspaceSvg;
+    return Blockly.getFocusManager().getFocusedTree() === workspaceSvg;
+  });
+}
+
+/**
  * Focuses and selects a block with the provided ID.
  *
  * This throws an error if no block exists for the specified ID.


### PR DESCRIPTION
In conjunction with https://github.com/google/blockly/pull/9151, this PR fixes https://github.com/google/blockly/issues/9002 by adding support for navigating into and manipulating blocks within mutator workspaces using keyboard navigation.