### PR TITLE
feat: paste into correct workspace, allow cross-workspace pasting

### DIFF
--- a/README.md
+++ b/README.md
@@ -43,7 +43,7 @@ on this repository! Include information about how to reproduce the bug, what
 the bad behaviour was, and what you expected it to do. The Blockly team will
 triage the bug and add it to the roadmap.
 
-## Testing in your app
+## Using in your app
 
 ### Installation
 
@@ -67,13 +67,48 @@ npm install @blockly/keyboard-navigation --save
 
 ```js
 import * as Blockly from 'blockly';
-import {KeyboardNavigation} from '@blockly/keyboard-experiment';
+import {KeyboardNavigation} from '@blockly/keyboard-navigation';
 // Inject Blockly.
 const workspace = Blockly.inject('blocklyDiv', {
   toolbox: toolboxCategories,
 });
 // Initialize plugin.
 const keyboardNav = new KeyboardNavigation(workspace);
+```
+
+### Usage with cross-tab-copy-paste plugin
+
+This plugin adds context menu items for copying & pasting. It also adds feedback to copying & pasting as toasts that are shown to the user upon successful copy or cut. It is compatible with the `@blockly/plugin-cross-tab-copy-paste` by following these steps:
+
+```js
+import * as Blockly from 'blockly';
+import {KeyboardNavigation} from '@blockly/keyboard-navigation';
+import {CrossTabCopyPaste} from '@blockly/plugin-cross-tab-copy-paste';
+
+// Inject Blockly.
+const workspace = Blockly.inject('blocklyDiv', {
+  toolbox: toolboxCategories,
+});
+
+// Initialize cross-tab-copy-paste
+// Must be done before keyboard-navigation
+const crossTabOptions = {
+  // Don't use the context menu options from the ctcp plugin,
+  // because the keyboard-navigation plugin provides its own.
+  contextMenu: false,
+  shortcut: true,
+};
+const plugin = new CrossTabCopyPaste();
+plugin.init(crossTabOptions, () => {
+  console.log('Use this error callback to handle TypeError while pasting');
+});
+
+// Initialize keyboard-navigation.
+// You must pass the `allowCrossWorkspacePaste` option in order for paste
+// to appear correctly enabled/disabled in the context menu.
+const keyboardNav = new KeyboardNavigation(workspace, {
+  allowCrossWorkspacePaste: true,
+});
 ```
 
 ## Contributing

--- a/src/actions/clipboard.ts
+++ b/src/actions/clipboard.ts
@@ -82,8 +82,6 @@ export class Clipboard {
       name: Constants.SHORTCUT_NAMES.CUT,
       preconditionFn: this.oldCutShortcut.preconditionFn,
       callback: this.cutCallback.bind(this),
-      // The registry gives back keycodes as an object instead of an array
-      // See https://github.com/google/blockly/issues/9008
       keyCodes: this.oldCutShortcut.keyCodes,
       allowCollision: false,
     };
@@ -236,8 +234,6 @@ export class Clipboard {
       name: Constants.SHORTCUT_NAMES.COPY,
       preconditionFn: this.oldCopyShortcut.preconditionFn,
       callback: this.copyCallback.bind(this),
-      // The registry gives back keycodes as an object instead of an array
-      // See https://github.com/google/blockly/issues/9008
       keyCodes: this.oldCopyShortcut.keyCodes,
       allowCollision: false,
     };

