### PR TITLE
chore: Clean up unused fields in mover.ts.

### DIFF
--- a/src/actions/mover.ts
+++ b/src/actions/mover.ts
@@ -56,18 +56,6 @@ export class Mover {
   protected moves: Map<WorkspaceSvg, MoveInfo> = new Map();
 
   /**
-   * The stashed isDragging function, which is replaced at the beginning
-   * of a keyboard drag and reset at the end of a keyboard drag.
-   */
-  oldIsDragging: (() => boolean) | null = null;
-
-  /**
-   * The stashed getGesture function, which is replaced at the beginning
-   * of a keyboard drag and reset at the end of a keyboard drag.
-   */
-  oldGetGesture: ((e: PointerEvent) => Gesture | null) | null = null;
-
-  /**
    * The block's base drag strategy, which will be overridden during
    * keyboard drags and reset at the end of the drag.
    */

--- a/src/actions/mover.ts
+++ b/src/actions/mover.ts
@@ -8,7 +8,6 @@ import type {
   BlockSvg,
   IDragger,
   IDragStrategy,
-  Gesture,
   RenderedConnection,
 } from 'blockly';
 import {


### PR DESCRIPTION
This PR fixes #489 by removing two unused fields from mover.ts.