### PR TITLE
test: add scenario with workspace and block comments

### DIFF
--- a/test/index.html
+++ b/test/index.html
@@ -205,6 +205,7 @@
                   navigation test blocks
                 </option>
                 <option value="moveTestBlocks">move test blocks</option>
+                <option value="comments">comments</option>
               </select>
             </div>
             <div>

--- a/test/loadTestBlocks.js
+++ b/test/loadTestBlocks.js
@@ -862,6 +862,121 @@ const moveTestBlocks = {
   },
 };
 
+const comments = {
+  'workspaceComments': [
+    {
+      'height': 100,
+      'width': 146.63990783691406,
+      'id': 'workspace_comment_1',
+      'x': 96.5390625,
+      'y': 531.42578125,
+      'text': 'Workspace comment',
+    },
+  ],
+  'blocks': {
+    'languageVersion': 0,
+    'blocks': [
+      {
+        'type': 'p5_setup',
+        'id': 'p5_setup_1',
+        'x': 0,
+        'y': 75,
+        'deletable': false,
+        'inputs': {
+          'STATEMENTS': {
+            'block': {
+              'type': 'p5_canvas',
+              'id': 'create_canvas_1',
+              'deletable': false,
+              'movable': false,
+              'fields': {
+                'WIDTH': 400,
+                'HEIGHT': 400,
+              },
+              'next': {
+                'block': {
+                  'type': 'p5_background_color',
+                  'id': 'set_background_color_1',
+                  'inputs': {
+                    'COLOR': {
+                      'shadow': {
+                        'type': 'colour_picker',
+                        'id': 'set_background_color_1_color',
+                        'fields': {
+                          'COLOUR': '#9999ff',
+                        },
+                      },
+                    },
+                  },
+                },
+              },
+            },
+          },
+        },
+      },
+      {
+        'type': 'p5_draw',
+        'id': 'p5_draw_1',
+        'x': 0,
+        'y': 332,
+        'deletable': false,
+        'inputs': {
+          'STATEMENTS': {
+            'block': {
+              'type': 'simple_circle',
+              'id': 'draw_circle_1',
+              'icons': {
+                'comment': {
+                  'text': 'Pinned block comment',
+                  'pinned': true,
+                  'height': 80,
+                  'width': 160,
+                },
+              },
+              'inputs': {
+                'COLOR': {
+                  'shadow': {
+                    'type': 'colour_picker',
+                    'id': 'draw_circle_1_color',
+                    'fields': {
+                      'COLOUR': '#ffff00',
+                    },
+                  },
+                },
+              },
+              'next': {
+                'block': {
+                  'type': 'simple_circle',
+                  'id': 'draw_circle_2',
+                  'icons': {
+                    'comment': {
+                      'text': 'Unpinned block comment',
+                      'pinned': false,
+                      'height': 80,
+                      'width': 160,
+                    },
+                  },
+                  'inputs': {
+                    'COLOR': {
+                      'shadow': {
+                        'type': 'colour_picker',
+                        'id': 'draw_circle_2_color',
+                        'fields': {
+                          'COLOUR': '#000000',
+                        },
+                      },
+                    },
+                  },
+                },
+              },
+            },
+          },
+        },
+      },
+    ],
+  },
+};
+
 /**
  * Loads saved state from local storage into the given workspace.
  * @param {Blockly.Workspace} workspace Blockly workspace to load into.
@@ -870,11 +985,12 @@ const moveTestBlocks = {
 export const load = function (workspace, scenarioString) {
   const scenarioMap = {
     'blank': blankCanvas,
-    'sun': sunnyDay,
-    'simpleCircle': simpleCircle,
+    'comments': comments,
     'moreBlocks': moreBlocks,
-    'navigationTestBlocks': navigationTestBlocks,
     'moveTestBlocks': moveTestBlocks,
+    'navigationTestBlocks': navigationTestBlocks,
+    'simpleCircle': simpleCircle,
+    'sun': sunnyDay,
   };
 
   const data = JSON.stringify(scenarioMap[scenarioString]);


### PR DESCRIPTION
Aim is to illustrate a bug where a new workspace comment has different behaviour to one that's been loaded (the new Cmd+Enter shortcut seems not to work). Will also be useful once navigation is supported for comments themselves.

Demo: https://test-comments.blockly-keyboard-experimentation.pages.dev/?scenario=comments&toolbox=toolbox&renderer=zelos