--- a/src/actions/clipboard.ts
+++ b/src/actions/clipboard.ts
@@ -319,6 +319,7 @@ export class Clipboard {
   /**
    * Get the workspace to paste into based on which type of thing the menu was opened on.
    *
+   * @param scope scope of shortcut or context menu item
    * @returns WorkspaceSvg to paste into or undefined
    */
   private getPasteWorkspace(

--- a/src/index.ts
+++ b/src/index.ts
@@ -41,11 +41,21 @@ export class KeyboardNavigation {
    * Constructs the keyboard navigation.
    *
    * @param workspace The workspace that the plugin will be added to.
+   * @param options Options for plugin
+   * @param options.allowCrossWorkspacePaste If true, will allow paste
+   * option to appear enabled when pasting in a different workspace
+   * than was copied from. Defaults to false. Set to true if using
+   * cross-tab-copy-paste plugin or similar.
    */
-  constructor(workspace: Blockly.WorkspaceSvg) {
+  constructor(
+    workspace: Blockly.WorkspaceSvg,
+    options: {allowCrossWorkspacePaste: boolean} = {
+      allowCrossWorkspacePaste: false,
+    },
+  ) {
     this.workspace = workspace;
 
-    this.navigationController = new NavigationController();
+    this.navigationController = new NavigationController(options);
     this.navigationController.init();
     this.navigationController.addWorkspace(workspace);
     this.navigationController.enable(workspace);

--- a/src/navigation_controller.ts
+++ b/src/navigation_controller.ts
@@ -58,7 +58,7 @@ export class NavigationController {
   /** Keyboard shortcut for disconnection. */
   disconnectAction: DisconnectAction = new DisconnectAction(this.navigation);
 
-  clipboard: Clipboard = new Clipboard(this.navigation);
+  clipboard: Clipboard;
 
   duplicateAction = new DuplicateAction();
 
@@ -74,6 +74,14 @@ export class NavigationController {
   actionMenu: ActionMenu = new ActionMenu(this.navigation);
 
   moveActions = new MoveActions(this.mover);
+
+  constructor(
+    private options: {allowCrossWorkspacePaste: boolean} = {
+      allowCrossWorkspacePaste: false,
+    },
+  ) {
+    this.clipboard = new Clipboard(this.navigation, options);
+  }
 
   /**
    * Original Toolbox.prototype.onShortcut method, saved by

--- a/src/navigation_controller.ts
+++ b/src/navigation_controller.ts
@@ -75,7 +75,7 @@ export class NavigationController {
   actionMenu: ActionMenu = new ActionMenu(this.navigation);
 
   moveActions = new MoveActions(this.mover);
-  
+
   stackNavigationAction: StackNavigationAction = new StackNavigationAction();
 
   constructor(

--- a/test/webdriverio/test/actions_test.ts
+++ b/test/webdriverio/test/actions_test.ts
@@ -86,14 +86,12 @@ suite('Menus test', function () {
             {'disabled': true, 'text': 'Move Block M'},
             {'disabled': true, 'text': 'Cut ⌘ X'},
             {'text': 'Copy ⌘ C'},
-            {'disabled': true, 'text': 'Paste ⌘ V'},
           ]
         : [
             {'text': 'Help'},
             {'disabled': true, 'text': 'Move Block M'},
             {'disabled': true, 'text': 'Cut Ctrl + X'},
             {'text': 'Copy Ctrl + C'},
-            {'disabled': true, 'text': 'Paste Ctrl + V'},
           ],
       await contextMenuItems(this.browser),
     );


### PR DESCRIPTION
Fixes #615 

- Removes the `copyWorkspace` property from the clipboard actions. This is now (once again) tracked in core for the default copy/paste implementation, and having it here was incorrect for the cross-tab-copy-paste implementation.
- By default, the "paste" option in the context menu will be greyed out if you try to paste in a workspace that does not match the one that was copied from. This is because if you use the default implementation of copy/paste from core, you will always paste into the workspace that was copied from, and it would be confusing if you selected the "paste" option in workspace B but a block appeared in workspace A.
- If a developer has enabled an alternate implementation of copy/paste, such as that provided by `@blockly/plugin-cross-tab-copy-paste`, then they can pass an option upon initializing the plugin that makes the option not appear greyed out in these cases.
- Updates the readme with this information

Tested with vanilla blockly and with the cross-tab-copy-paste plugin.

Note to reviewer: I rearranged the code in clipboard.ts because it was in an order that was driving me nuts. If you view this PR commit-wise it will be easier to review.