### PR TITLE
fix: account for ephemeral focus in enter precondition 

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -10,7 +10,7 @@
       "license": "Apache-2.0",
       "devDependencies": {
         "@blockly/dev-scripts": "^4.0.8",
-        "@blockly/field-colour": "^6.0.0",
+        "@blockly/field-colour": "^6.0.2",
         "@eslint/eslintrc": "^2.1.2",
         "@eslint/js": "^8.49.0",
         "@types/chai": "^5.2.1",
@@ -977,12 +977,27 @@
       }
     },
     "node_modules/@blockly/field-colour": {
-      "version": "6.0.0",
-      "resolved": "https://registry.npmjs.org/@blockly/field-colour/-/field-colour-6.0.0.tgz",
-      "integrity": "sha512-cKmXb4YMpr29a5a34bMOh5gpVv3Fh19tpEeSAy6V+LhOpEx3DQ57Ch8wEcC8K37fvCUp9tMtzcL2OXBT5LtdNA==",
+      "version": "6.0.2",
+      "resolved": "https://registry.npmjs.org/@blockly/field-colour/-/field-colour-6.0.2.tgz",
+      "integrity": "sha512-IJMGKei53+n9Ld5kFxpMptq6KxeJ8sbrWF+YWqH5f4nMojiOhvGK8dkuM0s69OiiHByPr5YBIr1+aZQReKnN3Q==",
       "dev": true,
+      "dependencies": {
+        "@blockly/field-grid-dropdown": "^6.0.1"
+      },
       "engines": {
         "node": ">=8.0.0"
+      },
+      "peerDependencies": {
+        "blockly": "^12.0.0"
+      }
+    },
+    "node_modules/@blockly/field-grid-dropdown": {
+      "version": "6.0.1",
+      "resolved": "https://registry.npmjs.org/@blockly/field-grid-dropdown/-/field-grid-dropdown-6.0.1.tgz",
+      "integrity": "sha512-Y3H5Z4A4cwhbIqP2pWJNTIGoCiKtYUdveZk8U83wGk9goQL2cUgQ4jfpEaxjfZVG+VG4mBwVV4nZHFDc6cJJJQ==",
+      "dev": true,
+      "engines": {
+        "node": ">=8.17.0"
       },
       "peerDependencies": {
         "blockly": "^12.0.0"

--- a/package.json
+++ b/package.json
@@ -49,7 +49,7 @@
   ],
   "devDependencies": {
     "@blockly/dev-scripts": "^4.0.8",
-    "@blockly/field-colour": "^6.0.0",
+    "@blockly/field-colour": "^6.0.2",
     "@eslint/eslintrc": "^2.1.2",
     "@eslint/js": "^8.49.0",
     "@types/chai": "^5.2.1",

--- a/src/actions/enter.ts
+++ b/src/actions/enter.ts
@@ -64,7 +64,8 @@ export class EnterAction {
             const targetWorkspace = workspace.isFlyout
               ? workspace.targetWorkspace
               : workspace;
-            return !!targetWorkspace && !targetWorkspace.isReadOnly();
+            if (!targetWorkspace) return false;
+            return this.navigation.canCurrentlyEdit(targetWorkspace);
           }
           default:
             return false;
@@ -111,6 +112,8 @@ export class EnterAction {
    * @returns True if the enter action should be handled.
    */
   private shouldHandleEnterForWS(workspace: WorkspaceSvg): boolean {
+    if (!this.navigation.canCurrentlyNavigate(workspace)) return false;
+
     const cursor = workspace.getCursor();
     const curNode = cursor?.getCurNode();
     if (!curNode) return false;

--- a/src/navigation.ts
+++ b/src/navigation.ts
@@ -96,7 +96,12 @@ export class Navigation {
    * @returns The state of the given workspace.
    */
   getState(): Constants.STATE {
-    const focusedTree = Blockly.getFocusManager().getFocusedTree();
+    const focusManager = Blockly.getFocusManager();
+    if (focusManager.ephemeralFocusTaken()) {
+      return Constants.STATE.NOWHERE;
+    }
+
+    const focusedTree = focusManager.getFocusedTree();
     if (focusedTree instanceof Blockly.WorkspaceSvg) {
       if (focusedTree.isFlyout) {
         return Constants.STATE.FLYOUT;
@@ -837,11 +842,7 @@ export class Navigation {
       workspace.targetWorkspace ??
       workspace
     ).keyboardAccessibilityMode;
-    return (
-      !!accessibilityMode &&
-      this.getState() !== Constants.STATE.NOWHERE &&
-      !Blockly.getFocusManager().ephemeralFocusTaken()
-    );
+    return !!accessibilityMode && this.getState() !== Constants.STATE.NOWHERE;
   }
 
   /**
@@ -854,7 +855,7 @@ export class Navigation {
    * @returns whether keyboard navigation and editing is currently allowed.
    */
   canCurrentlyEdit(workspace: Blockly.WorkspaceSvg) {
-    return this.canCurrentlyNavigate(workspace) && !workspace.options.readOnly;
+    return this.canCurrentlyNavigate(workspace) && !workspace.isReadOnly();
   }
 
   /**

--- a/test/webdriverio/test/basic_test.ts
+++ b/test/webdriverio/test/basic_test.ts
@@ -375,15 +375,14 @@ suite('Keyboard navigation on Fields', function () {
     await keyRight(this.browser);
     // Enter to choose.
     await this.browser.keys(Key.Enter);
-    await this.browser.pause(1000);
 
-    // Check that browser focus is back on the colour block, not e.g. a widget
-    // or dropdown div. Not sufficient to check with the focus manager.
-    // TODO: fix and flip.
-    chai.assert.isFalse(
-      await this.browser.execute(() =>
-        document.activeElement?.classList.contains('blocklyActiveFocus'),
-      ),
+    // Focus seems to take longer than a single pause to settle.
+    await this.browser.waitUntil(
+      () =>
+        this.browser.execute(() =>
+          document.activeElement?.classList.contains('blocklyActiveFocus'),
+        ),
+      {timeout: 1000},
     );
   });
 });

--- a/test/webdriverio/test/basic_test.ts
+++ b/test/webdriverio/test/basic_test.ts
@@ -363,4 +363,27 @@ suite('Keyboard navigation on Fields', function () {
     // The same field should still be focused
     chai.assert.equal(await getFocusedFieldName(this.browser), 'BOOL');
   });
+
+  test('Do not reopen field editor when handling enter to make a choice inside the editor', async function () {
+    // Open colour picker
+    await focusOnBlockField(this.browser, 'colour_picker_1', 'COLOUR');
+    await this.browser.pause(PAUSE_TIME);
+    await this.browser.keys(Key.Enter);
+    await this.browser.pause(PAUSE_TIME);
+
+    // Move right to pick a new colour.
+    await keyRight(this.browser);
+    // Enter to choose.
+    await this.browser.keys(Key.Enter);
+    await this.browser.pause(1000);
+
+    // Check that browser focus is back on the colour block, not e.g. a widget
+    // or dropdown div. Not sufficient to check with the focus manager.
+    // TODO: fix and flip.
+    chai.assert.isFalse(
+      await this.browser.execute(() =>
+        document.activeElement?.classList.contains('blocklyActiveFocus'),
+      ),
+    );
+  });
 });


### PR DESCRIPTION
Previously bugs could occur if the field editor contained e.g. a button but did not prevent keydown events propagating.

This is true of field-colour from 6.0.2 so this PR upgrades to demonstrate that.

I've tried to make the enter action's preconditions more similar to the others, using canCurrentlyNavigate/canCurrentlyEdit.

I've also changed where we account for ephemeral focus so that the Constants.STATE value is NOWHERE when ephemeral focus is in progress. I don't think anything good can come of the state value representing somewhere that doesn't have focus.

Demos:
- [First commit that just upgrades field colour to demo the bug](https://upgrade-field-colour.blockly-keyboard-experimentation.pages.dev/)
- [This branch with fix](https://ephemeral-enter.blockly-keyboard-experimentation.pages.dev/)

Closes https://github.com/google/blockly-keyboard-experimentation/issues/618