### PR TITLE
test: Make tests faster, more robust, more consistent

### DIFF
--- a/test/webdriverio/test/actions_test.ts
+++ b/test/webdriverio/test/actions_test.ts
@@ -14,6 +14,7 @@ import {
   tabNavigateToWorkspace,
   testFileLocations,
   testSetup,
+  sendKeyAndWait,
   keyRight,
   contextMenuItems,
 } from './test_setup.js';
@@ -30,8 +31,7 @@ suite('Menus test', function () {
     await tabNavigateToWorkspace(this.browser);
     await focusOnBlock(this.browser, 'draw_circle_1');
     await this.browser.pause(PAUSE_TIME);
-    await this.browser.keys([Key.Ctrl, Key.Return]);
-    await this.browser.pause(PAUSE_TIME);
+    await sendKeyAndWait(this.browser, [Key.Ctrl, Key.Return]);
 
     chai.assert.deepEqual(
       process.platform === 'darwin'
@@ -73,8 +73,7 @@ suite('Menus test', function () {
     await moveToToolboxCategory(this.browser, 'Functions');
     // Move to flyout.
     await keyRight(this.browser);
-    await this.browser.keys([Key.Ctrl, Key.Return]);
-    await this.browser.pause(PAUSE_TIME);
+    await sendKeyAndWait(this.browser, [Key.Ctrl, Key.Return]);
 
     chai.assert.deepEqual(
       process.platform === 'darwin'
@@ -97,9 +96,8 @@ suite('Menus test', function () {
   test('Menu on workspace', async function () {
     // Navigate to draw_circle_1.
     await tabNavigateToWorkspace(this.browser);
-    await this.browser.keys('w');
-    await this.browser.keys([Key.Ctrl, Key.Return]);
-    await this.browser.pause(PAUSE_TIME);
+    await sendKeyAndWait(this.browser, 'w');
+    await sendKeyAndWait(this.browser, [Key.Ctrl, Key.Return]);
 
     chai.assert.deepEqual(
       process.platform === 'darwin'
@@ -132,9 +130,9 @@ suite('Menus test', function () {
     await tabNavigateToWorkspace(this.browser);
     await focusOnBlock(this.browser, 'draw_circle_1');
     // Start moving the block
-    await this.browser.keys('m');
-    await this.browser.keys([Key.Ctrl, Key.Return]);
-    await this.browser.pause(PAUSE_TIME);
+    await sendKeyAndWait(this.browser, 'm');
+    await sendKeyAndWait(this.browser, [Key.Ctrl, Key.Return]);
+
     chai.assert.isTrue(
       await contextMenuExists(this.browser, 'Collapse Block', true),
       'The menu should not be openable during a move',

--- a/test/webdriverio/test/actions_test.ts
+++ b/test/webdriverio/test/actions_test.ts
@@ -19,9 +19,6 @@ import {
 } from './test_setup.js';
 
 suite('Menus test', function () {
-  // Setting timeout to unlimited as these tests take longer time to run
-  this.timeout(0);
-
   // Clear the workspace and load start blocks
   setup(async function () {
     this.browser = await testSetup(testFileLocations.BASE);

--- a/test/webdriverio/test/basic_test.ts
+++ b/test/webdriverio/test/basic_test.ts
@@ -28,7 +28,7 @@ suite('Keyboard navigation on Blocks', function () {
   // Setting timeout to unlimited as these tests take a longer time to run than most mocha test
   this.timeout(0);
 
-  // Setup Selenium for all of the tests
+  // Clear the workspace and load start blocks.
   suiteSetup(async function () {
     this.browser = await testSetup(testFileLocations.NAVIGATION_TEST_BLOCKS);
   });
@@ -255,7 +255,7 @@ suite('Keyboard navigation on Fields', function () {
   // Setting timeout to unlimited as these tests take a longer time to run than most mocha test
   this.timeout(0);
 
-  // Setup Selenium for all of the tests
+  // Clear the workspace and load start blocks.
   suiteSetup(async function () {
     this.browser = await testSetup(testFileLocations.NAVIGATION_TEST_BLOCKS);
   });

--- a/test/webdriverio/test/basic_test.ts
+++ b/test/webdriverio/test/basic_test.ts
@@ -25,9 +25,6 @@ import {
 import {Key} from 'webdriverio';
 
 suite('Keyboard navigation on Blocks', function () {
-  // Setting timeout to unlimited as these tests take a longer time to run than most mocha test
-  this.timeout(0);
-
   // Clear the workspace and load start blocks.
   suiteSetup(async function () {
     this.browser = await testSetup(testFileLocations.NAVIGATION_TEST_BLOCKS);
@@ -252,9 +249,6 @@ suite('Keyboard navigation on Blocks', function () {
 });
 
 suite('Keyboard navigation on Fields', function () {
-  // Setting timeout to unlimited as these tests take a longer time to run than most mocha test
-  this.timeout(0);
-
   // Clear the workspace and load start blocks.
   suiteSetup(async function () {
     this.browser = await testSetup(testFileLocations.NAVIGATION_TEST_BLOCKS);

--- a/test/webdriverio/test/basic_test.ts
+++ b/test/webdriverio/test/basic_test.ts
@@ -16,6 +16,7 @@ import {
   testSetup,
   testFileLocations,
   PAUSE_TIME,
+  sendKeyAndWait,
   tabNavigateToWorkspace,
   keyLeft,
   keyRight,
@@ -236,13 +237,11 @@ suite('Keyboard navigation on Blocks', function () {
     await tabNavigateToWorkspace(this.browser);
     await this.browser.pause(PAUSE_TIME);
     await focusOnBlock(this.browser, 'text_print_1');
-    await this.browser.keys('m');
-    await this.browser.pause(PAUSE_TIME);
+    await sendKeyAndWait(this.browser, 'm');
 
     chai.assert.isTrue(await isDragging(this.browser));
 
-    await this.browser.keys(Key.Tab);
-    await this.browser.pause(PAUSE_TIME);
+    await sendKeyAndWait(this.browser, Key.Tab);
 
     chai.assert.isFalse(await isDragging(this.browser));
   });
@@ -348,8 +347,7 @@ suite('Keyboard navigation on Fields', function () {
     // Open a field editor dropdown
     await focusOnBlockField(this.browser, 'logic_boolean_1', 'BOOL');
     await this.browser.pause(PAUSE_TIME);
-    await this.browser.keys(Key.Enter);
-    await this.browser.pause(PAUSE_TIME);
+    await sendKeyAndWait(this.browser, Key.Enter);
 
     // Try to navigate to a different block
     await keyRight(this.browser);
@@ -362,13 +360,12 @@ suite('Keyboard navigation on Fields', function () {
     // Open colour picker
     await focusOnBlockField(this.browser, 'colour_picker_1', 'COLOUR');
     await this.browser.pause(PAUSE_TIME);
-    await this.browser.keys(Key.Enter);
-    await this.browser.pause(PAUSE_TIME);
+    await sendKeyAndWait(this.browser, Key.Enter);
 
     // Move right to pick a new colour.
     await keyRight(this.browser);
     // Enter to choose.
-    await this.browser.keys(Key.Enter);
+    await sendKeyAndWait(this.browser, Key.Enter);
 
     // Focus seems to take longer than a single pause to settle.
     await this.browser.waitUntil(

--- a/test/webdriverio/test/clipboard_test.ts
+++ b/test/webdriverio/test/clipboard_test.ts
@@ -21,9 +21,6 @@ import {
 import {Key, KeyAction, PointerAction, WheelAction} from 'webdriverio';
 
 suite('Clipboard test', function () {
-  // Setting timeout to unlimited as these tests take longer time to run
-  this.timeout(0);
-
   // Clear the workspace and load start blocks
   setup(async function () {
     this.browser = await testSetup(testFileLocations.BASE);

--- a/test/webdriverio/test/clipboard_test.ts
+++ b/test/webdriverio/test/clipboard_test.ts
@@ -17,6 +17,7 @@ import {
   focusOnBlock,
   focusOnBlockField,
   blockIsPresent,
+  sendKeyAndWait,
 } from './test_setup.js';
 import {Key, KeyAction, PointerAction, WheelAction} from 'webdriverio';
 
@@ -33,9 +34,8 @@ suite('Clipboard test', function () {
     await focusOnBlock(this.browser, 'draw_circle_1');
 
     // Copy and paste
-    await this.browser.keys([Key.Ctrl, 'c']);
-    await this.browser.keys([Key.Ctrl, 'v']);
-    await this.browser.pause(PAUSE_TIME);
+    await sendKeyAndWait(this.browser, [Key.Ctrl, 'c']);
+    await sendKeyAndWait(this.browser, [Key.Ctrl, 'v']);
 
     const block = await getBlockElementById(this.browser, 'draw_circle_1');
     const blocks = await getSameBlocks(this.browser, block);
@@ -55,9 +55,9 @@ suite('Clipboard test', function () {
     const block = await getBlockElementById(this.browser, 'draw_circle_1');
 
     // Cut and paste
-    await this.browser.keys([Key.Ctrl, 'x']);
+    await sendKeyAndWait(this.browser, [Key.Ctrl, 'x']);
     await block.waitForExist({reverse: true});
-    await this.browser.keys([Key.Ctrl, 'v']);
+    await sendKeyAndWait(this.browser, [Key.Ctrl, 'v']);
     await block.waitForExist();
     await this.browser.pause(PAUSE_TIME);
 
@@ -115,11 +115,10 @@ suite('Clipboard test', function () {
     // Open a field editor
     await focusOnBlockField(this.browser, 'draw_circle_1_color', 'COLOUR');
     await this.browser.pause(PAUSE_TIME);
-    await this.browser.keys(Key.Enter);
-    await this.browser.pause(PAUSE_TIME);
+    await sendKeyAndWait(this.browser, Key.Enter);
 
     // Try to cut block while field editor is open
-    await this.browser.keys([Key.Ctrl, 'x']);
+    await sendKeyAndWait(this.browser, [Key.Ctrl, 'x']);
 
     // Block is not deleted
     chai.assert.isTrue(

--- a/test/webdriverio/test/delete_test.ts
+++ b/test/webdriverio/test/delete_test.ts
@@ -15,6 +15,7 @@ import {
   testFileLocations,
   PAUSE_TIME,
   tabNavigateToWorkspace,
+  sendKeyAndWait,
   keyRight,
   focusOnBlockField,
 } from './test_setup.js';
@@ -36,8 +37,7 @@ suite('Deleting Blocks', function () {
       .expect(await blockIsPresent(this.browser, 'controls_if_2'))
       .equal(true);
 
-    await this.browser.keys(Key.Backspace);
-    await this.browser.pause(PAUSE_TIME);
+    await sendKeyAndWait(this.browser, Key.Backspace);
 
     chai
       .expect(await blockIsPresent(this.browser, 'controls_if_2'))
@@ -58,8 +58,7 @@ suite('Deleting Blocks', function () {
       .expect(await blockIsPresent(this.browser, 'controls_if_2'))
       .equal(true);
 
-    await this.browser.keys([Key.Ctrl, 'x']);
-    await this.browser.pause(PAUSE_TIME);
+    await sendKeyAndWait(this.browser, [Key.Ctrl, 'x']);
 
     chai
       .expect(await blockIsPresent(this.browser, 'controls_if_2'))
@@ -81,8 +80,7 @@ suite('Deleting Blocks', function () {
       .equal(true);
     chai.expect(await blockIsPresent(this.browser, 'text_print_1')).equal(true);
 
-    await this.browser.keys(Key.Backspace);
-    await this.browser.pause(PAUSE_TIME);
+    await sendKeyAndWait(this.browser, Key.Backspace);
 
     chai
       .expect(await blockIsPresent(this.browser, 'logic_boolean_1'))
@@ -103,8 +101,7 @@ suite('Deleting Blocks', function () {
       .equal(true);
     chai.expect(await blockIsPresent(this.browser, 'text_print_1')).equal(true);
 
-    await this.browser.keys([Key.Ctrl, 'x']);
-    await this.browser.pause(PAUSE_TIME);
+    await sendKeyAndWait(this.browser, [Key.Ctrl, 'x']);
 
     chai
       .expect(await blockIsPresent(this.browser, 'logic_boolean_1'))
@@ -124,8 +121,7 @@ suite('Deleting Blocks', function () {
       .expect(await blockIsPresent(this.browser, 'logic_boolean_1'))
       .equal(true);
 
-    await this.browser.keys(Key.Backspace);
-    await this.browser.pause(PAUSE_TIME);
+    await sendKeyAndWait(this.browser, Key.Backspace);
 
     chai
       .expect(await blockIsPresent(this.browser, 'logic_boolean_1'))
@@ -146,8 +142,7 @@ suite('Deleting Blocks', function () {
       .expect(await blockIsPresent(this.browser, 'logic_boolean_1'))
       .equal(true);
 
-    await this.browser.keys([Key.Ctrl, 'x']);
-    await this.browser.pause(PAUSE_TIME);
+    await sendKeyAndWait(this.browser, [Key.Ctrl, 'x']);
 
     chai
       .expect(await blockIsPresent(this.browser, 'logic_boolean_1'))
@@ -173,16 +168,13 @@ suite('Deleting Blocks', function () {
     // Move to flyout.
     await keyRight(this.browser);
     // Select number block.
-    await this.browser.keys(Key.Enter);
-    await this.browser.pause(PAUSE_TIME);
+    await sendKeyAndWait(this.browser, Key.Enter);
     // Confirm move.
-    await this.browser.keys(Key.Enter);
-    await this.browser.pause(PAUSE_TIME);
+    await sendKeyAndWait(this.browser, Key.Enter);
 
     chai.assert.equal('math_number', await getFocusedBlockType(this.browser));
 
-    await this.browser.keys(Key.Backspace);
-    await this.browser.pause(PAUSE_TIME);
+    await sendKeyAndWait(this.browser, Key.Backspace);
 
     chai.assert.equal(
       await getCurrentFocusedBlockId(this.browser),
@@ -200,16 +192,13 @@ suite('Deleting Blocks', function () {
     // Move to flyout.
     await keyRight(this.browser);
     // Select number block.
-    await this.browser.keys(Key.Enter);
-    await this.browser.pause(PAUSE_TIME);
+    await sendKeyAndWait(this.browser, Key.Enter);
     // Confirm move.
-    await this.browser.keys(Key.Enter);
-    await this.browser.pause(PAUSE_TIME);
+    await sendKeyAndWait(this.browser, Key.Enter);
 
     chai.assert.equal('math_number', await getFocusedBlockType(this.browser));
 
-    await this.browser.keys([Key.Ctrl, 'x']);
-    await this.browser.pause(PAUSE_TIME);
+    await sendKeyAndWait(this.browser, [Key.Ctrl, 'x']);
 
     chai.assert.equal(
       await getCurrentFocusedBlockId(this.browser),
@@ -221,11 +210,10 @@ suite('Deleting Blocks', function () {
     // Open a field editor
     await focusOnBlockField(this.browser, 'colour_picker_1', 'COLOUR');
     await this.browser.pause(PAUSE_TIME);
-    await this.browser.keys(Key.Enter);
-    await this.browser.pause(PAUSE_TIME);
+    await sendKeyAndWait(this.browser, Key.Enter);
 
     // Try to delete block while field editor is open
-    await this.browser.keys(Key.Backspace);
+    await sendKeyAndWait(this.browser, Key.Backspace);
 
     // Block is not deleted
     chai.assert.isTrue(await blockIsPresent(this.browser, 'colour_picker_1'));

--- a/test/webdriverio/test/delete_test.ts
+++ b/test/webdriverio/test/delete_test.ts
@@ -21,9 +21,6 @@ import {
 import {Key} from 'webdriverio';
 
 suite('Deleting Blocks', function () {
-  // Setting timeout to unlimited as these tests take a longer time to run than most mocha test
-  this.timeout(0);
-
   setup(async function () {
     this.browser = await testSetup(testFileLocations.NAVIGATION_TEST_BLOCKS);
     await this.browser.pause(PAUSE_TIME);

--- a/test/webdriverio/test/duplicate_test.ts
+++ b/test/webdriverio/test/duplicate_test.ts
@@ -14,6 +14,7 @@ import {
   tabNavigateToWorkspace,
   testFileLocations,
   testSetup,
+  sendKeyAndWait,
 } from './test_setup.js';
 
 suite('Duplicate test', function () {
@@ -29,8 +30,7 @@ suite('Duplicate test', function () {
     await focusOnBlock(this.browser, 'draw_circle_1');
 
     // Duplicate
-    await this.browser.keys('d');
-    await this.browser.pause(PAUSE_TIME);
+    await sendKeyAndWait(this.browser, 'd');
 
     // Check a different block of the same type has focus.
     chai.assert.notEqual(
@@ -62,7 +62,7 @@ suite('Duplicate test', function () {
     await this.browser.pause(PAUSE_TIME);
 
     // Duplicate.
-    await this.browser.keys('d');
+    await sendKeyAndWait(this.browser, 'd');
 
     // Assert we have two comments with the same text.
     const commentTexts = await this.browser.execute(() =>

--- a/test/webdriverio/test/duplicate_test.ts
+++ b/test/webdriverio/test/duplicate_test.ts
@@ -17,9 +17,6 @@ import {
 } from './test_setup.js';
 
 suite('Duplicate test', function () {
-  // Setting timeout to unlimited as these tests take longer time to run
-  this.timeout(0);
-
   // Clear the workspace and load start blocks
   setup(async function () {
     this.browser = await testSetup(testFileLocations.BASE);

--- a/test/webdriverio/test/flyout_test.ts
+++ b/test/webdriverio/test/flyout_test.ts
@@ -14,6 +14,7 @@ import {
   keyDown,
   tabNavigateBackward,
   tabNavigateToWorkspace,
+  sendKeyAndWait,
   keyRight,
   getCurrentFocusNodeId,
   getCurrentFocusedBlockId,
@@ -164,7 +165,7 @@ suite('Toolbox and flyout test', function () {
   test('Tabbing to the workspace after selecting flyout block via workspace toolbox shortcut should close the flyout', async function () {
     await tabNavigateToWorkspace(this.browser);
 
-    await this.browser.keys('t');
+    await sendKeyAndWait(this.browser, 't');
     await keyRight(this.browser);
     await tabNavigateForward(this.browser);
 

--- a/test/webdriverio/test/insert_test.ts
+++ b/test/webdriverio/test/insert_test.ts
@@ -14,6 +14,7 @@ import {
   tabNavigateToWorkspace,
   testFileLocations,
   testSetup,
+  sendKeyAndWait,
   keyRight,
   getCurrentFocusedBlockId,
   blockIsPresent,
@@ -33,15 +34,15 @@ suite('Insert test', function () {
     await tabNavigateToWorkspace(this.browser);
     await focusOnBlock(this.browser, 'draw_circle_1');
     // Insert 'if' block
-    await this.browser.keys('t');
+    await sendKeyAndWait(this.browser, 't');
     await keyRight(this.browser);
-    await this.browser.keys(Key.Enter);
+    await sendKeyAndWait(this.browser, Key.Enter);
     chai.assert.equal('controls_if', await getFocusedBlockType(this.browser));
     const ifId = await getCurrentFocusedBlockId(this.browser);
     chai.assert.ok(ifId);
 
     // Cancel
-    await this.browser.keys(Key.Escape);
+    await sendKeyAndWait(this.browser, Key.Escape);
 
     chai.assert.isFalse(await blockIsPresent(this.browser, ifId));
   });
@@ -49,17 +50,17 @@ suite('Insert test', function () {
   test('Insert and cancel with workspace selection', async function () {
     // Navigate to workspace.
     await tabNavigateToWorkspace(this.browser);
-    await this.browser.keys('w');
+    await sendKeyAndWait(this.browser, 'w');
     // Insert 'if' block
-    await this.browser.keys('t');
+    await sendKeyAndWait(this.browser, 't');
     await keyRight(this.browser);
-    await this.browser.keys(Key.Enter);
+    await sendKeyAndWait(this.browser, Key.Enter);
     chai.assert.equal('controls_if', await getFocusedBlockType(this.browser));
     const ifId = await getCurrentFocusedBlockId(this.browser);
     chai.assert.ok(ifId);
 
     // Cancel
-    await this.browser.keys(Key.Escape);
+    await sendKeyAndWait(this.browser, Key.Escape);
 
     chai.assert.isFalse(await blockIsPresent(this.browser, ifId));
   });
@@ -73,9 +74,9 @@ suite('Insert test', function () {
     // Move to flyout.
     await keyRight(this.browser);
     // Select Function block.
-    await this.browser.keys(Key.Enter);
+    await sendKeyAndWait(this.browser, Key.Enter);
     // Confirm move.
-    await this.browser.keys(Key.Enter);
+    await sendKeyAndWait(this.browser, Key.Enter);
 
     chai.assert.equal(
       'procedures_defnoreturn',
@@ -89,9 +90,9 @@ suite('Insert test', function () {
     // Insert 'if' block
     await keyRight(this.browser);
     // Choose.
-    await this.browser.keys(Key.Enter);
+    await sendKeyAndWait(this.browser, Key.Enter);
     // Confirm position.
-    await this.browser.keys(Key.Enter);
+    await sendKeyAndWait(this.browser, Key.Enter);
 
     // Assert inserted inside first block p5_setup not at top-level.
     chai.assert.equal('controls_if', await getFocusedBlockType(this.browser));

--- a/test/webdriverio/test/insert_test.ts
+++ b/test/webdriverio/test/insert_test.ts
@@ -22,9 +22,6 @@ import {
 } from './test_setup.js';
 
 suite('Insert test', function () {
-  // Setting timeout to unlimited as these tests take longer time to run
-  this.timeout(0);
-
   // Clear the workspace and load start blocks
   setup(async function () {
     this.browser = await testSetup(testFileLocations.BASE);

--- a/test/webdriverio/test/keyboard_mode_test.ts
+++ b/test/webdriverio/test/keyboard_mode_test.ts
@@ -15,6 +15,7 @@ import {
   tabNavigateToWorkspace,
   clickBlock,
   contextMenuItems,
+  sendKeyAndWait,
 } from './test_setup.js';
 import {Key} from 'webdriverio';
 
@@ -44,8 +45,7 @@ suite(
 
     test('T to open toolbox enables keyboard mode', async function () {
       await this.browser.pause(PAUSE_TIME);
-      await this.browser.keys('t');
-      await this.browser.pause(PAUSE_TIME);
+      await sendKeyAndWait(this.browser, 't');
 
       chai.assert.isTrue(await isKeyboardNavigating(this.browser));
     });
@@ -53,15 +53,14 @@ suite(
     test('M for move mode enables keyboard mode', async function () {
       await focusOnBlock(this.browser, 'controls_if_2');
       await this.browser.pause(PAUSE_TIME);
-      await this.browser.keys('m');
+      await sendKeyAndWait(this.browser, 'm');
 
       chai.assert.isTrue(await isKeyboardNavigating(this.browser));
     });
 
     test('W for workspace cursor enables keyboard mode', async function () {
       await this.browser.pause(PAUSE_TIME);
-      await this.browser.keys('w');
-      await this.browser.pause(PAUSE_TIME);
+      await sendKeyAndWait(this.browser, 'w');
 
       chai.assert.isTrue(await isKeyboardNavigating(this.browser));
     });
@@ -69,8 +68,7 @@ suite(
     test('X to disconnect enables keyboard mode', async function () {
       await focusOnBlock(this.browser, 'controls_if_2');
       await this.browser.pause(PAUSE_TIME);
-      await this.browser.keys('x');
-      await this.browser.pause(PAUSE_TIME);
+      await sendKeyAndWait(this.browser, 'x');
 
       chai.assert.isTrue(await isKeyboardNavigating(this.browser));
     });
@@ -79,8 +77,7 @@ suite(
       // Make sure we're on a copyable block so that copy occurs
       await focusOnBlock(this.browser, 'controls_if_2');
       await this.browser.pause(PAUSE_TIME);
-      await this.browser.keys([Key.Ctrl, 'c']);
-      await this.browser.pause(PAUSE_TIME);
+      await sendKeyAndWait(this.browser, [Key.Ctrl, 'c']);
 
       chai.assert.isFalse(await isKeyboardNavigating(this.browser));
 
@@ -89,8 +86,7 @@ suite(
       });
 
       await this.browser.pause(PAUSE_TIME);
-      await this.browser.keys([Key.Ctrl, 'c']);
-      await this.browser.pause(PAUSE_TIME);
+      await sendKeyAndWait(this.browser, [Key.Ctrl, 'c']);
 
       chai.assert.isTrue(await isKeyboardNavigating(this.browser));
     });
@@ -99,8 +95,7 @@ suite(
       // Make sure we're on a deletable block so that delete occurs
       await focusOnBlock(this.browser, 'controls_if_2');
       await this.browser.pause(PAUSE_TIME);
-      await this.browser.keys(Key.Backspace);
-      await this.browser.pause(PAUSE_TIME);
+      await sendKeyAndWait(this.browser, Key.Backspace);
 
       chai.assert.isFalse(await isKeyboardNavigating(this.browser));
 
@@ -111,8 +106,7 @@ suite(
       // Focus a different deletable block
       await focusOnBlock(this.browser, 'controls_if_1');
       await this.browser.pause(PAUSE_TIME);
-      await this.browser.keys(Key.Backspace);
-      await this.browser.pause(PAUSE_TIME);
+      await sendKeyAndWait(this.browser, Key.Backspace);
 
       chai.assert.isTrue(await isKeyboardNavigating(this.browser));
     });

--- a/test/webdriverio/test/keyboard_mode_test.ts
+++ b/test/webdriverio/test/keyboard_mode_test.ts
@@ -14,6 +14,7 @@ import {
   getBlockElementById,
   tabNavigateToWorkspace,
   clickBlock,
+  contextMenuItems,
 } from './test_setup.js';
 import {Key} from 'webdriverio';
 
@@ -124,7 +125,8 @@ suite(
       await this.browser.pause(PAUSE_TIME);
       // Right click a block
       clickBlock(this.browser, 'controls_if_1', {button: 'right'});
-      await this.browser.pause(PAUSE_TIME);
+      // Wait for context menu to appear.
+      await contextMenuItems(this.browser);
 
       chai.assert.isFalse(await isKeyboardNavigating(this.browser));
     });

--- a/test/webdriverio/test/keyboard_mode_test.ts
+++ b/test/webdriverio/test/keyboard_mode_test.ts
@@ -26,9 +26,6 @@ const isKeyboardNavigating = function (browser: WebdriverIO.Browser) {
 suite(
   'Keyboard navigation mode set on mouse or keyboard interaction',
   function () {
-    // Setting timeout to unlimited as these tests take a longer time to run than most mocha tests
-    this.timeout(0);
-
     setup(async function () {
       // Reload the page between tests
       this.browser = await testSetup(testFileLocations.NAVIGATION_TEST_BLOCKS);

--- a/test/webdriverio/test/move_test.ts
+++ b/test/webdriverio/test/move_test.ts
@@ -18,9 +18,6 @@ import {
 } from './test_setup.js';
 
 suite('Move tests', function () {
-  // Setting timeout to unlimited as these tests take longer time to run
-  this.timeout(0);
-
   // Clear the workspace and load start blocks
   setup(async function () {
     this.browser = await testSetup(testFileLocations.MOVE_TEST_BLOCKS);

--- a/test/webdriverio/test/move_test.ts
+++ b/test/webdriverio/test/move_test.ts
@@ -47,7 +47,7 @@ suite('Move tests', function () {
       chai.assert(info.nextId, 'selected block has no next block');
 
       // Start move.
-      await this.browser.keys('m');
+      await sendKeyAndWait(this.browser, 'm');
 
       // Check that the moving block has nothing connected it its
       // next/previous connections, and same thing connected to value
@@ -82,7 +82,7 @@ suite('Move tests', function () {
       );
 
       // Abort move.
-      await this.browser.keys(Key.Escape);
+      await sendKeyAndWait(this.browser, Key.Escape);
     }
   });
 
@@ -107,7 +107,7 @@ suite('Move tests', function () {
       chai.assert(info.valueId, 'selected block has no child value block');
 
       // Start move.
-      await this.browser.keys('m');
+      await sendKeyAndWait(this.browser, 'm');
 
       // Check that the moving block has nothing connected it its
       // next/previous connections, and same thing connected to value
@@ -141,7 +141,7 @@ suite('Move tests', function () {
       );
 
       // Abort move.
-      await this.browser.keys(Key.Escape);
+      await sendKeyAndWait(this.browser, Key.Escape);
     }
   });
 
@@ -165,7 +165,7 @@ suite('Move tests', function () {
     await tabNavigateToWorkspace(this.browser);
     await focusOnBlock(this.browser, BLOCK);
     const startCoordinate = await getCoordinate(this.browser, BLOCK);
-    await this.browser.keys('m');
+    await sendKeyAndWait(this.browser, 'm');
 
     // Check constrained moves have no effect.
     await keyDown(this.browser, 5);
@@ -198,7 +198,7 @@ suite('Move tests', function () {
     }
 
     // Abort move.
-    await this.browser.keys(Key.Escape);
+    await sendKeyAndWait(this.browser, Key.Escape);
   });
 });
 

--- a/test/webdriverio/test/mutator_test.ts
+++ b/test/webdriverio/test/mutator_test.ts
@@ -21,9 +21,6 @@ import {
 import {Key} from 'webdriverio';
 
 suite('Mutator navigation', function () {
-  // Setting timeout to unlimited as these tests take a longer time to run than most mocha test
-  this.timeout(0);
-
   // Clear the workspace and load start blocks.
   setup(async function () {
     this.browser = await testSetup(testFileLocations.NAVIGATION_TEST_BLOCKS);

--- a/test/webdriverio/test/mutator_test.ts
+++ b/test/webdriverio/test/mutator_test.ts
@@ -15,6 +15,7 @@ import {
   testFileLocations,
   PAUSE_TIME,
   tabNavigateToWorkspace,
+  sendKeyAndWait,
   keyRight,
   keyDown,
 } from './test_setup.js';
@@ -32,8 +33,7 @@ suite('Mutator navigation', function () {
       // Navigate to the mutator icon
       await keyRight(this.browser);
       // Activate the icon
-      await this.browser.keys(Key.Enter);
-      await this.browser.pause(PAUSE_TIME);
+      await sendKeyAndWait(this.browser, Key.Enter);
     };
   });
 
@@ -51,8 +51,7 @@ suite('Mutator navigation', function () {
 
   test('Escape dismisses mutator', async function () {
     await this.openMutator();
-    await this.browser.keys(Key.Escape);
-    await this.browser.pause(PAUSE_TIME);
+    await sendKeyAndWait(this.browser, Key.Escape);
 
     // Main workspace should be the focused tree (since mutator workspace is gone)
     const mainWorkspaceFocused = await focusedTreeIsMainWorkspace(this.browser);
@@ -72,11 +71,9 @@ suite('Mutator navigation', function () {
   test('Escape in the mutator flyout focuses the mutator workspace', async function () {
     await this.openMutator();
     // Focus the flyout
-    await this.browser.keys('t');
-    await this.browser.pause(PAUSE_TIME);
+    await sendKeyAndWait(this.browser, 't');
     // Hit escape to return focus to the mutator workspace
-    await this.browser.keys(Key.Escape);
-    await this.browser.pause(PAUSE_TIME);
+    await sendKeyAndWait(this.browser, Key.Escape);
     // The "if" placeholder block in the mutator should be focused
     const focusedBlockType = await getFocusedBlockType(this.browser);
     chai.assert.equal(focusedBlockType, 'controls_if_if');
@@ -84,8 +81,7 @@ suite('Mutator navigation', function () {
 
   test('T focuses the mutator flyout', async function () {
     await this.openMutator();
-    await this.browser.keys('t');
-    await this.browser.pause(PAUSE_TIME);
+    await sendKeyAndWait(this.browser, 't');
 
     // The "else if" block in the mutator flyout should be focused
     const focusedBlockType = await getFocusedBlockType(this.browser);
@@ -94,16 +90,14 @@ suite('Mutator navigation', function () {
 
   test('Blocks can be inserted from the mutator flyout', async function () {
     await this.openMutator();
-    await this.browser.keys('t');
-    await this.browser.pause(PAUSE_TIME);
+    await sendKeyAndWait(this.browser, 't');
     // Navigate down to the second block in the flyout
     await keyDown(this.browser);
     await this.browser.pause(PAUSE_TIME);
     // Hit enter to enter insert mode
-    await this.browser.keys(Key.Enter);
-    await this.browser.pause(PAUSE_TIME);
+    await sendKeyAndWait(this.browser, Key.Enter);
     // Hit enter again to lock it into place on the connection
-    await this.browser.keys(Key.Enter);
+    await sendKeyAndWait(this.browser, Key.Enter);
 
     const topBlocks = await this.browser.execute(() => {
       const focusedTree = Blockly.getFocusManager().getFocusedTree();

--- a/test/webdriverio/test/mutator_test.ts
+++ b/test/webdriverio/test/mutator_test.ts
@@ -24,7 +24,7 @@ suite('Mutator navigation', function () {
   // Setting timeout to unlimited as these tests take a longer time to run than most mocha test
   this.timeout(0);
 
-  // Setup Selenium for all of the tests
+  // Clear the workspace and load start blocks.
   setup(async function () {
     this.browser = await testSetup(testFileLocations.NAVIGATION_TEST_BLOCKS);
     this.openMutator = async () => {

--- a/test/webdriverio/test/scroll_test.ts
+++ b/test/webdriverio/test/scroll_test.ts
@@ -20,7 +20,7 @@ suite('Scrolling into view', function () {
   // Setting timeout to unlimited as these tests take longer time to run
   this.timeout(0);
 
-  // Clear the workspace and load start blocks
+  // Clear the workspace and load start blocks.
   setup(async function () {
     this.browser = await testSetup(testFileLocations.BASE);
     // Predictable small window size for scrolling.

--- a/test/webdriverio/test/scroll_test.ts
+++ b/test/webdriverio/test/scroll_test.ts
@@ -8,6 +8,7 @@ import * as Blockly from 'blockly';
 import * as chai from 'chai';
 import {Key} from 'webdriverio';
 import {
+  sendKeyAndWait,
   keyDown,
   keyRight,
   PAUSE_TIME,
@@ -18,7 +19,7 @@ import {
 
 suite('Scrolling into view', function () {
   // Clear the workspace and load start blocks.
-  setup(async function () {
+  suiteSetup(async function () {
     this.browser = await testSetup(testFileLocations.BASE);
     // Predictable small window size for scrolling.
     this.windowSize = await this.browser.getWindowSize()
@@ -26,7 +27,8 @@ suite('Scrolling into view', function () {
     await this.browser.pause(PAUSE_TIME);
   });
 
-  teardown(async function() {
+  suiteTeardown(async function() {
+    // Restore original window size
     await this.browser.setWindowSize(this.windowSize.width, this.windowSize.height);
   });
 
@@ -35,9 +37,9 @@ suite('Scrolling into view', function () {
 
     // Separate the two top-level blocks by moving p5_draw_1 further down.
     await keyDown(this.browser, 3);
-    await this.browser.keys('m');
+    await sendKeyAndWait(this.browser, 'm');
     await this.browser.keys([Key.Alt, ...new Array(25).fill(Key.ArrowDown)]);
-    await this.browser.keys(Key.Enter);
+    await sendKeyAndWait(this.browser, Key.Enter);
     // Scroll back up, leaving cursor on the draw block out of the viewport.
     await this.browser.execute(() => {
       const workspace = Blockly.getMainWorkspace() as Blockly.WorkspaceSvg;
@@ -49,10 +51,9 @@ suite('Scrolling into view', function () {
     });
 
     // Insert and confirm the test block which should be scrolled into view.
-    await this.browser.keys('t');
+    await sendKeyAndWait(this.browser, 't');
     await keyRight(this.browser);
-    await this.browser.keys(Key.Enter);
-    await this.browser.keys(Key.Enter);
+    await sendKeyAndWait(this.browser, Key.Enter, 2);
 
     // Assert new block has been scrolled into the viewport.
     await this.browser.pause(PAUSE_TIME);

--- a/test/webdriverio/test/scroll_test.ts
+++ b/test/webdriverio/test/scroll_test.ts
@@ -22,14 +22,17 @@ suite('Scrolling into view', function () {
   suiteSetup(async function () {
     this.browser = await testSetup(testFileLocations.BASE);
     // Predictable small window size for scrolling.
-    this.windowSize = await this.browser.getWindowSize()
+    this.windowSize = await this.browser.getWindowSize();
     this.browser.setWindowSize(800, 600);
     await this.browser.pause(PAUSE_TIME);
   });
 
-  suiteTeardown(async function() {
+  suiteTeardown(async function () {
     // Restore original window size
-    await this.browser.setWindowSize(this.windowSize.width, this.windowSize.height);
+    await this.browser.setWindowSize(
+      this.windowSize.width,
+      this.windowSize.height,
+    );
   });
 
   test('Insert scrolls new block into view', async function () {

--- a/test/webdriverio/test/scroll_test.ts
+++ b/test/webdriverio/test/scroll_test.ts
@@ -24,8 +24,13 @@ suite('Scrolling into view', function () {
   setup(async function () {
     this.browser = await testSetup(testFileLocations.BASE);
     // Predictable small window size for scrolling.
+    this.windowSize = await this.browser.getWindowSize()
     this.browser.setWindowSize(800, 600);
     await this.browser.pause(PAUSE_TIME);
+  });
+
+  teardown(async function() {
+    await this.browser.setWindowSize(this.windowSize.width, this.windowSize.height);
   });
 
   test('Insert scrolls new block into view', async function () {

--- a/test/webdriverio/test/scroll_test.ts
+++ b/test/webdriverio/test/scroll_test.ts
@@ -17,9 +17,6 @@ import {
 } from './test_setup.js';
 
 suite('Scrolling into view', function () {
-  // Setting timeout to unlimited as these tests take longer time to run
-  this.timeout(0);
-
   // Clear the workspace and load start blocks.
   setup(async function () {
     this.browser = await testSetup(testFileLocations.BASE);

--- a/test/webdriverio/test/stack_navigation.ts
+++ b/test/webdriverio/test/stack_navigation.ts
@@ -18,7 +18,7 @@ suite('Stack navigation', function () {
   // Setting timeout to unlimited as these tests take longer time to run
   this.timeout(0);
 
-  // Clear the workspace and load start blocks
+  // Clear the workspace and load start blocks.
   setup(async function () {
     this.browser = await testSetup(testFileLocations.COMMENTS);
     await this.browser.pause(PAUSE_TIME);

--- a/test/webdriverio/test/stack_navigation.ts
+++ b/test/webdriverio/test/stack_navigation.ts
@@ -15,9 +15,6 @@ import {
 } from './test_setup.js';
 
 suite('Stack navigation', function () {
-  // Setting timeout to unlimited as these tests take longer time to run
-  this.timeout(0);
-
   // Clear the workspace and load start blocks.
   setup(async function () {
     this.browser = await testSetup(testFileLocations.COMMENTS);

--- a/test/webdriverio/test/stack_navigation.ts
+++ b/test/webdriverio/test/stack_navigation.ts
@@ -12,6 +12,7 @@ import {
   tabNavigateToWorkspace,
   testFileLocations,
   testSetup,
+  sendKeyAndWait,
 } from './test_setup.js';
 
 suite('Stack navigation', function () {
@@ -27,17 +28,17 @@ suite('Stack navigation', function () {
       'p5_setup_1',
       await getCurrentFocusedBlockId(this.browser),
     );
-    await this.browser.keys('n');
+    await sendKeyAndWait(this.browser, 'n');
     chai.assert.equal(
       'p5_draw_1',
       await getCurrentFocusedBlockId(this.browser),
     );
-    await this.browser.keys('n');
+    await sendKeyAndWait(this.browser, 'n');
     chai.assert.equal(
       'workspace_comment_1',
       await getCurrentFocusNodeId(this.browser),
     );
-    await this.browser.keys('n');
+    await sendKeyAndWait(this.browser, 'n');
     // Looped around.
     chai.assert.equal(
       'p5_setup_1',
@@ -51,18 +52,18 @@ suite('Stack navigation', function () {
       'p5_setup_1',
       await getCurrentFocusedBlockId(this.browser),
     );
-    await this.browser.keys('b');
+    await sendKeyAndWait(this.browser, 'b');
     // Looped to bottom.
     chai.assert.equal(
       'workspace_comment_1',
       await getCurrentFocusNodeId(this.browser),
     );
-    await this.browser.keys('b');
+    await sendKeyAndWait(this.browser, 'b');
     chai.assert.equal(
       'p5_draw_1',
       await getCurrentFocusedBlockId(this.browser),
     );
-    await this.browser.keys('b');
+    await sendKeyAndWait(this.browser, 'b');
     chai.assert.equal(
       'p5_setup_1',
       await getCurrentFocusedBlockId(this.browser),

--- a/test/webdriverio/test/test_setup.ts
+++ b/test/webdriverio/test/test_setup.ts
@@ -27,10 +27,25 @@ import {fileURLToPath} from 'url';
 let driver: webdriverio.Browser | null = null;
 
 /**
- * The default amount of time to wait during a test. Increase this to make
- * tests easier to watch; decrease it to make tests run faster.
+ * The default amount of time to wait during a test, in ms.  Increase
+ * this to make tests easier to watch; decrease it to make tests run
+ * faster.
+ *
+ * Tests should pass reliably even with this set to zero; use one of
+ * the browser.wait* functions if you need your test to wait for
+ * something to happen after sending input.
+ *
+ * Setting this to values greater than about 50ms is likely to cause
+ * tests to time out; increase the timeout for the test or suite you
+ * are working on with:
+ *
+ *     this.timeout(new_value_great_than_2000ms);
+ *
+ * or disable timeouts completely with:
+ *
+ *     this.timeout(0);
  */
-export const PAUSE_TIME = 50;
+export const PAUSE_TIME = 0;
 
 /**
  * Start up WebdriverIO and load the test page. This should only be

--- a/test/webdriverio/test/test_setup.ts
+++ b/test/webdriverio/test/test_setup.ts
@@ -11,9 +11,9 @@
  * This file is to be used in the suiteSetup for any automated fuctional test.
  *
  * Note: In this file many functions return browser elements that can
- * be clicked or otherwise interacted with through Selenium WebDriver. These
+ * be clicked or otherwise interacted with through WebdriverIO. These
  * elements are not the raw HTML and SVG elements on the page; they are
- * identifiers that Selenium can use to find those elements.
+ * identifiers that WebdriverIO can use to find those elements.
  */
 
 import * as Blockly from 'blockly';
@@ -33,10 +33,12 @@ let driver: webdriverio.Browser | null = null;
 export const PAUSE_TIME = 50;
 
 /**
- * Start up the test page. This should only be done once, to avoid
- * constantly popping browser windows open and closed.
+ * Start up WebdriverIO and load the test page. This should only be
+ * done once, to avoid constantly popping browser windows open and
+ * closed.
  *
- * @returns A Promise that resolves to a webdriverIO browser that tests can manipulate.
+ * @returns A Promise that resolves to a WebdriverIO browser that
+ *     tests can manipulate.
  */
 export async function driverSetup(): Promise<webdriverio.Browser> {
   const options = {
@@ -68,14 +70,14 @@ export async function driverSetup(): Promise<webdriverio.Browser> {
     // https://github.com/google/blockly/issues/5345 for details.
     options.capabilities['goog:chromeOptions'].args.push('--disable-gpu');
   }
-  // Use Selenium to bring up the page
+  // Use webdriver to bring up the page
   console.log('Starting webdriverio...');
   driver = await webdriverio.remote(options);
   return driver;
 }
 
 /**
- * End the webdriverIO session.
+ * End the WebdriverIO session.
  *
  * @return A Promise that resolves after the actions have been completed.
  */
@@ -90,7 +92,8 @@ export async function driverTeardown() {
  *
  * @param playgroundUrl The URL to open for the test, which should be
  *     a Blockly playground with a workspace.
- * @returns A Promise that resolves to a webdriverIO browser that tests can manipulate.
+ * @returns A Promise that resolves to a WebdriverIO browser that
+ *     tests can manipulate.
  */
 export async function testSetup(
   playgroundUrl: string,
@@ -679,7 +682,7 @@ export async function clickBlock(
     findableId,
   );
 
-  // In the test context, get the Webdriverio Element that we've identified.
+  // In the test context, get the WebdriverIO Element that we've identified.
   const elem = await browser.$(`#${findableId}`);
 
   await elem.click(clickOptions);

--- a/test/webdriverio/test/workspace_comment_test.ts
+++ b/test/webdriverio/test/workspace_comment_test.ts
@@ -24,9 +24,6 @@ import {
 import {Key} from 'webdriverio';
 
 suite('Workspace comment navigation', function () {
-  // Setting timeout to unlimited as these tests take a longer time to run than most mocha test
-  this.timeout(0);
-
   // Clear the workspace and load start blocks.
   setup(async function () {
     this.browser = await testSetup(testFileLocations.NAVIGATION_TEST_BLOCKS);

--- a/test/webdriverio/test/workspace_comment_test.ts
+++ b/test/webdriverio/test/workspace_comment_test.ts
@@ -27,7 +27,7 @@ suite('Workspace comment navigation', function () {
   // Setting timeout to unlimited as these tests take a longer time to run than most mocha test
   this.timeout(0);
 
-  // Setup Selenium for all of the tests
+  // Clear the workspace and load start blocks.
   setup(async function () {
     this.browser = await testSetup(testFileLocations.NAVIGATION_TEST_BLOCKS);
     [this.commentId1, this.commentId2] = await this.browser.execute(() => {

--- a/test/webdriverio/test/workspace_comment_test.ts
+++ b/test/webdriverio/test/workspace_comment_test.ts
@@ -7,7 +7,6 @@
 import * as chai from 'chai';
 import * as Blockly from 'blockly';
 import {
-  contextMenuExists,
   focusOnBlock,
   getCurrentFocusNodeId,
   getFocusedBlockType,


### PR DESCRIPTION
A bunch of small fixes and refactors of tests:

* fix: Have `scroll_test.ts` restore window size after it's done.
* docs: Use "WebdriverIO" instead of "Selenium" (since we don't use Selenium!)
* chore: Remove unneeded `timeout(0)` calls.
* fix: Set `PAUSE_TIME` to 0, making tests run about 50% faster by default.
* fix: Fix one flakey right-click test in `keyboard_mode_test.ts` that was previously depending on a fixed-duration pause.
* refactor: Use `sendKeyAndWait` in almost all places instead of `browser.keys`.
