### PR TITLE
test: allow testing of workspace comments

### DIFF
--- a/test/index.html
+++ b/test/index.html
@@ -99,6 +99,10 @@
         box-sizing: border-box;
       }
 
+      .blocklyDeleteIcon {
+        display: block;
+      }
+
       /* Blocks, connections and fields. */
       .blocklyKeyboardNavigation
         .blocklyActiveFocus:is(.blocklyPath, .blocklyHighlightedConnectionPath),

--- a/test/index.ts
+++ b/test/index.ts
@@ -92,6 +92,7 @@ function createWorkspace(): Blockly.WorkspaceSvg {
   const workspace = Blockly.inject(blocklyDiv, injectOptions);
 
   new KeyboardNavigation(workspace);
+  Blockly.ContextMenuItems.registerCommentOptions();
   registerRunCodeShortcut();
 
   // Disable blocks that aren't inside the setup or draw loops.


### PR DESCRIPTION
Call `registerCommentOptions` so we can add workspace comments which are worth testing with keyboard navigation.
Add the delete icon as that's a factor in navigation too.