### PR TITLE
fix: Remove null checks for cursor.

### DIFF
--- a/src/actions/action_menu.ts
+++ b/src/actions/action_menu.ts
@@ -86,9 +86,7 @@ export class ActionMenu {
     // TODO(#362): Pass this through the precondition and callback instead of making it up.
     const menuOpenEvent = new KeyboardEvent('keydown');
 
-    const cursor = workspace.getCursor();
-    if (!cursor) throw new Error('workspace has no cursor');
-    const node = cursor.getCurNode();
+    const node = workspace.getCursor().getCurNode();
     if (!node) return false;
     // TODO(google/blockly#8847): Add typeguard for IContextMenu in core when this moves over
     if (

--- a/src/actions/arrow_navigation.ts
+++ b/src/actions/arrow_navigation.ts
@@ -38,11 +38,7 @@ export class ArrowNavigation {
     workspace: WorkspaceSvg,
     shortcut: ShortcutRegistry.KeyboardShortcut,
   ): boolean {
-    const cursor = workspace.getCursor();
-    if (!cursor || !cursor.getCurNode()) {
-      return false;
-    }
-    const curNode = cursor.getCurNode();
+    const curNode = workspace.getCursor().getCurNode();
     if (curNode instanceof Field) {
       return curNode.onShortcut(shortcut);
     }
@@ -70,7 +66,7 @@ export class ArrowNavigation {
             if (
               !this.navigation.defaultWorkspaceCursorPositionIfNeeded(workspace)
             ) {
-              workspace.getCursor()?.in();
+              workspace.getCursor().in();
             }
             isHandled = true;
           }
@@ -103,7 +99,7 @@ export class ArrowNavigation {
             if (
               !this.navigation.defaultWorkspaceCursorPositionIfNeeded(workspace)
             ) {
-              workspace.getCursor()?.out();
+              workspace.getCursor().out();
             }
             isHandled = true;
           }
@@ -169,7 +165,7 @@ export class ArrowNavigation {
                     workspace,
                   )
                 ) {
-                  workspace.getCursor()?.next();
+                  workspace.getCursor().next();
                 }
                 isHandled = true;
               }
@@ -182,7 +178,7 @@ export class ArrowNavigation {
                     workspace.targetWorkspace,
                   )
                 ) {
-                  workspace.getCursor()?.next();
+                  workspace.getCursor().next();
                 }
                 isHandled = true;
               }
@@ -232,7 +228,7 @@ export class ArrowNavigation {
                     'last',
                   )
                 ) {
-                  workspace.getCursor()?.prev();
+                  workspace.getCursor().prev();
                 }
                 isHandled = true;
               }
@@ -246,7 +242,7 @@ export class ArrowNavigation {
                     'last',
                   )
                 ) {
-                  workspace.getCursor()?.prev();
+                  workspace.getCursor().prev();
                 }
                 isHandled = true;
               }

