### PR TITLE
chore: Create workflow for auto-adding assigners

### DIFF
--- a/.github/workflows/assign_reviewers.yml
+++ b/.github/workflows/assign_reviewers.yml
@@ -1,0 +1,43 @@
+name: Assign requested reviewers
+
+# This workflow adds requested reviewers as assignees. If you remove a
+# requested reviewer, it will not remove them as an assignee.
+#
+# See https://github.com/google/blockly/issues/5643 for more
+# information on why this was added.
+#
+# N.B.: Runs with a read-write repo token.  Do not check out the
+# submitted branch!
+on:
+  pull_request_target:
+    types: [review_requested]
+
+jobs:
+  requested-reviewer:
+    runs-on: ubuntu-latest
+    permissions:
+      pull-requests: write
+    steps:
+      - name: Assign requested reviewer
+        uses: actions/github-script@v7
+        with:
+          script: |
+            try {
+              if (context.payload.pull_request === undefined) {
+              throw new Error("Can't get pull_request payload. " +
+                              'Check a request reviewer event was triggered.');
+              }
+              const reviewers = context.payload.pull_request.requested_reviewers;
+              // Assignees takes in a list of logins rather than the
+              // reviewer object.
+              const reviewerNames = reviewers.map(reviewer => reviewer.login);
+              const {number:issue_number} = context.payload.pull_request;
+              github.rest.issues.addAssignees({
+                owner: context.repo.owner,
+                repo: context.repo.repo,
+                issue_number: issue_number,
+                assignees: reviewerNames
+              });
+            } catch (error) {
+              core.setFailed(error.message);
+            }


### PR DESCRIPTION
This adds a workflow for automatically assigning reviewers in PRs. It's an exact copy of the version used in core Blockly: https://github.com/google/blockly/blob/b44f7bf1b0b08b135119c304bdbd2e0f6284f828/.github/workflows/assign_reviewers.yml#L1.

Note that this will not actually run until it's merged in since it uses `pull_request_target`.