### PR TITLE
Ensure black on white for move indicator.

### DIFF
--- a/src/move_indicator.ts
+++ b/src/move_indicator.ts
@@ -53,7 +53,7 @@ export class MoveIndicatorBubble
       Blockly.utils.Svg.PATH,
       {
         'fill': 'none',
-        'stroke': 'currentColor',
+        'stroke': 'black',
         'stroke-linecap': 'round',
         'stroke-linejoin': 'round',
         'stroke-width': '2',


### PR DESCRIPTION
This fixes the icon in MakeCode's nascent dark theme, which sets color to white at a high level in the DOM which is then used on semi-transparent white here via currentColor. Seems reasonable to hardcode the foreground if we do so for the white background.

Example of broken state in MakeCode:

<img width="314" alt="image" src="https://github.com/user-attachments/assets/4c65a372-297c-4322-b5d7-113681271d6e" />

If there are further styling demands here then a CSS class on the group might be helpful. Having said that, I think this icon looks OK in dark and light modes as-is.