### PR TITLE
feat!: use blockly v12.2.0

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@blockly/keyboard-navigation",
-  "version": "1.0.0",
+  "version": "2.0.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@blockly/keyboard-navigation",
-      "version": "1.0.0",
+      "version": "2.0.0",
       "license": "Apache-2.0",
       "devDependencies": {
         "@blockly/dev-scripts": "^4.0.8",
@@ -18,7 +18,7 @@
         "@types/p5": "^1.7.6",
         "@typescript-eslint/eslint-plugin": "^6.7.2",
         "@typescript-eslint/parser": "^6.7.2",
-        "blockly": "^12.1.0",
+        "blockly": "^12.2.0",
         "chai": "^5.2.0",
         "eslint": "^8.49.0",
         "eslint-config-google": "^0.14.0",
@@ -3062,9 +3062,9 @@
       }
     },
     "node_modules/blockly": {
-      "version": "12.1.0",
-      "resolved": "https://registry.npmjs.org/blockly/-/blockly-12.1.0.tgz",
-      "integrity": "sha512-J9OMcMVR1HaqqRf3WJJpLBUHh4hy3Ma7JQoMZruRH7evS3kxrihHodVFOuqQzRvHtBtTtcQjzVLZog+0vpB58g==",
+      "version": "12.2.0",
+      "resolved": "https://registry.npmjs.org/blockly/-/blockly-12.2.0.tgz",
+      "integrity": "sha512-s4QL9ogEMzc4Pxfe8Oi3Kmu6SQ0ts2thzmRYjdnMSEIVZFpBZ4OUuNKvpFICqujO0yfAo99zON8KzxAFw8hA1w==",
       "dev": true,
       "dependencies": {
         "jsdom": "26.1.0"

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@blockly/keyboard-navigation",
-  "version": "1.0.0",
+  "version": "2.0.0",
   "description": "A plugin for keyboard navigation.",
   "scripts": {
     "audit:fix": "blockly-scripts auditFix",
@@ -57,7 +57,7 @@
     "@types/p5": "^1.7.6",
     "@typescript-eslint/eslint-plugin": "^6.7.2",
     "@typescript-eslint/parser": "^6.7.2",
-    "blockly": "^12.1.0",
+    "blockly": "^12.2.0",
     "chai": "^5.2.0",
     "eslint": "^8.49.0",
     "eslint-config-google": "^0.14.0",
@@ -73,7 +73,7 @@
     "webdriverio": "^9.12.1"
   },
   "peerDependencies": {
-    "blockly": "^12.1.0"
+    "blockly": "^12.2.0"
   },
   "publishConfig": {
     "access": "public",


### PR DESCRIPTION
- Update minimum version of Blockly to v12.2.0, which is a breaking change
- Update version number of plugin to v2.0.0