--- a/src/actions/disconnect.ts
+++ b/src/actions/disconnect.ts
@@ -78,7 +78,6 @@ export class DisconnectAction {
    */
   disconnectBlocks(workspace: WorkspaceSvg) {
     const cursor = workspace.getCursor();
-    if (!cursor) return;
     const curNode = cursor.getCurNode();
     if (!(curNode instanceof BlockSvg)) return;
 

--- a/src/actions/edit.ts
+++ b/src/actions/edit.ts
@@ -6,7 +6,6 @@
 
 import {
   ContextMenuRegistry,
-  LineCursor,
   Msg,
   keyboardNavigationController,
 } from 'blockly';

--- a/src/actions/edit.ts
+++ b/src/actions/edit.ts
@@ -67,7 +67,7 @@ export class EditAction {
         if (!workspace || !this.navigation.canCurrentlyNavigate(workspace)) {
           return 'disabled';
         }
-        const cursor = workspace.getCursor() as LineCursor | null;
+        const cursor = workspace.getCursor();
         if (!cursor) return 'disabled';
         return cursor.atEndOfLine() ? 'hidden' : 'enabled';
       },

--- a/src/actions/edit.ts
+++ b/src/actions/edit.ts
@@ -4,11 +4,7 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-import {
-  ContextMenuRegistry,
-  Msg,
-  keyboardNavigationController,
-} from 'blockly';
+import {ContextMenuRegistry, Msg, keyboardNavigationController} from 'blockly';
 import {Navigation} from 'src/navigation';
 import {getMenuItem} from '../shortcut_formatting';
 import * as Constants from '../constants';

--- a/src/actions/enter.ts
+++ b/src/actions/enter.ts
@@ -116,8 +116,7 @@ export class EnterAction {
   private shouldHandleEnterForWS(workspace: WorkspaceSvg): boolean {
     if (!this.navigation.canCurrentlyNavigate(workspace)) return false;
 
-    const cursor = workspace.getCursor();
-    const curNode = cursor?.getCurNode();
+    const curNode = workspace.getCursor().getCurNode();
     if (!curNode) return false;
     if (curNode instanceof Field) return curNode.isClickable();
     if (
@@ -143,7 +142,7 @@ export class EnterAction {
    */
   private handleEnterForWS(workspace: WorkspaceSvg): boolean {
     const cursor = workspace.getCursor();
-    const curNode = cursor?.getCurNode();
+    const curNode = cursor.getCurNode();
     if (!curNode) return false;
     if (curNode instanceof Field) {
       curNode.showEditor();
@@ -168,7 +167,7 @@ export class EnterAction {
       // See icon_navigation_policy.
       if (curNode instanceof icons.MutatorIcon) {
         renderManagement.finishQueuedRenders().then(() => {
-          cursor?.in();
+          cursor.in();
         });
       }
       return true;

--- a/src/actions/move.ts
+++ b/src/actions/move.ts
@@ -260,7 +260,7 @@ export class MoveActions {
     const node = getFocusManager().getFocusedNode();
     if (node instanceof comments.RenderedWorkspaceComment) return node;
 
-    let block = workspace?.getCursor()?.getSourceBlock();
+    let block = workspace.getCursor().getSourceBlock();
     if (!block) return undefined;
     while (block.isShadow()) {
       block = block.getParent();

--- a/src/actions/mover.ts
+++ b/src/actions/mover.ts
@@ -160,7 +160,7 @@ export class Mover {
     // In case a block is detached, ensure that it still retains focus
     // (otherwise dragging will break). This is also the point a new block's
     // initial insert position is scrolled into view.
-    workspace.getCursor()?.setCurNode(draggable);
+    workspace.getCursor().setCurNode(draggable);
     draggable.getFocusableElement().addEventListener('blur', blurListener);
 
     // Register a keyboard shortcut under the key combos of all existing
@@ -257,7 +257,7 @@ export class Mover {
     );
 
     if (dragStrategy.moveType === MoveType.Insert && target) {
-      workspace.getCursor()?.setCurNode(target);
+      workspace.getCursor().setCurNode(target);
     }
 
     this.postDragEndCleanup(workspace, info);

--- a/src/actions/ws_movement.ts
+++ b/src/actions/ws_movement.ts
@@ -119,11 +119,7 @@ export class WorkspaceMovement {
    * @param workspace The workspace the cursor is on.
    */
   createWSCursor(workspace: WorkspaceSvg) {
-    const cursor = workspace.getCursor();
-
-    if (!cursor) return false;
-
-    cursor.setCurNode(workspace);
+    workspace.getCursor().setCurNode(workspace);
     return true;
   }
 }

--- a/src/navigation.ts
+++ b/src/navigation.ts
@@ -72,10 +72,7 @@ export class Navigation {
   removeWorkspace(workspace: Blockly.WorkspaceSvg) {
     const workspaceIdx = this.workspaces.indexOf(workspace);
     const flyout = workspace.getFlyout();
-
-    if (workspace.getCursor()) {
-      this.disableKeyboardAccessibility(workspace);
-    }
+    this.disableKeyboardAccessibility(workspace);
 
     if (workspaceIdx > -1) {
       this.workspaces.splice(workspaceIdx, 1);
@@ -259,9 +256,9 @@ export class Navigation {
   ) {
     const mutatedBlockId = e.blockId;
     const cursor = workspace.getCursor();
-    const block = cursor?.getSourceBlock();
+    const block = cursor.getSourceBlock();
     if (block && block.id === mutatedBlockId) {
-      cursor?.setCurNode(block);
+      cursor.setCurNode(block);
     }
   }
 
@@ -346,9 +343,6 @@ export class Navigation {
   ) {
     const topBlocks = workspace.getTopBlocks(true);
     const cursor = workspace.getCursor();
-    if (!cursor) {
-      return;
-    }
     const disposed = cursor.getSourceBlock()?.disposed;
     if (cursor.getCurNode() && !disposed) {
       // Retain the cursor's previous position since it's set, but only if not
@@ -800,7 +794,7 @@ export class Navigation {
    */
   paste(copyData: Blockly.ICopyData, workspace: Blockly.WorkspaceSvg): boolean {
     // Do this before clipoard.paste due to cursor/focus workaround in getCurNode.
-    const targetNode = workspace.getCursor()?.getCurNode();
+    const targetNode = workspace.getCursor().getCurNode();
 
     Blockly.Events.setGroup(true);
     const block = Blockly.clipboard.paste(

--- a/test/webdriverio/test/workspace_comment_test.ts
+++ b/test/webdriverio/test/workspace_comment_test.ts
@@ -7,7 +7,6 @@
 import * as chai from 'chai';
 import * as Blockly from 'blockly';
 import {
-  contextMenuExists,
   focusOnBlock,
   getCurrentFocusNodeId,
   getFocusedBlockType,


### PR DESCRIPTION
This PR fixes #471 by removing checks/conditions for a null cursor. The cursor was made always non-null in https://github.com/google/blockly/pull/9210, so these are now unnecessary.