### PR TITLE
chore: update blockly version in package lock

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -34,7 +34,7 @@
         "webdriverio": "^9.12.1"
       },
       "peerDependencies": {
-        "blockly": "^12.1.0"
+        "blockly": "^12.2.0"
       }
     },
     "node_modules/@asamuzakjp/css-color": {


### PR DESCRIPTION
Package-lock was out of date.