### PR TITLE
fix: prevent enter on icons moving to next icon/field

### DIFF
--- a/src/actions/enter.ts
+++ b/src/actions/enter.ts
@@ -159,9 +159,13 @@ export class EnterAction {
       // opening a bubble of some sort. We then need to wait for the bubble to
       // appear before attempting to navigate into it.
       curNode.onClick();
-      renderManagement.finishQueuedRenders().then(() => {
-        cursor?.in();
-      });
+      // This currently only works for MutatorIcons.
+      // See icon_navigation_policy.
+      if (curNode instanceof icons.MutatorIcon) {
+        renderManagement.finishQueuedRenders().then(() => {
+          cursor?.in();
+        });
+      }
       return true;
     }
     return false;


### PR DESCRIPTION
The in() behaviour relied on here only works for MutatorIcons. See icon_navigation_policy.ts in core.

That might change over time, but there will still be some icons for which this isn't appropriate.

Prior to this change enter on a comment icon or a MakeCode debug breakpoint icon inexplicably moves the cursor to the next field/icon.