### PR TITLE
feat: Add support for acting on workspace comments and icons.

### DIFF
--- a/src/actions/enter.ts
+++ b/src/actions/enter.ts
@@ -127,15 +127,10 @@ export class EnterAction {
       return !workspace.isReadOnly();
     }
     // Returning true is sometimes incorrect for icons, but there's no API to check.
-    if (
-      curNode instanceof BlockSvg ||
+    return curNode instanceof BlockSvg ||
       curNode instanceof icons.Icon ||
       curNode instanceof comments.CommentBarButton ||
-      curNode instanceof comments.RenderedWorkspaceComment
-    ) {
-      return true;
-    }
-    return false;
+      curNode instanceof comments.RenderedWorkspaceComment;
   }
 
   /**

--- a/src/actions/enter.ts
+++ b/src/actions/enter.ts
@@ -130,7 +130,7 @@ export class EnterAction {
     if (
       curNode instanceof BlockSvg ||
       curNode instanceof icons.Icon ||
-      curNode instanceof comments.CommentIcon ||
+      curNode instanceof comments.CommentBarButton ||
       curNode instanceof comments.RenderedWorkspaceComment
     ) {
       return true;
@@ -171,11 +171,10 @@ export class EnterAction {
         cursor?.in();
       });
       return true;
-    } else if (curNode instanceof comments.CommentIcon) {
+    } else if (curNode instanceof comments.CommentBarButton) {
       curNode.performAction();
       return true;
     } else if (curNode instanceof comments.RenderedWorkspaceComment) {
-      curNode.setEditable(true);
       curNode.setCollapsed(false);
       getFocusManager().focusNode(curNode.getEditorFocusableNode());
       return true;

--- a/src/actions/enter.ts
+++ b/src/actions/enter.ts
@@ -16,6 +16,8 @@ import {
   icons,
   FocusableTreeTraverser,
   renderManagement,
+  comments,
+  getFocusManager,
 } from 'blockly/core';
 
 import type {Block} from 'blockly/core';
@@ -124,9 +126,15 @@ export class EnterAction {
     ) {
       return !workspace.isReadOnly();
     }
-    if (curNode instanceof BlockSvg) return true;
     // Returning true is sometimes incorrect for icons, but there's no API to check.
-    if (curNode instanceof icons.Icon) return true;
+    if (
+      curNode instanceof BlockSvg ||
+      curNode instanceof icons.Icon ||
+      curNode instanceof comments.CommentIcon ||
+      curNode instanceof comments.RenderedWorkspaceComment
+    ) {
+      return true;
+    }
     return false;
   }
 
@@ -162,6 +170,14 @@ export class EnterAction {
       renderManagement.finishQueuedRenders().then(() => {
         cursor?.in();
       });
+      return true;
+    } else if (curNode instanceof comments.CommentIcon) {
+      curNode.performAction();
+      return true;
+    } else if (curNode instanceof comments.RenderedWorkspaceComment) {
+      curNode.setEditable(true);
+      curNode.setCollapsed(false);
+      getFocusManager().focusNode(curNode.getEditorFocusableNode());
       return true;
     }
     return false;

--- a/src/actions/enter.ts
+++ b/src/actions/enter.ts
@@ -127,10 +127,12 @@ export class EnterAction {
       return !workspace.isReadOnly();
     }
     // Returning true is sometimes incorrect for icons, but there's no API to check.
-    return curNode instanceof BlockSvg ||
+    return (
+      curNode instanceof BlockSvg ||
       curNode instanceof icons.Icon ||
       curNode instanceof comments.CommentBarButton ||
-      curNode instanceof comments.RenderedWorkspaceComment;
+      curNode instanceof comments.RenderedWorkspaceComment
+    );
   }
 
   /**

--- a/src/actions/mover.ts
+++ b/src/actions/mover.ts
@@ -5,10 +5,13 @@
  */
 
 import type {
-  BlockSvg,
   IDragger,
   IDragStrategy,
   RenderedConnection,
+  IDraggable,
+  IFocusableNode,
+  IBoundedElement,
+  ISelectable,
 } from 'blockly';
 import {
   Connection,
@@ -18,12 +21,15 @@ import {
   utils,
   WorkspaceSvg,
   ShortcutRegistry,
+  BlockSvg,
+  comments,
 } from 'blockly';
 import * as Constants from '../constants';
 import {Direction, getXYFromDirection} from '../drag_direction';
 import {KeyboardDragStrategy} from '../keyboard_drag_strategy';
 import {Navigation} from '../navigation';
 import {clearMoveHints} from '../hints';
+import {MoveIndicatorBubble} from '../move_indicator';
 
 /**
  * The distance to move an item, in workspace coordinates, when
@@ -42,45 +48,47 @@ const CONSTRAINED_ADDITIONAL_PADDING = 70;
 const COMMIT_MOVE_SHORTCUT = 'commitMove';
 
 /**
- * Low-level code for moving blocks with keyboard shortcuts.
+ * Low-level code for moving elements with keyboard shortcuts.
  */
 export class Mover {
   /**
    * Map of moves in progress.
    *
    * An entry for a given workspace in this map means that the this
-   * Mover is moving a block on that workspace, and will disable
+   * Mover is moving an element on that workspace, and will disable
    * normal cursor movement until the move is complete.
    */
   protected moves: Map<WorkspaceSvg, MoveInfo> = new Map();
 
   /**
-   * The block's base drag strategy, which will be overridden during
+   * The element's base drag strategy, which will be overridden during
    * keyboard drags and reset at the end of the drag.
    */
   private oldDragStrategy: IDragStrategy | null = null;
 
+  private moveIndicator?: MoveIndicatorBubble;
+
   constructor(protected navigation: Navigation) {}
 
   /**
-   * Returns true iff we are able to begin moving the block which
+   * Returns true iff we are able to begin moving the draggable element which
    * currently has focus on the given workspace.
    *
    * @param workspace The workspace to move on.
-   * @param block The block to try to drag.
+   * @param draggable The draggable element to try to drag.
    * @returns True iff we can begin a move.
    */
-  canMove(workspace: WorkspaceSvg, block: BlockSvg) {
+  canMove(workspace: WorkspaceSvg, draggable: IDraggable) {
     return !!(
       this.navigation.getState() === Constants.STATE.WORKSPACE &&
       this.navigation.canCurrentlyEdit(workspace) &&
       !this.moves.has(workspace) && // No move in progress.
-      block?.isMovable()
+      draggable?.isMovable()
     );
   }
 
   /**
-   * Returns true iff we are currently moving a block on the given
+   * Returns true iff we are currently moving an element on the given
    * workspace.
    *
    * @param workspace The workspace we might be moving on.
@@ -99,46 +107,50 @@ export class Mover {
    * Should only be called if canMove has returned true.
    *
    * @param workspace The workspace we might be moving on.
-   * @param block The block to start dragging.
-   * @param insertStartPoint Where to insert the block, or null if the block
+   * @param draggable The element to start dragging.
+   * @param insertStartPoint Where to insert the element, or null if the element
    *     already existed.
    * @returns True iff a move has successfully begun.
    */
   startMove(
     workspace: WorkspaceSvg,
-    block: BlockSvg,
+    draggable: IDraggable & IFocusableNode & IBoundedElement & ISelectable,
     insertStartPoint: RenderedConnection | null,
   ) {
-    this.patchDragStrategy(block, insertStartPoint);
-    // Begin dragging block.
+    if (draggable instanceof BlockSvg) {
+      this.patchDragStrategy(draggable, insertStartPoint);
+    } else if (draggable instanceof comments.RenderedWorkspaceComment) {
+      this.moveIndicator = new MoveIndicatorBubble(draggable);
+    }
+    // Begin dragging element.
     const DraggerClass = registry.getClassFromOptions(
       registry.Type.BLOCK_DRAGGER,
       workspace.options,
       true,
     );
     if (!DraggerClass) throw new Error('no Dragger registered');
-    const dragger = new DraggerClass(block, workspace);
+    const dragger = new DraggerClass(draggable, workspace);
     // Set up a blur listener to end the move if the user clicks away
     const blurListener = () => {
       this.finishMove(workspace);
     };
     // Record that a move is in progress and start dragging.
     workspace.setKeyboardMoveInProgress(true);
-    const info = new MoveInfo(block, dragger, blurListener);
+    const info = new MoveInfo(workspace, draggable, dragger, blurListener);
     this.moves.set(workspace, info);
     // Begin drag.
     dragger.onDragStart(info.fakePointerEvent('pointerdown'));
     info.updateTotalDelta();
-    // In case the block is detached, ensure that it still retains focus
+    // In case a block is detached, ensure that it still retains focus
     // (otherwise dragging will break). This is also the point a new block's
     // initial insert position is scrolled into view.
-    workspace.getCursor()?.setCurNode(block);
-    block.getFocusableElement().addEventListener('blur', blurListener);
+    workspace.getCursor()?.setCurNode(draggable);
+    draggable.getFocusableElement().addEventListener('blur', blurListener);
 
     // Register a keyboard shortcut under the key combos of all existing
     // keyboard shortcuts that commits the move before allowing the real
     // shortcut to proceed. This avoids all kinds of fun brokenness when
-    // deleting/copying/otherwise acting on a block in move mode.
+    // deleting/copying/otherwise acting on a element in move mode.
     const shortcutKeys = Object.values(ShortcutRegistry.registry.getRegistry())
       .flatMap((shortcut) => shortcut.keyCodes)
       .filter((keyCode) => {
@@ -210,7 +222,9 @@ export class Mover {
   abortMove(workspace: WorkspaceSvg) {
     const info = this.preDragEndCleanup(workspace);
 
-    const dragStrategy = info.block.getDragStrategy() as KeyboardDragStrategy;
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    const dragStrategy = (info.draggable as any)
+      .dragStrategy as KeyboardDragStrategy;
     this.patchDragger(
       info.dragger as dragging.Dragger,
       dragStrategy.isNewBlock,
@@ -220,7 +234,7 @@ export class Mover {
     // @ts-expect-error Access to private property connectionCandidate.
     const target = dragStrategy.connectionCandidate?.neighbour;
 
-    // Prevent the stragegy connecting the block so we just delete one block.
+    // Prevent the strategy connecting the block so we just delete one block.
     // @ts-expect-error Access to private property connectionCandidate.
     dragStrategy.connectionCandidate = null;
 
@@ -241,7 +255,7 @@ export class Mover {
    * Common clean-up for finish/abort.
    *
    * @param workspace The workspace on which we are moving.
-   * @returns The info for the block.
+   * @returns The info for the element.
    */
   private preDragEndCleanup(workspace: WorkspaceSvg) {
     ShortcutRegistry.registry.unregister(COMMIT_MOVE_SHORTCUT);
@@ -251,7 +265,7 @@ export class Mover {
     if (!info) throw new Error('no move info for workspace');
 
     // Remove the blur listener before ending the drag
-    info.block
+    info.draggable
       .getFocusableElement()
       .removeEventListener('blur', info.blurListener);
 
@@ -262,16 +276,20 @@ export class Mover {
    * Common clean-up for finish/abort.
    *
    * @param workspace The workspace on which we are moving.
-   * @param info The info for the block.
+   * @param info The info for the element.
    */
   private postDragEndCleanup(workspace: WorkspaceSvg, info: MoveInfo) {
-    this.unpatchDragStrategy(info.block);
+    this.moveIndicator?.dispose();
+    this.moveIndicator = undefined;
+    if (info.draggable instanceof BlockSvg) {
+      this.unpatchDragStrategy(info.draggable);
+    }
     this.moves.delete(workspace);
     workspace.setKeyboardMoveInProgress(false);
-    // Delay scroll until after block has finished moving.
-    setTimeout(() => this.scrollCurrentBlockIntoView(workspace), 0);
-    // If the block gets reattached, ensure it retains focus.
-    getFocusManager().focusNode(info.block);
+    // Delay scroll until after element has finished moving.
+    setTimeout(() => this.scrollCurrentElementIntoView(workspace), 0);
+    // If a block gets reattached, ensure it retains focus.
+    getFocusManager().focusNode(info.draggable);
   }
 
   /**
@@ -293,7 +311,10 @@ export class Mover {
     );
 
     info.updateTotalDelta();
-    this.scrollCurrentBlockIntoView(workspace, CONSTRAINED_ADDITIONAL_PADDING);
+    this.scrollCurrentElementIntoView(
+      workspace,
+      CONSTRAINED_ADDITIONAL_PADDING,
+    );
     return true;
   }
 
@@ -318,7 +339,8 @@ export class Mover {
       info.fakePointerEvent('pointermove'),
       info.totalDelta.clone().scale(workspace.scale),
     );
-    this.scrollCurrentBlockIntoView(workspace);
+    this.scrollCurrentElementIntoView(workspace);
+    this.moveIndicator?.updateLocation();
     return true;
   }
 
@@ -351,16 +373,20 @@ export class Mover {
   }
 
   /**
-   * Scrolls the current block into view if one exists.
+   * Scrolls the current element into view.
    *
-   * @param workspace The workspace to get current block from.
+   * @param workspace The workspace to get current element from.
    * @param padding Amount of spacing to put between the bounds and the edge of
    *     the workspace's viewport.
    */
-  private scrollCurrentBlockIntoView(workspace: WorkspaceSvg, padding = 0) {
-    const blockToView = this.moves.get(workspace)?.block;
-    if (blockToView) {
-      const bounds = blockToView.getBoundingRectangleWithoutChildren().clone();
+  private scrollCurrentElementIntoView(workspace: WorkspaceSvg, padding = 0) {
+    const draggable = this.moves.get(workspace)?.draggable;
+    if (draggable) {
+      const bounds = (
+        draggable instanceof BlockSvg
+          ? draggable.getBoundingRectangleWithoutChildren()
+          : draggable.getBoundingRectangle()
+      ).clone();
       bounds.top -= padding;
       bounds.bottom += padding;
       bounds.left -= padding;
@@ -372,10 +398,10 @@ export class Mover {
   /**
    * Monkeypatch: override either wouldDeleteDraggable or shouldReturnToStart,
    * based on whether this was an insertion of a new block or a movement of
-   * an existing block.
+   * an existing element.
    *
    * @param dragger The dragger to patch.
-   * @param isNewBlock Whether the moving block was created for this action.
+   * @param isNewBlock Whether a moving block was created for this action.
    */
   private patchDragger(dragger: dragging.Dragger, isNewBlock: boolean) {
     if (isNewBlock) {
@@ -397,18 +423,21 @@ export class Mover {
 export class MoveInfo {
   /** Total distance moved, in workspace units. */
   totalDelta = new utils.Coordinate(0, 0);
-  readonly parentNext: Connection | null;
-  readonly parentInput: Connection | null;
+  readonly parentNext: Connection | null = null;
+  readonly parentInput: Connection | null = null;
   readonly startLocation: utils.Coordinate;
 
   constructor(
-    readonly block: BlockSvg,
+    readonly workspace: WorkspaceSvg,
+    readonly draggable: IDraggable & IFocusableNode & IBoundedElement,
     readonly dragger: IDragger,
     readonly blurListener: EventListener,
   ) {
-    this.parentNext = block.previousConnection?.targetConnection ?? null;
-    this.parentInput = block.outputConnection?.targetConnection ?? null;
-    this.startLocation = block.getRelativeToSurfaceXY();
+    if (draggable instanceof BlockSvg) {
+      this.parentNext = draggable.previousConnection?.targetConnection ?? null;
+      this.parentInput = draggable.outputConnection?.targetConnection ?? null;
+    }
+    this.startLocation = draggable.getRelativeToSurfaceXY();
   }
 
   /**
@@ -420,11 +449,8 @@ export class MoveInfo {
    *     dragging code.
    */
   fakePointerEvent(type: string, direction?: Direction): PointerEvent {
-    const workspace = this.block.workspace;
-    if (!(workspace instanceof WorkspaceSvg)) throw new TypeError();
-
-    const blockCoords = utils.svgMath.wsToScreenCoordinates(
-      workspace,
+    const coordinates = utils.svgMath.wsToScreenCoordinates(
+      this.workspace,
       new utils.Coordinate(
         this.startLocation.x + this.totalDelta.x,
         this.startLocation.y + this.totalDelta.y,
@@ -432,25 +458,29 @@ export class MoveInfo {
     );
     const tilts = getXYFromDirection(direction);
     return new PointerEvent(type, {
-      clientX: blockCoords.x,
-      clientY: blockCoords.y,
+      clientX: coordinates.x,
+      clientY: coordinates.y,
       tiltX: tilts.x,
       tiltY: tilts.y,
     });
   }
 
   /**
-   * The keyboard drag may have moved the block to an appropriate location
-   * for a preview. Update the saved delta to reflect the block's new
+   * The keyboard drag may have moved a block to an appropriate location
+   * for a preview. Update the saved delta to reflect the element's new
    * location, so that it does not jump during the next unconstrained move.
    */
   updateTotalDelta() {
-    const workspace = this.block.workspace;
-    if (!(workspace instanceof WorkspaceSvg)) throw new TypeError();
-
-    this.totalDelta = new utils.Coordinate(
-      this.block.relativeCoords.x - this.startLocation.x,
-      this.block.relativeCoords.y - this.startLocation.y,
-    );
+    if (this.draggable instanceof BlockSvg) {
+      this.totalDelta = new utils.Coordinate(
+        this.draggable.relativeCoords.x - this.startLocation.x,
+        this.draggable.relativeCoords.y - this.startLocation.y,
+      );
+    } else {
+      this.totalDelta = new utils.Coordinate(
+        this.draggable.getBoundingRectangle().left - this.startLocation.x,
+        this.draggable.getBoundingRectangle().top - this.startLocation.y,
+      );
+    }
   }
 }

--- a/src/move_indicator.ts
+++ b/src/move_indicator.ts
@@ -29,13 +29,16 @@ export class MoveIndicatorBubble
    * @param sourceBlock The block this bubble should be associated with.
    */
   /* eslint-disable @typescript-eslint/naming-convention */
-  constructor(private sourceBlock: Blockly.BlockSvg) {
+  constructor(
+    private sourceElement: Blockly.ISelectable & Blockly.IBoundedElement,
+  ) {
+    const workspace = sourceElement.workspace as Blockly.WorkspaceSvg;
     this.svgRoot = Blockly.utils.dom.createSvgElement(
       Blockly.utils.Svg.G,
       {},
-      this.sourceBlock.workspace.getBubbleCanvas(),
+      workspace.getBubbleCanvas(),
     );
-    const rtl = this.sourceBlock.workspace.RTL;
+    const rtl = workspace.RTL;
     Blockly.utils.dom.createSvgElement(
       Blockly.utils.Svg.CIRCLE,
       {
@@ -88,13 +91,18 @@ export class MoveIndicatorBubble
    * Recalculates this bubble's location, keeping it adjacent to its block.
    */
   updateLocation() {
-    const bounds = this.sourceBlock.getBoundingRectangleWithoutChildren();
-    const x = this.sourceBlock.workspace.RTL
+    const bounds =
+      this.sourceElement instanceof Blockly.BlockSvg
+        ? this.sourceElement.getBoundingRectangleWithoutChildren()
+        : this.sourceElement.getBoundingRectangle();
+    const x = this.sourceElement.workspace.RTL
       ? bounds.left + 20
       : bounds.right - 20;
     const y = bounds.top - 20;
     this.moveTo(x, y);
-    this.sourceBlock.workspace.getLayerManager()?.moveToDragLayer(this);
+    (this.sourceElement.workspace as Blockly.WorkspaceSvg)
+      .getLayerManager()
+      ?.moveToDragLayer(this);
   }
 
   /**

--- a/test/webdriverio/index.html
+++ b/test/webdriverio/index.html
@@ -42,6 +42,10 @@
         outline: none;
       }
 
+      .blocklyDeleteIcon {
+        display: block;
+      }
+
       pre,
       code {
         overflow: auto;

--- a/test/webdriverio/index.ts
+++ b/test/webdriverio/index.ts
@@ -81,6 +81,7 @@ function createWorkspace(): Blockly.WorkspaceSvg {
   const workspace = Blockly.inject(blocklyDiv, injectOptions);
 
   new KeyboardNavigation(workspace);
+  Blockly.ContextMenuItems.registerCommentOptions();
 
   // Disable blocks that aren't inside the setup or draw loops.
   workspace.addChangeListener(Blockly.Events.disableOrphans);

--- a/test/webdriverio/test/test_setup.ts
+++ b/test/webdriverio/test/test_setup.ts
@@ -264,6 +264,27 @@ export async function focusOnBlock(
 }
 
 /**
+ * Focuses and selects a workspace comment with the provided ID.
+ *
+ * This throws an error if no workspace comment exists for the specified ID.
+ *
+ * @param browser The active WebdriverIO Browser object.
+ * @param commentId The ID of the workspace comment to select.
+ */
+export async function focusOnWorkspaceComment(
+  browser: WebdriverIO.Browser,
+  commentId: string,
+) {
+  return await browser.execute((commentId) => {
+    const workspaceSvg = Blockly.getMainWorkspace() as Blockly.WorkspaceSvg;
+    const comment = workspaceSvg.getCommentById(commentId);
+    if (!comment)
+      throw new Error(`No workspace comment found with ID: ${commentId}.`);
+    Blockly.getFocusManager().focusNode(comment);
+  }, commentId);
+}
+
+/**
  * Focuses and selects the field of a block given a block ID and field name.
  *
  * This throws an error if no block exists for the specified ID, or if the block

--- a/test/webdriverio/test/test_setup.ts
+++ b/test/webdriverio/test/test_setup.ts
@@ -278,8 +278,9 @@ export async function focusOnWorkspaceComment(
   return await browser.execute((commentId) => {
     const workspaceSvg = Blockly.getMainWorkspace() as Blockly.WorkspaceSvg;
     const comment = workspaceSvg.getCommentById(commentId);
-    if (!comment)
+    if (!comment) {
       throw new Error(`No workspace comment found with ID: ${commentId}.`);
+    }
     Blockly.getFocusManager().focusNode(comment);
   }, commentId);
 }

--- a/test/webdriverio/test/workspace_comment_test.ts
+++ b/test/webdriverio/test/workspace_comment_test.ts
@@ -1,0 +1,180 @@
+/**
+ * @license
+ * Copyright 2025 Google LLC
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import * as chai from 'chai';
+import * as Blockly from 'blockly';
+import {
+  contextMenuExists,
+  focusOnBlock,
+  getCurrentFocusNodeId,
+  getFocusedBlockType,
+  testSetup,
+  focusOnWorkspaceComment,
+  testFileLocations,
+  PAUSE_TIME,
+  keyLeft,
+  keyRight,
+  keyDown,
+  keyUp,
+} from './test_setup.js';
+import {Key} from 'webdriverio';
+
+suite('Workspace comment navigation', function () {
+  // Setting timeout to unlimited as these tests take a longer time to run than most mocha test
+  this.timeout(0);
+
+  // Setup Selenium for all of the tests
+  setup(async function () {
+    this.browser = await testSetup(testFileLocations.NAVIGATION_TEST_BLOCKS);
+    [this.comment1, this.comment2] = await this.browser.execute(() => {
+      const workspace = Blockly.getMainWorkspace();
+      const comment1 = Blockly.serialization.workspaceComments.append(
+        {
+          text: 'Comment one',
+          x: 200,
+          y: 200,
+        },
+        workspace,
+      );
+
+      const comment2 = Blockly.serialization.workspaceComments.append(
+        {
+          text: 'Comment two',
+          x: 300,
+          y: 300,
+        },
+        workspace,
+      );
+
+      return [comment1.id, comment2.id];
+    });
+  });
+
+  test('Navigate forward from block to workspace comment', async function () {
+    await focusOnBlock(this.browser, 'p5_canvas_1');
+    await keyDown(this.browser);
+    const focusedNodeId = await getCurrentFocusNodeId(this.browser);
+    chai.assert.equal(focusedNodeId, this.comment1);
+  });
+
+  test('Navigate forward from workspace comment to block', async function () {
+    await focusOnWorkspaceComment(this.browser, this.comment2);
+    await keyDown(this.browser);
+    const focusedBlock = await getFocusedBlockType(this.browser);
+    chai.assert.equal(focusedBlock, 'p5_draw');
+  });
+
+  test('Navigate backward from block to workspace comment', async function () {
+    await focusOnBlock(this.browser, 'p5_draw_1');
+    await keyUp(this.browser);
+    const focusedNodeId = await getCurrentFocusNodeId(this.browser);
+    chai.assert.equal(focusedNodeId, this.comment2);
+  });
+
+  test('Navigate backward from workspace comment to block', async function () {
+    await focusOnWorkspaceComment(this.browser, this.comment1);
+    await keyUp(this.browser);
+    const focusedBlock = await getFocusedBlockType(this.browser);
+    chai.assert.equal(focusedBlock, 'p5_canvas');
+  });
+
+  test('Navigate forward from workspace comment to workspace comment', async function () {
+    await focusOnWorkspaceComment(this.browser, this.comment1);
+    await keyDown(this.browser);
+    const focusedNodeId = await getCurrentFocusNodeId(this.browser);
+    chai.assert.equal(focusedNodeId, this.comment2);
+  });
+
+  test('Navigate backward from workspace comment to workspace comment', async function () {
+    await focusOnWorkspaceComment(this.browser, this.comment2);
+    await keyUp(this.browser);
+    const focusedNodeId = await getCurrentFocusNodeId(this.browser);
+    chai.assert.equal(focusedNodeId, this.comment1);
+  });
+
+  test('Navigate forward from workspace comment to workspace comment button', async function () {
+    await focusOnWorkspaceComment(this.browser, this.comment1);
+    await keyRight(this.browser);
+    const focusedNodeId = await getCurrentFocusNodeId(this.browser);
+    chai.assert.equal(focusedNodeId, `${this.comment1}_collapse_bar_button`);
+  });
+
+  test('Navigate backward from workspace comment button to workspace comment', async function () {
+    await focusOnWorkspaceComment(this.browser, this.comment1);
+    await keyRight(this.browser);
+    await keyLeft(this.browser);
+    const focusedNodeId = await getCurrentFocusNodeId(this.browser);
+    chai.assert.equal(focusedNodeId, this.comment1);
+  });
+
+  test('Navigate forward from workspace comment button to workspace comment button', async function () {
+    await focusOnWorkspaceComment(this.browser, this.comment1);
+    await keyRight(this.browser);
+    await keyRight(this.browser);
+    const focusedNodeId = await getCurrentFocusNodeId(this.browser);
+    chai.assert.equal(focusedNodeId, `${this.comment1}_delete_bar_button`);
+  });
+
+  test('Navigate backward from workspace comment button to workspace comment button', async function () {
+    await focusOnWorkspaceComment(this.browser, this.comment1);
+    await keyRight(this.browser);
+    await keyRight(this.browser);
+    await keyLeft(this.browser);
+    const focusedNodeId = await getCurrentFocusNodeId(this.browser);
+    chai.assert.equal(focusedNodeId, `${this.comment1}_collapse_bar_button`);
+  });
+
+  test('Activate workspace comment button', async function () {
+    await focusOnWorkspaceComment(this.browser, this.comment1);
+    await keyRight(this.browser);
+    await this.browser.keys(Key.Enter);
+    await this.browser.pause(PAUSE_TIME);
+    const collapsed = await this.browser.execute((commentId) => {
+      return Blockly.getMainWorkspace()
+        .getCommentById(commentId)
+        ?.isCollapsed();
+    }, this.comment1);
+    chai.assert.isTrue(collapsed);
+  });
+
+  test('Activating workspace comment focuses its editor', async function () {
+    await focusOnWorkspaceComment(this.browser, this.comment1);
+    await this.browser.keys(Key.Enter);
+    await this.browser.pause(PAUSE_TIME);
+    const focusedNodeId = await getCurrentFocusNodeId(this.browser);
+    chai.assert.equal(focusedNodeId, `${this.comment1}_comment_textarea_`);
+  });
+
+  test('Terminating editing commits edits and focuses root workspace comment', async function () {
+    await focusOnWorkspaceComment(this.browser, this.comment1);
+    await this.browser.keys(Key.Enter);
+    await this.browser.pause(PAUSE_TIME);
+    await this.browser.keys('Hello world');
+    await this.browser.pause(PAUSE_TIME);
+    await this.browser.keys(Key.Escape);
+    const focusedNodeId = await getCurrentFocusNodeId(this.browser);
+    chai.assert.equal(focusedNodeId, `${this.comment1}`);
+
+    const commentText = await this.browser.execute((commentId) => {
+      return Blockly.getMainWorkspace().getCommentById(commentId)?.getText();
+    }, this.comment1);
+    chai.assert.equal(commentText, 'Comment oneHello world');
+  });
+
+  test('Action menu can be displayed for a workspace comment', async function () {
+    await focusOnWorkspaceComment(this.browser, this.comment1);
+    await this.browser.keys([Key.Ctrl, Key.Return]);
+    await this.browser.pause(PAUSE_TIME);
+    chai.assert.isTrue(
+      await contextMenuExists(this.browser, 'Duplicate Comment'),
+      'The menu should be openable on a workspace comment',
+    );
+    chai.assert.isTrue(
+      await contextMenuExists(this.browser, 'Remove Comment'),
+      'The menu should be openable on a workspace comment',
+    );
+  });
+});

--- a/test/webdriverio/test/workspace_comment_test.ts
+++ b/test/webdriverio/test/workspace_comment_test.ts
@@ -13,8 +13,8 @@ import {
   getFocusedBlockType,
   testSetup,
   focusOnWorkspaceComment,
+  sendKeyAndWait,
   testFileLocations,
-  PAUSE_TIME,
   keyLeft,
   keyRight,
   keyDown,
@@ -142,8 +142,7 @@ suite('Workspace comment navigation', function () {
   test('Activate workspace comment button', async function () {
     await focusOnWorkspaceComment(this.browser, this.commentId1);
     await keyRight(this.browser);
-    await this.browser.keys(Key.Enter);
-    await this.browser.pause(PAUSE_TIME);
+    await sendKeyAndWait(this.browser, Key.Enter);
     const collapsed = await this.browser.execute((commentId) => {
       return Blockly.getMainWorkspace()
         .getCommentById(commentId)
@@ -154,19 +153,16 @@ suite('Workspace comment navigation', function () {
 
   test('Activating workspace comment focuses its editor', async function () {
     await focusOnWorkspaceComment(this.browser, this.commentId1);
-    await this.browser.keys(Key.Enter);
-    await this.browser.pause(PAUSE_TIME);
+    await sendKeyAndWait(this.browser, Key.Enter);
     const focusedNodeId = await getCurrentFocusNodeId(this.browser);
     chai.assert.equal(focusedNodeId, `${this.commentId1}_comment_textarea_`);
   });
 
   test('Terminating editing commits edits and focuses root workspace comment', async function () {
     await focusOnWorkspaceComment(this.browser, this.commentId1);
-    await this.browser.keys(Key.Enter);
-    await this.browser.pause(PAUSE_TIME);
-    await this.browser.keys('Hello world');
-    await this.browser.pause(PAUSE_TIME);
-    await this.browser.keys(Key.Escape);
+    await sendKeyAndWait(this.browser, Key.Enter);
+    await sendKeyAndWait(this.browser, 'Hello world');
+    await sendKeyAndWait(this.browser, Key.Escape);
     const focusedNodeId = await getCurrentFocusNodeId(this.browser);
     chai.assert.equal(focusedNodeId, `${this.commentId1}`);
 
@@ -178,8 +174,7 @@ suite('Workspace comment navigation', function () {
 
   test('Action menu can be displayed for a workspace comment', async function () {
     await focusOnWorkspaceComment(this.browser, this.commentId1);
-    await this.browser.keys([Key.Ctrl, Key.Return]);
-    await this.browser.pause(PAUSE_TIME);
+    await sendKeyAndWait(this.browser, [Key.Ctrl, Key.Return]);
     chai.assert.isTrue(
       await contextMenuExists(this.browser, 'Duplicate Comment'),
       'The menu should be openable on a workspace comment',
@@ -200,15 +195,10 @@ suite('Workspace comment navigation', function () {
     const initialPosition = await this.getCommentLocation(this.commentId1);
     chai.assert.deepEqual(initialPosition, [200, 200]);
 
-    await this.browser.keys('m');
-    await this.browser.pause(PAUSE_TIME);
-    await this.browser.keys([Key.Alt, Key.ArrowDown]);
-    await this.browser.pause(PAUSE_TIME);
-    await this.browser.keys([Key.Alt, Key.ArrowDown]);
-    await this.browser.pause(PAUSE_TIME);
-    await this.browser.keys([Key.Alt, Key.ArrowRight]);
-    await this.browser.pause(PAUSE_TIME);
-    await this.browser.keys(Key.Enter);
+    await sendKeyAndWait(this.browser, 'm');
+    await sendKeyAndWait(this.browser, [Key.Alt, Key.ArrowDown], 2);
+    await sendKeyAndWait(this.browser, [Key.Alt, Key.ArrowRight]);
+    await sendKeyAndWait(this.browser, Key.Enter);
 
     const newPosition = await this.getCommentLocation(this.commentId1);
     chai.assert.deepEqual(newPosition, [220, 240]);

--- a/test/webdriverio/test/workspace_comment_test.ts
+++ b/test/webdriverio/test/workspace_comment_test.ts
@@ -51,6 +51,18 @@ suite('Workspace comment navigation', function () {
 
       return [comment1.id, comment2.id];
     });
+
+    this.getCommentLocation = async (commentId: string) => {
+      return this.browser.execute((commentId: string) => {
+        const comment = Blockly.getMainWorkspace().getCommentById(commentId);
+        if (!comment) return null;
+        const bounds = (
+          comment as Blockly.comments.RenderedWorkspaceComment
+        ).getBoundingRectangle();
+
+        return [bounds.left, bounds.top];
+      }, commentId);
+    };
   });
 
   test('Navigate forward from block to workspace comment', async function () {
@@ -176,5 +188,29 @@ suite('Workspace comment navigation', function () {
       await contextMenuExists(this.browser, 'Remove Comment'),
       'The menu should be openable on a workspace comment',
     );
+    chai.assert.isTrue(
+      await contextMenuExists(this.browser, 'Move CommentM'),
+      'The menu should be openable on a workspace comment',
+    );
+  });
+
+  test('Workspace comments can be moved', async function () {
+    await focusOnWorkspaceComment(this.browser, this.comment1);
+
+    const initialPosition = await this.getCommentLocation(this.comment1);
+    chai.assert.deepEqual(initialPosition, [200, 200]);
+
+    await this.browser.keys('m');
+    await this.browser.pause(PAUSE_TIME);
+    await this.browser.keys([Key.Alt, Key.ArrowDown]);
+    await this.browser.pause(PAUSE_TIME);
+    await this.browser.keys([Key.Alt, Key.ArrowDown]);
+    await this.browser.pause(PAUSE_TIME);
+    await this.browser.keys([Key.Alt, Key.ArrowRight]);
+    await this.browser.pause(PAUSE_TIME);
+    await this.browser.keys(Key.Enter);
+
+    const newPosition = await this.getCommentLocation(this.comment1);
+    chai.assert.deepEqual(newPosition, [220, 240]);
   });
 });

--- a/test/webdriverio/test/workspace_comment_test.ts
+++ b/test/webdriverio/test/workspace_comment_test.ts
@@ -29,7 +29,7 @@ suite('Workspace comment navigation', function () {
   // Setup Selenium for all of the tests
   setup(async function () {
     this.browser = await testSetup(testFileLocations.NAVIGATION_TEST_BLOCKS);
-    [this.comment1, this.comment2] = await this.browser.execute(() => {
+    [this.commentId1, this.commentId2] = await this.browser.execute(() => {
       const workspace = Blockly.getMainWorkspace();
       const comment1 = Blockly.serialization.workspaceComments.append(
         {
@@ -69,11 +69,11 @@ suite('Workspace comment navigation', function () {
     await focusOnBlock(this.browser, 'p5_canvas_1');
     await keyDown(this.browser);
     const focusedNodeId = await getCurrentFocusNodeId(this.browser);
-    chai.assert.equal(focusedNodeId, this.comment1);
+    chai.assert.equal(focusedNodeId, this.commentId1);
   });
 
   test('Navigate forward from workspace comment to block', async function () {
-    await focusOnWorkspaceComment(this.browser, this.comment2);
+    await focusOnWorkspaceComment(this.browser, this.commentId2);
     await keyDown(this.browser);
     const focusedBlock = await getFocusedBlockType(this.browser);
     chai.assert.equal(focusedBlock, 'p5_draw');
@@ -83,64 +83,64 @@ suite('Workspace comment navigation', function () {
     await focusOnBlock(this.browser, 'p5_draw_1');
     await keyUp(this.browser);
     const focusedNodeId = await getCurrentFocusNodeId(this.browser);
-    chai.assert.equal(focusedNodeId, this.comment2);
+    chai.assert.equal(focusedNodeId, this.commentId2);
   });
 
   test('Navigate backward from workspace comment to block', async function () {
-    await focusOnWorkspaceComment(this.browser, this.comment1);
+    await focusOnWorkspaceComment(this.browser, this.commentId1);
     await keyUp(this.browser);
     const focusedBlock = await getFocusedBlockType(this.browser);
     chai.assert.equal(focusedBlock, 'p5_canvas');
   });
 
   test('Navigate forward from workspace comment to workspace comment', async function () {
-    await focusOnWorkspaceComment(this.browser, this.comment1);
+    await focusOnWorkspaceComment(this.browser, this.commentId1);
     await keyDown(this.browser);
     const focusedNodeId = await getCurrentFocusNodeId(this.browser);
-    chai.assert.equal(focusedNodeId, this.comment2);
+    chai.assert.equal(focusedNodeId, this.commentId2);
   });
 
   test('Navigate backward from workspace comment to workspace comment', async function () {
-    await focusOnWorkspaceComment(this.browser, this.comment2);
+    await focusOnWorkspaceComment(this.browser, this.commentId2);
     await keyUp(this.browser);
     const focusedNodeId = await getCurrentFocusNodeId(this.browser);
-    chai.assert.equal(focusedNodeId, this.comment1);
+    chai.assert.equal(focusedNodeId, this.commentId1);
   });
 
   test('Navigate forward from workspace comment to workspace comment button', async function () {
-    await focusOnWorkspaceComment(this.browser, this.comment1);
+    await focusOnWorkspaceComment(this.browser, this.commentId1);
     await keyRight(this.browser);
     const focusedNodeId = await getCurrentFocusNodeId(this.browser);
-    chai.assert.equal(focusedNodeId, `${this.comment1}_collapse_bar_button`);
+    chai.assert.equal(focusedNodeId, `${this.commentId1}_collapse_bar_button`);
   });
 
   test('Navigate backward from workspace comment button to workspace comment', async function () {
-    await focusOnWorkspaceComment(this.browser, this.comment1);
+    await focusOnWorkspaceComment(this.browser, this.commentId1);
     await keyRight(this.browser);
     await keyLeft(this.browser);
     const focusedNodeId = await getCurrentFocusNodeId(this.browser);
-    chai.assert.equal(focusedNodeId, this.comment1);
+    chai.assert.equal(focusedNodeId, this.commentId1);
   });
 
   test('Navigate forward from workspace comment button to workspace comment button', async function () {
-    await focusOnWorkspaceComment(this.browser, this.comment1);
+    await focusOnWorkspaceComment(this.browser, this.commentId1);
     await keyRight(this.browser);
     await keyRight(this.browser);
     const focusedNodeId = await getCurrentFocusNodeId(this.browser);
-    chai.assert.equal(focusedNodeId, `${this.comment1}_delete_bar_button`);
+    chai.assert.equal(focusedNodeId, `${this.commentId1}_delete_bar_button`);
   });
 
   test('Navigate backward from workspace comment button to workspace comment button', async function () {
-    await focusOnWorkspaceComment(this.browser, this.comment1);
+    await focusOnWorkspaceComment(this.browser, this.commentId1);
     await keyRight(this.browser);
     await keyRight(this.browser);
     await keyLeft(this.browser);
     const focusedNodeId = await getCurrentFocusNodeId(this.browser);
-    chai.assert.equal(focusedNodeId, `${this.comment1}_collapse_bar_button`);
+    chai.assert.equal(focusedNodeId, `${this.commentId1}_collapse_bar_button`);
   });
 
   test('Activate workspace comment button', async function () {
-    await focusOnWorkspaceComment(this.browser, this.comment1);
+    await focusOnWorkspaceComment(this.browser, this.commentId1);
     await keyRight(this.browser);
     await this.browser.keys(Key.Enter);
     await this.browser.pause(PAUSE_TIME);
@@ -148,36 +148,36 @@ suite('Workspace comment navigation', function () {
       return Blockly.getMainWorkspace()
         .getCommentById(commentId)
         ?.isCollapsed();
-    }, this.comment1);
+    }, this.commentId1);
     chai.assert.isTrue(collapsed);
   });
 
   test('Activating workspace comment focuses its editor', async function () {
-    await focusOnWorkspaceComment(this.browser, this.comment1);
+    await focusOnWorkspaceComment(this.browser, this.commentId1);
     await this.browser.keys(Key.Enter);
     await this.browser.pause(PAUSE_TIME);
     const focusedNodeId = await getCurrentFocusNodeId(this.browser);
-    chai.assert.equal(focusedNodeId, `${this.comment1}_comment_textarea_`);
+    chai.assert.equal(focusedNodeId, `${this.commentId1}_comment_textarea_`);
   });
 
   test('Terminating editing commits edits and focuses root workspace comment', async function () {
-    await focusOnWorkspaceComment(this.browser, this.comment1);
+    await focusOnWorkspaceComment(this.browser, this.commentId1);
     await this.browser.keys(Key.Enter);
     await this.browser.pause(PAUSE_TIME);
     await this.browser.keys('Hello world');
     await this.browser.pause(PAUSE_TIME);
     await this.browser.keys(Key.Escape);
     const focusedNodeId = await getCurrentFocusNodeId(this.browser);
-    chai.assert.equal(focusedNodeId, `${this.comment1}`);
+    chai.assert.equal(focusedNodeId, `${this.commentId1}`);
 
     const commentText = await this.browser.execute((commentId) => {
       return Blockly.getMainWorkspace().getCommentById(commentId)?.getText();
-    }, this.comment1);
+    }, this.commentId1);
     chai.assert.equal(commentText, 'Comment oneHello world');
   });
 
   test('Action menu can be displayed for a workspace comment', async function () {
-    await focusOnWorkspaceComment(this.browser, this.comment1);
+    await focusOnWorkspaceComment(this.browser, this.commentId1);
     await this.browser.keys([Key.Ctrl, Key.Return]);
     await this.browser.pause(PAUSE_TIME);
     chai.assert.isTrue(
@@ -195,9 +195,9 @@ suite('Workspace comment navigation', function () {
   });
 
   test('Workspace comments can be moved', async function () {
-    await focusOnWorkspaceComment(this.browser, this.comment1);
+    await focusOnWorkspaceComment(this.browser, this.commentId1);
 
-    const initialPosition = await this.getCommentLocation(this.comment1);
+    const initialPosition = await this.getCommentLocation(this.commentId1);
     chai.assert.deepEqual(initialPosition, [200, 200]);
 
     await this.browser.keys('m');
@@ -210,7 +210,7 @@ suite('Workspace comment navigation', function () {
     await this.browser.pause(PAUSE_TIME);
     await this.browser.keys(Key.Enter);
 
-    const newPosition = await this.getCommentLocation(this.comment1);
+    const newPosition = await this.getCommentLocation(this.commentId1);
     chai.assert.deepEqual(newPosition, [220, 240]);
   });
 });


### PR DESCRIPTION
In conjunction with https://github.com/google/blockly/pull/9182, this PR adds support for editing workspace comments, activating their icons via keyboard navigation, and moving them.