### PR TITLE
chore: lint for floating promises

### DIFF
--- a/eslint.config.js
+++ b/eslint.config.js
@@ -259,4 +259,17 @@ module.exports = [
       '@typescript-eslint/no-require-imports': 'error',
     },
   },
+  {
+    files: ['test/webdriverio/test/*.ts'],
+    languageOptions: {
+      parserOptions: {
+        project: true,
+        tsconfigRootDir: __dirname,
+      },
+    },
+    rules: {
+      '@typescript-eslint/no-floating-promises': 'error',
+      '@typescript-eslint/no-misused-promises': 'error',
+    },
+  },
 ];

--- a/test/webdriverio/test/keyboard_mode_test.ts
+++ b/test/webdriverio/test/keyboard_mode_test.ts
@@ -86,7 +86,7 @@ suite(
 
       chai.assert.isFalse(await isKeyboardNavigating(this.browser));
 
-      this.browser.execute(() => {
+      await this.browser.execute(() => {
         Blockly.keyboardNavigationController.setIsActive(true);
       });
 
@@ -106,7 +106,7 @@ suite(
 
       chai.assert.isFalse(await isKeyboardNavigating(this.browser));
 
-      this.browser.execute(() => {
+      await this.browser.execute(() => {
         Blockly.keyboardNavigationController.setIsActive(true);
       });
 
@@ -126,7 +126,7 @@ suite(
 
       await this.browser.pause(PAUSE_TIME);
       // Right click a block
-      clickBlock(this.browser, 'controls_if_1', {button: 'right'});
+      await clickBlock(this.browser, 'controls_if_1', {button: 'right'});
       await this.browser.pause(PAUSE_TIME);
 
       chai.assert.isFalse(await isKeyboardNavigating(this.browser));

--- a/test/webdriverio/test/scroll_test.ts
+++ b/test/webdriverio/test/scroll_test.ts
@@ -24,7 +24,7 @@ suite('Scrolling into view', function () {
   setup(async function () {
     this.browser = await testSetup(testFileLocations.BASE);
     // Predictable small window size for scrolling.
-    this.browser.setWindowSize(800, 600);
+    await this.browser.setWindowSize(800, 600);
     await this.browser.pause(PAUSE_TIME);
   });
 

--- a/test/webdriverio/test/test_setup.ts
+++ b/test/webdriverio/test/test_setup.ts
@@ -441,10 +441,10 @@ export async function tabNavigateToWorkspace(
   hasFlyout = true,
 ) {
   // Navigate past the initial pre-injection focusable div element.
-  tabNavigateForward(browser);
-  if (hasToolbox) tabNavigateForward(browser);
-  if (hasFlyout) tabNavigateForward(browser);
-  tabNavigateForward(browser); // Tab to the workspace itself.
+  await tabNavigateForward(browser);
+  if (hasToolbox) await tabNavigateForward(browser);
+  if (hasFlyout) await tabNavigateForward(browser);
+  await tabNavigateForward(browser); // Tab to the workspace itself.
 }
 
 /**

--- a/test/webdriverio/test/workspace_comment_test.ts
+++ b/test/webdriverio/test/workspace_comment_test.ts
@@ -7,7 +7,6 @@
 import * as chai from 'chai';
 import * as Blockly from 'blockly';
 import {
-  contextMenuExists,
   focusOnBlock,
   getCurrentFocusNodeId,
   getFocusedBlockType,


### PR DESCRIPTION
Fix missing awaits in the webdriver tests.

Needed tsconfig information so I've added the project setting - see https://typescript-eslint.io/blog/parser-options-project-true/#introducing-true

It's all but inevitable that folks miss some awaits in webdriver tests and it's easy to mask the issue most of the time with a pause leading to tests that are both slow and flaky.

This is just a suggestion, feel free to close it if the team finds this to be more trouble than its worth and I'll open a version that just fixes the missing awaits we have right now. I personally find this kind of support really useful when writing async code like the webdriver tests.

Rules:
- https://typescript-eslint.io/rules/no-floating-promises
- https://typescript-eslint.io/rules/no-misused-promises
