### PR TITLE
test: Make tests faster, more robust, more consistent

### DIFF
--- a/test/webdriverio/test/actions_test.ts
+++ b/test/webdriverio/test/actions_test.ts
@@ -31,7 +31,6 @@ suite('Menus test', function () {
 
   test('Menu on block', async function () {
     // Navigate to draw_circle_1.
-    await tabNavigateToWorkspace(this.browser);
     await focusOnBlock(this.browser, 'draw_circle_1');
     await this.browser.pause(PAUSE_TIME);
     await sendKeyAndWait(this.browser, [Key.Ctrl, Key.Return]);
@@ -70,7 +69,6 @@ suite('Menus test', function () {
 
   test('Menu on block in the toolbox', async function () {
     // Navigate to draw_circle_1.
-    await tabNavigateToWorkspace(this.browser);
     await focusOnBlock(this.browser, 'draw_circle_1');
     // Navigate to a toolbox category
     await moveToToolboxCategory(this.browser, 'Functions');
@@ -130,7 +128,6 @@ suite('Menus test', function () {
 
   test('Menu on block during drag is not shown', async function () {
     // Navigate to draw_circle_1.
-    await tabNavigateToWorkspace(this.browser);
     await focusOnBlock(this.browser, 'draw_circle_1');
     // Start moving the block
     await sendKeyAndWait(this.browser, 'm');

--- a/test/webdriverio/test/actions_test.ts
+++ b/test/webdriverio/test/actions_test.ts
@@ -25,6 +25,11 @@ suite('Menus test', function () {
 
   // Clear the workspace and load start blocks.
   setup(async function () {
+    // This is the first test suite, which must wait for Chrome +
+    // chromedriver to start up, which can be slow—perhaps a few
+    // seconds.  Allow 30s just in case.
+    this.timeout(30000);
+
     this.browser = await testSetup(testFileLocations.BASE);
     await this.browser.pause(PAUSE_TIME);
   });

--- a/test/webdriverio/test/actions_test.ts
+++ b/test/webdriverio/test/actions_test.ts
@@ -22,7 +22,7 @@ suite('Menus test', function () {
   // Setting timeout to unlimited as these tests take longer time to run
   this.timeout(0);
 
-  // Clear the workspace and load start blocks
+  // Clear the workspace and load start blocks.
   setup(async function () {
     this.browser = await testSetup(testFileLocations.BASE);
     await this.browser.pause(PAUSE_TIME);

--- a/test/webdriverio/test/actions_test.ts
+++ b/test/webdriverio/test/actions_test.ts
@@ -14,6 +14,7 @@ import {
   tabNavigateToWorkspace,
   testFileLocations,
   testSetup,
+  sendKeyAndWait,
   keyRight,
   contextMenuItems,
 } from './test_setup.js';
@@ -33,8 +34,7 @@ suite('Menus test', function () {
     await tabNavigateToWorkspace(this.browser);
     await focusOnBlock(this.browser, 'draw_circle_1');
     await this.browser.pause(PAUSE_TIME);
-    await this.browser.keys([Key.Ctrl, Key.Return]);
-    await this.browser.pause(PAUSE_TIME);
+    await sendKeyAndWait(this.browser, [Key.Ctrl, Key.Return]);
 
     chai.assert.deepEqual(
       process.platform === 'darwin'
@@ -76,8 +76,7 @@ suite('Menus test', function () {
     await moveToToolboxCategory(this.browser, 'Functions');
     // Move to flyout.
     await keyRight(this.browser);
-    await this.browser.keys([Key.Ctrl, Key.Return]);
-    await this.browser.pause(PAUSE_TIME);
+    await sendKeyAndWait(this.browser, [Key.Ctrl, Key.Return]);
 
     chai.assert.deepEqual(
       process.platform === 'darwin'
@@ -100,9 +99,8 @@ suite('Menus test', function () {
   test('Menu on workspace', async function () {
     // Navigate to draw_circle_1.
     await tabNavigateToWorkspace(this.browser);
-    await this.browser.keys('w');
-    await this.browser.keys([Key.Ctrl, Key.Return]);
-    await this.browser.pause(PAUSE_TIME);
+    await sendKeyAndWait(this.browser, 'w');
+    await sendKeyAndWait(this.browser, [Key.Ctrl, Key.Return]);
 
     chai.assert.deepEqual(
       process.platform === 'darwin'
@@ -135,9 +133,9 @@ suite('Menus test', function () {
     await tabNavigateToWorkspace(this.browser);
     await focusOnBlock(this.browser, 'draw_circle_1');
     // Start moving the block
-    await this.browser.keys('m');
-    await this.browser.keys([Key.Ctrl, Key.Return]);
-    await this.browser.pause(PAUSE_TIME);
+    await sendKeyAndWait(this.browser, 'm');
+    await sendKeyAndWait(this.browser, [Key.Ctrl, Key.Return]);
+
     chai.assert.isTrue(
       await contextMenuExists(this.browser, 'Collapse Block', true),
       'The menu should not be openable during a move',

--- a/test/webdriverio/test/actions_test.ts
+++ b/test/webdriverio/test/actions_test.ts
@@ -19,8 +19,8 @@ import {
 } from './test_setup.js';
 
 suite('Menus test', function () {
-  // Setting timeout to unlimited as these tests take longer time to run
-  this.timeout(0);
+  // Disable timeouts when non-zero PAUSE_TIME is used to watch tests run.
+  if (PAUSE_TIME) this.timeout(0);
 
   // Clear the workspace and load start blocks.
   setup(async function () {

--- a/test/webdriverio/test/basic_test.ts
+++ b/test/webdriverio/test/basic_test.ts
@@ -28,7 +28,7 @@ suite('Keyboard navigation on Blocks', function () {
   // Setting timeout to unlimited as these tests take a longer time to run than most mocha test
   this.timeout(0);
 
-  // Setup Selenium for all of the tests
+  // Clear the workspace and load start blocks.
   suiteSetup(async function () {
     this.browser = await testSetup(testFileLocations.NAVIGATION_TEST_BLOCKS);
   });
@@ -255,7 +255,7 @@ suite('Keyboard navigation on Fields', function () {
   // Setting timeout to unlimited as these tests take a longer time to run than most mocha test
   this.timeout(0);
 
-  // Setup Selenium for all of the tests
+  // Clear the workspace and load start blocks.
   suiteSetup(async function () {
     this.browser = await testSetup(testFileLocations.NAVIGATION_TEST_BLOCKS);
   });

--- a/test/webdriverio/test/basic_test.ts
+++ b/test/webdriverio/test/basic_test.ts
@@ -16,6 +16,7 @@ import {
   testSetup,
   testFileLocations,
   PAUSE_TIME,
+  sendKeyAndWait,
   tabNavigateToWorkspace,
   keyLeft,
   keyRight,
@@ -239,13 +240,11 @@ suite('Keyboard navigation on Blocks', function () {
     await tabNavigateToWorkspace(this.browser);
     await this.browser.pause(PAUSE_TIME);
     await focusOnBlock(this.browser, 'text_print_1');
-    await this.browser.keys('m');
-    await this.browser.pause(PAUSE_TIME);
+    await sendKeyAndWait(this.browser, 'm');
 
     chai.assert.isTrue(await isDragging(this.browser));
 
-    await this.browser.keys(Key.Tab);
-    await this.browser.pause(PAUSE_TIME);
+    await sendKeyAndWait(this.browser, Key.Tab);
 
     chai.assert.isFalse(await isDragging(this.browser));
   });
@@ -354,8 +353,7 @@ suite('Keyboard navigation on Fields', function () {
     // Open a field editor dropdown
     await focusOnBlockField(this.browser, 'logic_boolean_1', 'BOOL');
     await this.browser.pause(PAUSE_TIME);
-    await this.browser.keys(Key.Enter);
-    await this.browser.pause(PAUSE_TIME);
+    await sendKeyAndWait(this.browser, Key.Enter);
 
     // Try to navigate to a different block
     await keyRight(this.browser);
@@ -368,13 +366,12 @@ suite('Keyboard navigation on Fields', function () {
     // Open colour picker
     await focusOnBlockField(this.browser, 'colour_picker_1', 'COLOUR');
     await this.browser.pause(PAUSE_TIME);
-    await this.browser.keys(Key.Enter);
-    await this.browser.pause(PAUSE_TIME);
+    await sendKeyAndWait(this.browser, Key.Enter);
 
     // Move right to pick a new colour.
     await keyRight(this.browser);
     // Enter to choose.
-    await this.browser.keys(Key.Enter);
+    await sendKeyAndWait(this.browser, Key.Enter);
 
     // Focus seems to take longer than a single pause to settle.
     await this.browser.waitUntil(

--- a/test/webdriverio/test/basic_test.ts
+++ b/test/webdriverio/test/basic_test.ts
@@ -54,8 +54,6 @@ suite('Keyboard navigation on Blocks', function () {
   });
 
   test('Down from statement block selects next block across stacks', async function () {
-    await tabNavigateToWorkspace(this.browser);
-    await this.browser.pause(PAUSE_TIME);
     await focusOnBlock(this.browser, 'p5_canvas_1');
     await this.browser.pause(PAUSE_TIME);
     await keyDown(this.browser);
@@ -66,8 +64,6 @@ suite('Keyboard navigation on Blocks', function () {
   });
 
   test('Up from statement block selects previous block', async function () {
-    await tabNavigateToWorkspace(this.browser);
-    await this.browser.pause(PAUSE_TIME);
     await focusOnBlock(this.browser, 'simple_circle_1');
     await this.browser.pause(PAUSE_TIME);
     await keyUp(this.browser);
@@ -78,8 +74,6 @@ suite('Keyboard navigation on Blocks', function () {
   });
 
   test('Down from parent block selects first child block', async function () {
-    await tabNavigateToWorkspace(this.browser);
-    await this.browser.pause(PAUSE_TIME);
     await focusOnBlock(this.browser, 'p5_setup_1');
     await this.browser.pause(PAUSE_TIME);
     await keyDown(this.browser);
@@ -89,8 +83,6 @@ suite('Keyboard navigation on Blocks', function () {
   });
 
   test('Up from child block selects parent block', async function () {
-    await tabNavigateToWorkspace(this.browser);
-    await this.browser.pause(PAUSE_TIME);
     await focusOnBlock(this.browser, 'p5_canvas_1');
     await this.browser.pause(PAUSE_TIME);
     await keyUp(this.browser);
@@ -100,8 +92,6 @@ suite('Keyboard navigation on Blocks', function () {
   });
 
   test('Right from block selects first field', async function () {
-    await tabNavigateToWorkspace(this.browser);
-    await this.browser.pause(PAUSE_TIME);
     await focusOnBlock(this.browser, 'p5_canvas_1');
     await this.browser.pause(PAUSE_TIME);
     await keyRight(this.browser);
@@ -114,8 +104,6 @@ suite('Keyboard navigation on Blocks', function () {
   });
 
   test('Right from block selects first inline input', async function () {
-    await tabNavigateToWorkspace(this.browser);
-    await this.browser.pause(PAUSE_TIME);
     await focusOnBlock(this.browser, 'simple_circle_1');
     await this.browser.pause(PAUSE_TIME);
     await keyRight(this.browser);
@@ -127,8 +115,6 @@ suite('Keyboard navigation on Blocks', function () {
   });
 
   test('Up from inline input selects statement block', async function () {
-    await tabNavigateToWorkspace(this.browser);
-    await this.browser.pause(PAUSE_TIME);
     await focusOnBlock(this.browser, 'math_number_2');
     await this.browser.pause(PAUSE_TIME);
     await keyUp(this.browser);
@@ -140,8 +126,6 @@ suite('Keyboard navigation on Blocks', function () {
   });
 
   test('Left from first inline input selects block', async function () {
-    await tabNavigateToWorkspace(this.browser);
-    await this.browser.pause(PAUSE_TIME);
     await focusOnBlock(this.browser, 'math_number_2');
     await this.browser.pause(PAUSE_TIME);
     await keyLeft(this.browser);
@@ -153,8 +137,6 @@ suite('Keyboard navigation on Blocks', function () {
   });
 
   test('Right from first inline input selects second inline input', async function () {
-    await tabNavigateToWorkspace(this.browser);
-    await this.browser.pause(PAUSE_TIME);
     await focusOnBlock(this.browser, 'math_number_2');
     await this.browser.pause(PAUSE_TIME);
     await keyRight(this.browser);
@@ -166,8 +148,6 @@ suite('Keyboard navigation on Blocks', function () {
   });
 
   test('Left from second inline input selects first inline input', async function () {
-    await tabNavigateToWorkspace(this.browser);
-    await this.browser.pause(PAUSE_TIME);
     await focusOnBlock(this.browser, 'math_number_3');
     await this.browser.pause(PAUSE_TIME);
     await keyLeft(this.browser);
@@ -179,8 +159,6 @@ suite('Keyboard navigation on Blocks', function () {
   });
 
   test('Right from last inline input selects next block', async function () {
-    await tabNavigateToWorkspace(this.browser);
-    await this.browser.pause(PAUSE_TIME);
     await focusOnBlock(this.browser, 'colour_picker_1');
     await this.browser.pause(PAUSE_TIME);
     await keyRight(this.browser);
@@ -191,8 +169,6 @@ suite('Keyboard navigation on Blocks', function () {
   });
 
   test('Down from inline input selects next block', async function () {
-    await tabNavigateToWorkspace(this.browser);
-    await this.browser.pause(PAUSE_TIME);
     await focusOnBlock(this.browser, 'colour_picker_1');
     await this.browser.pause(PAUSE_TIME);
     await keyDown(this.browser);
@@ -203,8 +179,6 @@ suite('Keyboard navigation on Blocks', function () {
   });
 
   test("Down from inline input selects block's child block", async function () {
-    await tabNavigateToWorkspace(this.browser);
-    await this.browser.pause(PAUSE_TIME);
     await focusOnBlock(this.browser, 'logic_boolean_1');
     await this.browser.pause(PAUSE_TIME);
     await keyDown(this.browser);
@@ -215,8 +189,6 @@ suite('Keyboard navigation on Blocks', function () {
   });
 
   test('Right from text block selects shadow block then field', async function () {
-    await tabNavigateToWorkspace(this.browser);
-    await this.browser.pause(PAUSE_TIME);
     await focusOnBlock(this.browser, 'text_print_1');
     await this.browser.pause(PAUSE_TIME);
     await keyRight(this.browser);
@@ -237,8 +209,6 @@ suite('Keyboard navigation on Blocks', function () {
   });
 
   test('Losing focus cancels move', async function () {
-    await tabNavigateToWorkspace(this.browser);
-    await this.browser.pause(PAUSE_TIME);
     await focusOnBlock(this.browser, 'text_print_1');
     await sendKeyAndWait(this.browser, 'm');
 
@@ -260,8 +230,6 @@ suite('Keyboard navigation on Fields', function () {
   });
 
   test('Up from first field selects block', async function () {
-    await tabNavigateToWorkspace(this.browser);
-    await this.browser.pause(PAUSE_TIME);
     await focusOnBlockField(this.browser, 'p5_canvas_1', 'WIDTH');
     await this.browser.pause(PAUSE_TIME);
     await keyUp(this.browser);
@@ -273,8 +241,6 @@ suite('Keyboard navigation on Fields', function () {
   });
 
   test('Left from first field selects block', async function () {
-    await tabNavigateToWorkspace(this.browser);
-    await this.browser.pause(PAUSE_TIME);
     await focusOnBlockField(this.browser, 'p5_canvas_1', 'WIDTH');
     await this.browser.pause(PAUSE_TIME);
     await keyLeft(this.browser);
@@ -286,8 +252,6 @@ suite('Keyboard navigation on Fields', function () {
   });
 
   test('Right from first field selects second field', async function () {
-    await tabNavigateToWorkspace(this.browser);
-    await this.browser.pause(PAUSE_TIME);
     await focusOnBlockField(this.browser, 'p5_canvas_1', 'WIDTH');
     await this.browser.pause(PAUSE_TIME);
     await keyRight(this.browser);
@@ -300,8 +264,6 @@ suite('Keyboard navigation on Fields', function () {
   });
 
   test('Left from second field selects first field', async function () {
-    await tabNavigateToWorkspace(this.browser);
-    await this.browser.pause(PAUSE_TIME);
     await focusOnBlockField(this.browser, 'p5_canvas_1', 'HEIGHT');
     await this.browser.pause(PAUSE_TIME);
     await keyLeft(this.browser);
@@ -314,8 +276,6 @@ suite('Keyboard navigation on Fields', function () {
   });
 
   test('Right from second field selects next block', async function () {
-    await tabNavigateToWorkspace(this.browser);
-    await this.browser.pause(PAUSE_TIME);
     await focusOnBlockField(this.browser, 'p5_canvas_1', 'HEIGHT');
     await this.browser.pause(PAUSE_TIME);
     await keyRight(this.browser);
@@ -326,8 +286,6 @@ suite('Keyboard navigation on Fields', function () {
   });
 
   test('Down from field selects next block', async function () {
-    await tabNavigateToWorkspace(this.browser);
-    await this.browser.pause(PAUSE_TIME);
     await focusOnBlockField(this.browser, 'p5_canvas_1', 'WIDTH');
     await this.browser.pause(PAUSE_TIME);
     await keyDown(this.browser);
@@ -338,8 +296,6 @@ suite('Keyboard navigation on Fields', function () {
   });
 
   test("Down from field selects block's child block", async function () {
-    await tabNavigateToWorkspace(this.browser);
-    await this.browser.pause(PAUSE_TIME);
     await focusOnBlockField(this.browser, 'controls_repeat_1', 'TIMES');
     await this.browser.pause(PAUSE_TIME);
     await keyDown(this.browser);

--- a/test/webdriverio/test/basic_test.ts
+++ b/test/webdriverio/test/basic_test.ts
@@ -25,8 +25,8 @@ import {
 import {Key} from 'webdriverio';
 
 suite('Keyboard navigation on Blocks', function () {
-  // Setting timeout to unlimited as these tests take a longer time to run than most mocha test
-  this.timeout(0);
+  // Disable timeouts when non-zero PAUSE_TIME is used to watch tests run.
+  if (PAUSE_TIME) this.timeout(0);
 
   // Clear the workspace and load start blocks.
   suiteSetup(async function () {
@@ -252,8 +252,8 @@ suite('Keyboard navigation on Blocks', function () {
 });
 
 suite('Keyboard navigation on Fields', function () {
-  // Setting timeout to unlimited as these tests take a longer time to run than most mocha test
-  this.timeout(0);
+  // Disable timeouts when non-zero PAUSE_TIME is used to watch tests run.
+  if (PAUSE_TIME) this.timeout(0);
 
   // Clear the workspace and load start blocks.
   suiteSetup(async function () {

--- a/test/webdriverio/test/block_comment_test.ts
+++ b/test/webdriverio/test/block_comment_test.ts
@@ -13,12 +13,13 @@ import {
   sendKeyAndWait,
   testFileLocations,
   keyRight,
+  PAUSE_TIME,
 } from './test_setup.js';
 import {Key} from 'webdriverio';
 
 suite('Block comment navigation', function () {
-  // Setting timeout to unlimited as these tests take a longer time to run than most mocha test
-  this.timeout(0);
+  // Disable timeouts when non-zero PAUSE_TIME is used to watch tests run.
+  if (PAUSE_TIME) this.timeout(0);
 
   // Clear the workspace and load start blocks.
   setup(async function () {

--- a/test/webdriverio/test/block_comment_test.ts
+++ b/test/webdriverio/test/block_comment_test.ts
@@ -20,7 +20,7 @@ suite('Block comment navigation', function () {
   // Setting timeout to unlimited as these tests take a longer time to run than most mocha test
   this.timeout(0);
 
-  // Setup Selenium for all of the tests
+  // Clear the workspace and load start blocks.
   setup(async function () {
     this.browser = await testSetup(testFileLocations.NAVIGATION_TEST_BLOCKS);
     await this.browser.execute(() => {

--- a/test/webdriverio/test/clipboard_test.ts
+++ b/test/webdriverio/test/clipboard_test.ts
@@ -25,7 +25,7 @@ suite('Clipboard test', function () {
   // Setting timeout to unlimited as these tests take longer time to run
   this.timeout(0);
 
-  // Clear the workspace and load start blocks
+  // Clear the workspace and load start blocks.
   setup(async function () {
     this.browser = await testSetup(testFileLocations.BASE);
     await this.browser.pause(PAUSE_TIME);

--- a/test/webdriverio/test/clipboard_test.ts
+++ b/test/webdriverio/test/clipboard_test.ts
@@ -34,7 +34,6 @@ suite('Clipboard test', function () {
 
   test('Copy and paste while block selected', async function () {
     // Navigate to draw_circle_1.
-    await tabNavigateToWorkspace(this.browser);
     await focusOnBlock(this.browser, 'draw_circle_1');
 
     // Copy and paste
@@ -54,7 +53,6 @@ suite('Clipboard test', function () {
 
   test('Cut and paste while block selected', async function () {
     // Navigate to draw_circle_1.
-    await tabNavigateToWorkspace(this.browser);
     await focusOnBlock(this.browser, 'draw_circle_1');
     const block = await getBlockElementById(this.browser, 'draw_circle_1');
 

--- a/test/webdriverio/test/clipboard_test.ts
+++ b/test/webdriverio/test/clipboard_test.ts
@@ -18,6 +18,7 @@ import {
   focusOnBlockField,
   blockIsPresent,
   getFocusedBlockType,
+  sendKeyAndWait,
 } from './test_setup.js';
 import {Key, KeyAction, PointerAction, WheelAction} from 'webdriverio';
 
@@ -37,9 +38,8 @@ suite('Clipboard test', function () {
     await focusOnBlock(this.browser, 'draw_circle_1');
 
     // Copy and paste
-    await this.browser.keys([Key.Ctrl, 'c']);
-    await this.browser.keys([Key.Ctrl, 'v']);
-    await this.browser.pause(PAUSE_TIME);
+    await sendKeyAndWait(this.browser, [Key.Ctrl, 'c']);
+    await sendKeyAndWait(this.browser, [Key.Ctrl, 'v']);
 
     const block = await getBlockElementById(this.browser, 'draw_circle_1');
     const blocks = await getSameBlocks(this.browser, block);
@@ -59,10 +59,9 @@ suite('Clipboard test', function () {
     const block = await getBlockElementById(this.browser, 'draw_circle_1');
 
     // Cut and paste
-    await this.browser.keys([Key.Ctrl, 'x']);
+    await sendKeyAndWait(this.browser, [Key.Ctrl, 'x']);
     await block.waitForExist({reverse: true});
-    await this.browser.keys([Key.Ctrl, 'v']);
-    await this.browser.pause(PAUSE_TIME);
+    await sendKeyAndWait(this.browser, [Key.Ctrl, 'v']);
 
     const focusedType = await getFocusedBlockType(this.browser);
 
@@ -117,11 +116,10 @@ suite('Clipboard test', function () {
     // Open a field editor
     await focusOnBlockField(this.browser, 'draw_circle_1_color', 'COLOUR');
     await this.browser.pause(PAUSE_TIME);
-    await this.browser.keys(Key.Enter);
-    await this.browser.pause(PAUSE_TIME);
+    await sendKeyAndWait(this.browser, Key.Enter);
 
     // Try to cut block while field editor is open
-    await this.browser.keys([Key.Ctrl, 'x']);
+    await sendKeyAndWait(this.browser, [Key.Ctrl, 'x']);
 
     // Block is not deleted
     chai.assert.isTrue(

--- a/test/webdriverio/test/clipboard_test.ts
+++ b/test/webdriverio/test/clipboard_test.ts
@@ -13,7 +13,6 @@ import {
   getBlockElementById,
   getSelectedBlockId,
   ElementWithId,
-  tabNavigateToWorkspace,
   focusOnBlock,
   focusOnBlockField,
   blockIsPresent,

--- a/test/webdriverio/test/clipboard_test.ts
+++ b/test/webdriverio/test/clipboard_test.ts
@@ -22,8 +22,8 @@ import {
 import {Key, KeyAction, PointerAction, WheelAction} from 'webdriverio';
 
 suite('Clipboard test', function () {
-  // Setting timeout to unlimited as these tests take longer time to run
-  this.timeout(0);
+  // Disable timeouts when non-zero PAUSE_TIME is used to watch tests run.
+  if (PAUSE_TIME) this.timeout(0);
 
   // Clear the workspace and load start blocks.
   setup(async function () {

--- a/test/webdriverio/test/delete_test.ts
+++ b/test/webdriverio/test/delete_test.ts
@@ -21,8 +21,8 @@ import {
 import {Key} from 'webdriverio';
 
 suite('Deleting Blocks', function () {
-  // Setting timeout to unlimited as these tests take a longer time to run than most mocha test
-  this.timeout(0);
+  // Disable timeouts when non-zero PAUSE_TIME is used to watch tests run.
+  if (PAUSE_TIME) this.timeout(0);
 
   // Clear the workspace and load start blocks.
   setup(async function () {

--- a/test/webdriverio/test/delete_test.ts
+++ b/test/webdriverio/test/delete_test.ts
@@ -24,6 +24,7 @@ suite('Deleting Blocks', function () {
   // Setting timeout to unlimited as these tests take a longer time to run than most mocha test
   this.timeout(0);
 
+  // Clear the workspace and load start blocks.
   setup(async function () {
     this.browser = await testSetup(testFileLocations.NAVIGATION_TEST_BLOCKS);
     await this.browser.pause(PAUSE_TIME);

--- a/test/webdriverio/test/delete_test.ts
+++ b/test/webdriverio/test/delete_test.ts
@@ -15,6 +15,7 @@ import {
   testFileLocations,
   PAUSE_TIME,
   tabNavigateToWorkspace,
+  sendKeyAndWait,
   keyRight,
   focusOnBlockField,
 } from './test_setup.js';
@@ -40,8 +41,7 @@ suite('Deleting Blocks', function () {
       .expect(await blockIsPresent(this.browser, 'controls_if_2'))
       .equal(true);
 
-    await this.browser.keys(Key.Backspace);
-    await this.browser.pause(PAUSE_TIME);
+    await sendKeyAndWait(this.browser, Key.Backspace);
 
     chai
       .expect(await blockIsPresent(this.browser, 'controls_if_2'))
@@ -62,8 +62,7 @@ suite('Deleting Blocks', function () {
       .expect(await blockIsPresent(this.browser, 'controls_if_2'))
       .equal(true);
 
-    await this.browser.keys([Key.Ctrl, 'x']);
-    await this.browser.pause(PAUSE_TIME);
+    await sendKeyAndWait(this.browser, [Key.Ctrl, 'x']);
 
     chai
       .expect(await blockIsPresent(this.browser, 'controls_if_2'))
@@ -85,8 +84,7 @@ suite('Deleting Blocks', function () {
       .equal(true);
     chai.expect(await blockIsPresent(this.browser, 'text_print_1')).equal(true);
 
-    await this.browser.keys(Key.Backspace);
-    await this.browser.pause(PAUSE_TIME);
+    await sendKeyAndWait(this.browser, Key.Backspace);
 
     chai
       .expect(await blockIsPresent(this.browser, 'logic_boolean_1'))
@@ -107,8 +105,7 @@ suite('Deleting Blocks', function () {
       .equal(true);
     chai.expect(await blockIsPresent(this.browser, 'text_print_1')).equal(true);
 
-    await this.browser.keys([Key.Ctrl, 'x']);
-    await this.browser.pause(PAUSE_TIME);
+    await sendKeyAndWait(this.browser, [Key.Ctrl, 'x']);
 
     chai
       .expect(await blockIsPresent(this.browser, 'logic_boolean_1'))
@@ -128,8 +125,7 @@ suite('Deleting Blocks', function () {
       .expect(await blockIsPresent(this.browser, 'logic_boolean_1'))
       .equal(true);
 
-    await this.browser.keys(Key.Backspace);
-    await this.browser.pause(PAUSE_TIME);
+    await sendKeyAndWait(this.browser, Key.Backspace);
 
     chai
       .expect(await blockIsPresent(this.browser, 'logic_boolean_1'))
@@ -150,8 +146,7 @@ suite('Deleting Blocks', function () {
       .expect(await blockIsPresent(this.browser, 'logic_boolean_1'))
       .equal(true);
 
-    await this.browser.keys([Key.Ctrl, 'x']);
-    await this.browser.pause(PAUSE_TIME);
+    await sendKeyAndWait(this.browser, [Key.Ctrl, 'x']);
 
     chai
       .expect(await blockIsPresent(this.browser, 'logic_boolean_1'))
@@ -177,16 +172,13 @@ suite('Deleting Blocks', function () {
     // Move to flyout.
     await keyRight(this.browser);
     // Select number block.
-    await this.browser.keys(Key.Enter);
-    await this.browser.pause(PAUSE_TIME);
+    await sendKeyAndWait(this.browser, Key.Enter);
     // Confirm move.
-    await this.browser.keys(Key.Enter);
-    await this.browser.pause(PAUSE_TIME);
+    await sendKeyAndWait(this.browser, Key.Enter);
 
     chai.assert.equal('math_number', await getFocusedBlockType(this.browser));
 
-    await this.browser.keys(Key.Backspace);
-    await this.browser.pause(PAUSE_TIME);
+    await sendKeyAndWait(this.browser, Key.Backspace);
 
     chai.assert.equal(
       await getCurrentFocusedBlockId(this.browser),
@@ -204,16 +196,13 @@ suite('Deleting Blocks', function () {
     // Move to flyout.
     await keyRight(this.browser);
     // Select number block.
-    await this.browser.keys(Key.Enter);
-    await this.browser.pause(PAUSE_TIME);
+    await sendKeyAndWait(this.browser, Key.Enter);
     // Confirm move.
-    await this.browser.keys(Key.Enter);
-    await this.browser.pause(PAUSE_TIME);
+    await sendKeyAndWait(this.browser, Key.Enter);
 
     chai.assert.equal('math_number', await getFocusedBlockType(this.browser));
 
-    await this.browser.keys([Key.Ctrl, 'x']);
-    await this.browser.pause(PAUSE_TIME);
+    await sendKeyAndWait(this.browser, [Key.Ctrl, 'x']);
 
     chai.assert.equal(
       await getCurrentFocusedBlockId(this.browser),
@@ -225,11 +214,10 @@ suite('Deleting Blocks', function () {
     // Open a field editor
     await focusOnBlockField(this.browser, 'colour_picker_1', 'COLOUR');
     await this.browser.pause(PAUSE_TIME);
-    await this.browser.keys(Key.Enter);
-    await this.browser.pause(PAUSE_TIME);
+    await sendKeyAndWait(this.browser, Key.Enter);
 
     // Try to delete block while field editor is open
-    await this.browser.keys(Key.Backspace);
+    await sendKeyAndWait(this.browser, Key.Backspace);
 
     // Block is not deleted
     chai.assert.isTrue(await blockIsPresent(this.browser, 'colour_picker_1'));

--- a/test/webdriverio/test/delete_test.ts
+++ b/test/webdriverio/test/delete_test.ts
@@ -32,8 +32,6 @@ suite('Deleting Blocks', function () {
   });
 
   test('Deleting block selects parent block', async function () {
-    await tabNavigateToWorkspace(this.browser);
-    await this.browser.pause(PAUSE_TIME);
     await focusOnBlock(this.browser, 'controls_if_2');
     await this.browser.pause(PAUSE_TIME);
 
@@ -53,8 +51,6 @@ suite('Deleting Blocks', function () {
   });
 
   test('Cutting block selects parent block', async function () {
-    await tabNavigateToWorkspace(this.browser);
-    await this.browser.pause(PAUSE_TIME);
     await focusOnBlock(this.browser, 'controls_if_2');
     await this.browser.pause(PAUSE_TIME);
 
@@ -74,8 +70,6 @@ suite('Deleting Blocks', function () {
   });
 
   test('Deleting block also deletes children and inputs', async function () {
-    await tabNavigateToWorkspace(this.browser);
-    await this.browser.pause(PAUSE_TIME);
     await focusOnBlock(this.browser, 'controls_if_2');
     await this.browser.pause(PAUSE_TIME);
 
@@ -95,8 +89,6 @@ suite('Deleting Blocks', function () {
   });
 
   test('Cutting block also removes children and inputs', async function () {
-    await tabNavigateToWorkspace(this.browser);
-    await this.browser.pause(PAUSE_TIME);
     await focusOnBlock(this.browser, 'controls_if_2');
     await this.browser.pause(PAUSE_TIME);
 
@@ -116,8 +108,6 @@ suite('Deleting Blocks', function () {
   });
 
   test('Deleting inline input selects parent block', async function () {
-    await tabNavigateToWorkspace(this.browser);
-    await this.browser.pause(PAUSE_TIME);
     await focusOnBlock(this.browser, 'logic_boolean_1');
     await this.browser.pause(PAUSE_TIME);
 
@@ -137,8 +127,6 @@ suite('Deleting Blocks', function () {
   });
 
   test('Cutting inline input selects parent block', async function () {
-    await tabNavigateToWorkspace(this.browser);
-    await this.browser.pause(PAUSE_TIME);
     await focusOnBlock(this.browser, 'logic_boolean_1');
     await this.browser.pause(PAUSE_TIME);
 

--- a/test/webdriverio/test/duplicate_test.ts
+++ b/test/webdriverio/test/duplicate_test.ts
@@ -14,6 +14,7 @@ import {
   tabNavigateToWorkspace,
   testFileLocations,
   testSetup,
+  sendKeyAndWait,
 } from './test_setup.js';
 
 suite('Duplicate test', function () {
@@ -32,8 +33,7 @@ suite('Duplicate test', function () {
     await focusOnBlock(this.browser, 'draw_circle_1');
 
     // Duplicate
-    await this.browser.keys('d');
-    await this.browser.pause(PAUSE_TIME);
+    await sendKeyAndWait(this.browser, 'd');
 
     // Check a different block of the same type has focus.
     chai.assert.notEqual(
@@ -65,7 +65,7 @@ suite('Duplicate test', function () {
     await this.browser.pause(PAUSE_TIME);
 
     // Duplicate.
-    await this.browser.keys('d');
+    await sendKeyAndWait(this.browser, 'd');
 
     // Assert we have two comments with the same text.
     const commentTexts = await this.browser.execute(() =>

--- a/test/webdriverio/test/duplicate_test.ts
+++ b/test/webdriverio/test/duplicate_test.ts
@@ -17,8 +17,8 @@ import {
 } from './test_setup.js';
 
 suite('Duplicate test', function () {
-  // Setting timeout to unlimited as these tests take longer time to run
-  this.timeout(0);
+  // Disable timeouts when non-zero PAUSE_TIME is used to watch tests run.
+  if (PAUSE_TIME) this.timeout(0);
 
   // Clear the workspace and load start blocks.
   setup(async function () {

--- a/test/webdriverio/test/duplicate_test.ts
+++ b/test/webdriverio/test/duplicate_test.ts
@@ -20,7 +20,7 @@ suite('Duplicate test', function () {
   // Setting timeout to unlimited as these tests take longer time to run
   this.timeout(0);
 
-  // Clear the workspace and load start blocks
+  // Clear the workspace and load start blocks.
   setup(async function () {
     this.browser = await testSetup(testFileLocations.BASE);
     await this.browser.pause(PAUSE_TIME);

--- a/test/webdriverio/test/flyout_test.ts
+++ b/test/webdriverio/test/flyout_test.ts
@@ -20,6 +20,9 @@ import {
 } from './test_setup.js';
 
 suite('Toolbox and flyout test', function () {
+  // Disable timeouts when non-zero PAUSE_TIME is used to watch tests run.
+  if (PAUSE_TIME) this.timeout(0);
+
   // Clear the workspace and load start blocks.
   setup(async function () {
     this.browser = await testSetup(testFileLocations.BASE);

--- a/test/webdriverio/test/flyout_test.ts
+++ b/test/webdriverio/test/flyout_test.ts
@@ -14,6 +14,7 @@ import {
   keyDown,
   tabNavigateBackward,
   tabNavigateToWorkspace,
+  sendKeyAndWait,
   keyRight,
   getCurrentFocusNodeId,
   getCurrentFocusedBlockId,
@@ -167,7 +168,7 @@ suite('Toolbox and flyout test', function () {
   test('Tabbing to the workspace after selecting flyout block via workspace toolbox shortcut should close the flyout', async function () {
     await tabNavigateToWorkspace(this.browser);
 
-    await this.browser.keys('t');
+    await sendKeyAndWait(this.browser, 't');
     await keyRight(this.browser);
     await tabNavigateForward(this.browser);
 

--- a/test/webdriverio/test/flyout_test.ts
+++ b/test/webdriverio/test/flyout_test.ts
@@ -20,7 +20,7 @@ import {
 } from './test_setup.js';
 
 suite('Toolbox and flyout test', function () {
-  // Clear the workspace and load start blocks
+  // Clear the workspace and load start blocks.
   setup(async function () {
     this.browser = await testSetup(testFileLocations.BASE);
     await this.browser.pause(PAUSE_TIME);

--- a/test/webdriverio/test/insert_test.ts
+++ b/test/webdriverio/test/insert_test.ts
@@ -22,8 +22,8 @@ import {
 } from './test_setup.js';
 
 suite('Insert test', function () {
-  // Setting timeout to unlimited as these tests take longer time to run
-  this.timeout(0);
+  // Disable timeouts when non-zero PAUSE_TIME is used to watch tests run.
+  if (PAUSE_TIME) this.timeout(0);
 
   // Clear the workspace and load start blocks.
   setup(async function () {

--- a/test/webdriverio/test/insert_test.ts
+++ b/test/webdriverio/test/insert_test.ts
@@ -25,7 +25,7 @@ suite('Insert test', function () {
   // Setting timeout to unlimited as these tests take longer time to run
   this.timeout(0);
 
-  // Clear the workspace and load start blocks
+  // Clear the workspace and load start blocks.
   setup(async function () {
     this.browser = await testSetup(testFileLocations.BASE);
     await this.browser.pause(PAUSE_TIME);

--- a/test/webdriverio/test/insert_test.ts
+++ b/test/webdriverio/test/insert_test.ts
@@ -14,6 +14,7 @@ import {
   tabNavigateToWorkspace,
   testFileLocations,
   testSetup,
+  sendKeyAndWait,
   keyRight,
   getCurrentFocusedBlockId,
   blockIsPresent,
@@ -36,15 +37,15 @@ suite('Insert test', function () {
     await tabNavigateToWorkspace(this.browser);
     await focusOnBlock(this.browser, 'draw_circle_1');
     // Insert 'if' block
-    await this.browser.keys('t');
+    await sendKeyAndWait(this.browser, 't');
     await keyRight(this.browser);
-    await this.browser.keys(Key.Enter);
+    await sendKeyAndWait(this.browser, Key.Enter);
     chai.assert.equal('controls_if', await getFocusedBlockType(this.browser));
     const ifId = await getCurrentFocusedBlockId(this.browser);
     chai.assert.ok(ifId);
 
     // Cancel
-    await this.browser.keys(Key.Escape);
+    await sendKeyAndWait(this.browser, Key.Escape);
 
     chai.assert.isFalse(await blockIsPresent(this.browser, ifId));
   });
@@ -52,17 +53,17 @@ suite('Insert test', function () {
   test('Insert and cancel with workspace selection', async function () {
     // Navigate to workspace.
     await tabNavigateToWorkspace(this.browser);
-    await this.browser.keys('w');
+    await sendKeyAndWait(this.browser, 'w');
     // Insert 'if' block
-    await this.browser.keys('t');
+    await sendKeyAndWait(this.browser, 't');
     await keyRight(this.browser);
-    await this.browser.keys(Key.Enter);
+    await sendKeyAndWait(this.browser, Key.Enter);
     chai.assert.equal('controls_if', await getFocusedBlockType(this.browser));
     const ifId = await getCurrentFocusedBlockId(this.browser);
     chai.assert.ok(ifId);
 
     // Cancel
-    await this.browser.keys(Key.Escape);
+    await sendKeyAndWait(this.browser, Key.Escape);
 
     chai.assert.isFalse(await blockIsPresent(this.browser, ifId));
   });
@@ -76,9 +77,9 @@ suite('Insert test', function () {
     // Move to flyout.
     await keyRight(this.browser);
     // Select Function block.
-    await this.browser.keys(Key.Enter);
+    await sendKeyAndWait(this.browser, Key.Enter);
     // Confirm move.
-    await this.browser.keys(Key.Enter);
+    await sendKeyAndWait(this.browser, Key.Enter);
 
     chai.assert.equal(
       'procedures_defnoreturn',
@@ -92,9 +93,9 @@ suite('Insert test', function () {
     // Insert 'if' block
     await keyRight(this.browser);
     // Choose.
-    await this.browser.keys(Key.Enter);
+    await sendKeyAndWait(this.browser, Key.Enter);
     // Confirm position.
-    await this.browser.keys(Key.Enter);
+    await sendKeyAndWait(this.browser, Key.Enter);
 
     // Assert inserted inside first block p5_setup not at top-level.
     chai.assert.equal('controls_if', await getFocusedBlockType(this.browser));

--- a/test/webdriverio/test/keyboard_mode_test.ts
+++ b/test/webdriverio/test/keyboard_mode_test.ts
@@ -14,6 +14,7 @@ import {
   getBlockElementById,
   tabNavigateToWorkspace,
   clickBlock,
+  sendKeyAndWait,
 } from './test_setup.js';
 import {Key} from 'webdriverio';
 
@@ -46,8 +47,7 @@ suite(
 
     test('T to open toolbox enables keyboard mode', async function () {
       await this.browser.pause(PAUSE_TIME);
-      await this.browser.keys('t');
-      await this.browser.pause(PAUSE_TIME);
+      await sendKeyAndWait(this.browser, 't');
 
       chai.assert.isTrue(await isKeyboardNavigating(this.browser));
     });
@@ -55,15 +55,14 @@ suite(
     test('M for move mode enables keyboard mode', async function () {
       await focusOnBlock(this.browser, 'controls_if_2');
       await this.browser.pause(PAUSE_TIME);
-      await this.browser.keys('m');
+      await sendKeyAndWait(this.browser, 'm');
 
       chai.assert.isTrue(await isKeyboardNavigating(this.browser));
     });
 
     test('W for workspace cursor enables keyboard mode', async function () {
       await this.browser.pause(PAUSE_TIME);
-      await this.browser.keys('w');
-      await this.browser.pause(PAUSE_TIME);
+      await sendKeyAndWait(this.browser, 'w');
 
       chai.assert.isTrue(await isKeyboardNavigating(this.browser));
     });
@@ -71,8 +70,7 @@ suite(
     test('X to disconnect enables keyboard mode', async function () {
       await focusOnBlock(this.browser, 'controls_if_2');
       await this.browser.pause(PAUSE_TIME);
-      await this.browser.keys('x');
-      await this.browser.pause(PAUSE_TIME);
+      await sendKeyAndWait(this.browser, 'x');
 
       chai.assert.isTrue(await isKeyboardNavigating(this.browser));
     });
@@ -81,8 +79,7 @@ suite(
       // Make sure we're on a copyable block so that copy occurs
       await focusOnBlock(this.browser, 'controls_if_2');
       await this.browser.pause(PAUSE_TIME);
-      await this.browser.keys([Key.Ctrl, 'c']);
-      await this.browser.pause(PAUSE_TIME);
+      await sendKeyAndWait(this.browser, [Key.Ctrl, 'c']);
 
       chai.assert.isFalse(await isKeyboardNavigating(this.browser));
 
@@ -91,8 +88,7 @@ suite(
       });
 
       await this.browser.pause(PAUSE_TIME);
-      await this.browser.keys([Key.Ctrl, 'c']);
-      await this.browser.pause(PAUSE_TIME);
+      await sendKeyAndWait(this.browser, [Key.Ctrl, 'c']);
 
       chai.assert.isTrue(await isKeyboardNavigating(this.browser));
     });
@@ -101,8 +97,7 @@ suite(
       // Make sure we're on a deletable block so that delete occurs
       await focusOnBlock(this.browser, 'controls_if_2');
       await this.browser.pause(PAUSE_TIME);
-      await this.browser.keys(Key.Backspace);
-      await this.browser.pause(PAUSE_TIME);
+      await sendKeyAndWait(this.browser, Key.Backspace);
 
       chai.assert.isFalse(await isKeyboardNavigating(this.browser));
 
@@ -113,8 +108,7 @@ suite(
       // Focus a different deletable block
       await focusOnBlock(this.browser, 'controls_if_1');
       await this.browser.pause(PAUSE_TIME);
-      await this.browser.keys(Key.Backspace);
-      await this.browser.pause(PAUSE_TIME);
+      await sendKeyAndWait(this.browser, Key.Backspace);
 
       chai.assert.isTrue(await isKeyboardNavigating(this.browser));
     });

--- a/test/webdriverio/test/keyboard_mode_test.ts
+++ b/test/webdriverio/test/keyboard_mode_test.ts
@@ -26,8 +26,8 @@ const isKeyboardNavigating = function (browser: WebdriverIO.Browser) {
 suite(
   'Keyboard navigation mode set on mouse or keyboard interaction',
   function () {
-    // Setting timeout to unlimited as these tests take a longer time to run than most mocha tests
-    this.timeout(0);
+    // Disable timeouts when non-zero PAUSE_TIME is used to watch tests run.
+    if (PAUSE_TIME) this.timeout(0);
 
     setup(async function () {
       // Reload the page between tests

--- a/test/webdriverio/test/move_test.ts
+++ b/test/webdriverio/test/move_test.ts
@@ -18,8 +18,8 @@ import {
 } from './test_setup.js';
 
 suite('Move tests', function () {
-  // Setting timeout to unlimited as these tests take longer time to run
-  this.timeout(0);
+  // Disable timeouts when non-zero PAUSE_TIME is used to watch tests run.
+  if (PAUSE_TIME) this.timeout(0);
 
   // Clear the workspace and load start blocks.
   setup(async function () {

--- a/test/webdriverio/test/move_test.ts
+++ b/test/webdriverio/test/move_test.ts
@@ -18,8 +18,9 @@ import {
 } from './test_setup.js';
 
 suite('Move tests', function () {
-  // Disable timeouts when non-zero PAUSE_TIME is used to watch tests run.
-  if (PAUSE_TIME) this.timeout(0);
+  // Increase timeout to 10s for this longer test (but disable
+  // timeouts if when non-zero PAUSE_TIME is used to watch tests) run.
+  this.timeout(PAUSE_TIME ? 0 : 10000);
 
   // Clear the workspace and load start blocks.
   setup(async function () {

--- a/test/webdriverio/test/move_test.ts
+++ b/test/webdriverio/test/move_test.ts
@@ -50,7 +50,7 @@ suite('Move tests', function () {
       chai.assert(info.nextId, 'selected block has no next block');
 
       // Start move.
-      await this.browser.keys('m');
+      await sendKeyAndWait(this.browser, 'm');
 
       // Check that the moving block has nothing connected it its
       // next/previous connections, and same thing connected to value
@@ -85,7 +85,7 @@ suite('Move tests', function () {
       );
 
       // Abort move.
-      await this.browser.keys(Key.Escape);
+      await sendKeyAndWait(this.browser, Key.Escape);
     }
   });
 
@@ -110,7 +110,7 @@ suite('Move tests', function () {
       chai.assert(info.valueId, 'selected block has no child value block');
 
       // Start move.
-      await this.browser.keys('m');
+      await sendKeyAndWait(this.browser, 'm');
 
       // Check that the moving block has nothing connected it its
       // next/previous connections, and same thing connected to value
@@ -144,7 +144,7 @@ suite('Move tests', function () {
       );
 
       // Abort move.
-      await this.browser.keys(Key.Escape);
+      await sendKeyAndWait(this.browser, Key.Escape);
     }
   });
 
@@ -168,7 +168,7 @@ suite('Move tests', function () {
     await tabNavigateToWorkspace(this.browser);
     await focusOnBlock(this.browser, BLOCK);
     const startCoordinate = await getCoordinate(this.browser, BLOCK);
-    await this.browser.keys('m');
+    await sendKeyAndWait(this.browser, 'm');
 
     // Check constrained moves have no effect.
     await keyDown(this.browser, 5);
@@ -201,7 +201,7 @@ suite('Move tests', function () {
     }
 
     // Abort move.
-    await this.browser.keys(Key.Escape);
+    await sendKeyAndWait(this.browser, Key.Escape);
   });
 });
 

--- a/test/webdriverio/test/move_test.ts
+++ b/test/webdriverio/test/move_test.ts
@@ -21,7 +21,7 @@ suite('Move tests', function () {
   // Setting timeout to unlimited as these tests take longer time to run
   this.timeout(0);
 
-  // Clear the workspace and load start blocks
+  // Clear the workspace and load start blocks.
   setup(async function () {
     this.browser = await testSetup(testFileLocations.MOVE_TEST_BLOCKS);
     await this.browser.pause(PAUSE_TIME);

--- a/test/webdriverio/test/mutator_test.ts
+++ b/test/webdriverio/test/mutator_test.ts
@@ -15,6 +15,7 @@ import {
   testFileLocations,
   PAUSE_TIME,
   tabNavigateToWorkspace,
+  sendKeyAndWait,
   keyRight,
   keyDown,
 } from './test_setup.js';
@@ -35,8 +36,7 @@ suite('Mutator navigation', function () {
       // Navigate to the mutator icon
       await keyRight(this.browser);
       // Activate the icon
-      await this.browser.keys(Key.Enter);
-      await this.browser.pause(PAUSE_TIME);
+      await sendKeyAndWait(this.browser, Key.Enter);
     };
   });
 
@@ -54,8 +54,7 @@ suite('Mutator navigation', function () {
 
   test('Escape dismisses mutator', async function () {
     await this.openMutator();
-    await this.browser.keys(Key.Escape);
-    await this.browser.pause(PAUSE_TIME);
+    await sendKeyAndWait(this.browser, Key.Escape);
 
     // Main workspace should be the focused tree (since mutator workspace is gone)
     const mainWorkspaceFocused = await focusedTreeIsMainWorkspace(this.browser);
@@ -75,11 +74,9 @@ suite('Mutator navigation', function () {
   test('Escape in the mutator flyout focuses the mutator workspace', async function () {
     await this.openMutator();
     // Focus the flyout
-    await this.browser.keys('t');
-    await this.browser.pause(PAUSE_TIME);
+    await sendKeyAndWait(this.browser, 't');
     // Hit escape to return focus to the mutator workspace
-    await this.browser.keys(Key.Escape);
-    await this.browser.pause(PAUSE_TIME);
+    await sendKeyAndWait(this.browser, Key.Escape);
     // The "if" placeholder block in the mutator should be focused
     const focusedBlockType = await getFocusedBlockType(this.browser);
     chai.assert.equal(focusedBlockType, 'controls_if_if');
@@ -87,8 +84,7 @@ suite('Mutator navigation', function () {
 
   test('T focuses the mutator flyout', async function () {
     await this.openMutator();
-    await this.browser.keys('t');
-    await this.browser.pause(PAUSE_TIME);
+    await sendKeyAndWait(this.browser, 't');
 
     // The "else if" block in the mutator flyout should be focused
     const focusedBlockType = await getFocusedBlockType(this.browser);
@@ -97,16 +93,14 @@ suite('Mutator navigation', function () {
 
   test('Blocks can be inserted from the mutator flyout', async function () {
     await this.openMutator();
-    await this.browser.keys('t');
-    await this.browser.pause(PAUSE_TIME);
+    await sendKeyAndWait(this.browser, 't');
     // Navigate down to the second block in the flyout
     await keyDown(this.browser);
     await this.browser.pause(PAUSE_TIME);
     // Hit enter to enter insert mode
-    await this.browser.keys(Key.Enter);
-    await this.browser.pause(PAUSE_TIME);
+    await sendKeyAndWait(this.browser, Key.Enter);
     // Hit enter again to lock it into place on the connection
-    await this.browser.keys(Key.Enter);
+    await sendKeyAndWait(this.browser, Key.Enter);
 
     const topBlocks = await this.browser.execute(() => {
       const focusedTree = Blockly.getFocusManager().getFocusedTree();

--- a/test/webdriverio/test/mutator_test.ts
+++ b/test/webdriverio/test/mutator_test.ts
@@ -21,8 +21,8 @@ import {
 import {Key} from 'webdriverio';
 
 suite('Mutator navigation', function () {
-  // Setting timeout to unlimited as these tests take a longer time to run than most mocha test
-  this.timeout(0);
+  // Disable timeouts when non-zero PAUSE_TIME is used to watch tests run.
+  if (PAUSE_TIME) this.timeout(0);
 
   // Clear the workspace and load start blocks.
   setup(async function () {

--- a/test/webdriverio/test/mutator_test.ts
+++ b/test/webdriverio/test/mutator_test.ts
@@ -24,7 +24,7 @@ suite('Mutator navigation', function () {
   // Setting timeout to unlimited as these tests take a longer time to run than most mocha test
   this.timeout(0);
 
-  // Setup Selenium for all of the tests
+  // Clear the workspace and load start blocks.
   setup(async function () {
     this.browser = await testSetup(testFileLocations.NAVIGATION_TEST_BLOCKS);
     this.openMutator = async () => {

--- a/test/webdriverio/test/scroll_test.ts
+++ b/test/webdriverio/test/scroll_test.ts
@@ -8,6 +8,7 @@ import * as Blockly from 'blockly';
 import * as chai from 'chai';
 import {Key} from 'webdriverio';
 import {
+  sendKeyAndWait,
   keyDown,
   keyRight,
   PAUSE_TIME,
@@ -48,9 +49,9 @@ suite('Scrolling into view', function () {
 
     // Separate the two top-level blocks by moving p5_draw_1 further down.
     await keyDown(this.browser, 3);
-    await this.browser.keys('m');
-    await this.browser.keys([Key.Alt, ...new Array(25).fill(Key.ArrowDown)]);
-    await this.browser.keys(Key.Enter);
+    await sendKeyAndWait(this.browser, 'm');
+    await sendKeyAndWait(this.browser, [Key.Alt, Key.ArrowDown], 25);
+    await sendKeyAndWait(this.browser, Key.Enter);
     // Scroll back up, leaving cursor on the draw block out of the viewport.
     await this.browser.execute(() => {
       const workspace = Blockly.getMainWorkspace() as Blockly.WorkspaceSvg;
@@ -62,10 +63,9 @@ suite('Scrolling into view', function () {
     });
 
     // Insert and confirm the test block which should be scrolled into view.
-    await this.browser.keys('t');
+    await sendKeyAndWait(this.browser, 't');
     await keyRight(this.browser);
-    await this.browser.keys(Key.Enter);
-    await this.browser.keys(Key.Enter);
+    await sendKeyAndWait(this.browser, Key.Enter, 2);
 
     // Assert new block has been scrolled into the viewport.
     await this.browser.pause(PAUSE_TIME);

--- a/test/webdriverio/test/scroll_test.ts
+++ b/test/webdriverio/test/scroll_test.ts
@@ -17,8 +17,8 @@ import {
 } from './test_setup.js';
 
 suite('Scrolling into view', function () {
-  // Setting timeout to unlimited as these tests take longer time to run
-  this.timeout(0);
+  // Disable timeouts when non-zero PAUSE_TIME is used to watch tests run.
+  if (PAUSE_TIME) this.timeout(0);
 
   // Resize browser to provide predictable small window size for scrolling.
   //

--- a/test/webdriverio/test/scroll_test.ts
+++ b/test/webdriverio/test/scroll_test.ts
@@ -20,12 +20,27 @@ suite('Scrolling into view', function () {
   // Setting timeout to unlimited as these tests take longer time to run
   this.timeout(0);
 
-  // Clear the workspace and load start blocks
-  setup(async function () {
+  // Resize browser to provide predictable small window size for scrolling.
+  //
+  // N.B. that this is called only one per suite, not once per test.
+  suiteSetup(async function () {
     this.browser = await testSetup(testFileLocations.BASE);
-    // Predictable small window size for scrolling.
+    this.windowSize = await this.browser.getWindowSize();
     await this.browser.setWindowSize(800, 600);
     await this.browser.pause(PAUSE_TIME);
+  });
+
+  // Restore original browser window size.
+  suiteTeardown(async function () {
+    await this.browser.setWindowSize(
+      this.windowSize.width,
+      this.windowSize.height,
+    );
+  });
+
+  // Clear the workspace and load start blocks.
+  setup(async function () {
+    await testSetup(testFileLocations.BASE);
   });
 
   test('Insert scrolls new block into view', async function () {

--- a/test/webdriverio/test/scroll_test.ts
+++ b/test/webdriverio/test/scroll_test.ts
@@ -45,6 +45,9 @@ suite('Scrolling into view', function () {
   });
 
   test('Insert scrolls new block into view', async function () {
+    // Increase timeout to 10s for this longer test.
+    this.timeout(PAUSE_TIME ? 0 : 10000);
+
     await tabNavigateToWorkspace(this.browser);
 
     // Separate the two top-level blocks by moving p5_draw_1 further down.

--- a/test/webdriverio/test/stack_navigation.ts
+++ b/test/webdriverio/test/stack_navigation.ts
@@ -18,7 +18,7 @@ suite('Stack navigation', function () {
   // Setting timeout to unlimited as these tests take longer time to run
   this.timeout(0);
 
-  // Clear the workspace and load start blocks
+  // Clear the workspace and load start blocks.
   setup(async function () {
     this.browser = await testSetup(testFileLocations.COMMENTS);
     await this.browser.pause(PAUSE_TIME);

--- a/test/webdriverio/test/stack_navigation.ts
+++ b/test/webdriverio/test/stack_navigation.ts
@@ -15,9 +15,6 @@ import {
 } from './test_setup.js';
 
 suite('Stack navigation', function () {
-  // Setting timeout to unlimited as these tests take longer time to run
-  this.timeout(0);
-
   // Clear the workspace and load start blocks.
   setup(async function () {
     this.browser = await testSetup(testFileLocations.COMMENTS);

--- a/test/webdriverio/test/stack_navigation.ts
+++ b/test/webdriverio/test/stack_navigation.ts
@@ -12,6 +12,7 @@ import {
   tabNavigateToWorkspace,
   testFileLocations,
   testSetup,
+  sendKeyAndWait,
 } from './test_setup.js';
 
 suite('Stack navigation', function () {
@@ -27,17 +28,17 @@ suite('Stack navigation', function () {
       'p5_setup_1',
       await getCurrentFocusedBlockId(this.browser),
     );
-    await this.browser.keys('n');
+    await sendKeyAndWait(this.browser, 'n');
     chai.assert.equal(
       'p5_draw_1',
       await getCurrentFocusedBlockId(this.browser),
     );
-    await this.browser.keys('n');
+    await sendKeyAndWait(this.browser, 'n');
     chai.assert.equal(
       'workspace_comment_1',
       await getCurrentFocusNodeId(this.browser),
     );
-    await this.browser.keys('n');
+    await sendKeyAndWait(this.browser, 'n');
     // Looped around.
     chai.assert.equal(
       'p5_setup_1',
@@ -51,18 +52,18 @@ suite('Stack navigation', function () {
       'p5_setup_1',
       await getCurrentFocusedBlockId(this.browser),
     );
-    await this.browser.keys('b');
+    await sendKeyAndWait(this.browser, 'b');
     // Looped to bottom.
     chai.assert.equal(
       'workspace_comment_1',
       await getCurrentFocusNodeId(this.browser),
     );
-    await this.browser.keys('b');
+    await sendKeyAndWait(this.browser, 'b');
     chai.assert.equal(
       'p5_draw_1',
       await getCurrentFocusedBlockId(this.browser),
     );
-    await this.browser.keys('b');
+    await sendKeyAndWait(this.browser, 'b');
     chai.assert.equal(
       'p5_setup_1',
       await getCurrentFocusedBlockId(this.browser),

--- a/test/webdriverio/test/styling_test.ts
+++ b/test/webdriverio/test/styling_test.ts
@@ -21,7 +21,7 @@ suite('Styling test', function () {
   // Setting timeout to unlimited as these tests take longer time to run
   this.timeout(0);
 
-  // Clear the workspace and load start blocks
+  // Clear the workspace and load start blocks.
   setup(async function () {
     this.browser = await testSetup(testFileLocations.BASE);
     await this.browser.pause(PAUSE_TIME);

--- a/test/webdriverio/test/styling_test.ts
+++ b/test/webdriverio/test/styling_test.ts
@@ -18,8 +18,8 @@ import {
 import * as chai from 'chai';
 
 suite('Styling test', function () {
-  // Setting timeout to unlimited as these tests take longer time to run
-  this.timeout(0);
+  // Disable timeouts when non-zero PAUSE_TIME is used to watch tests run.
+  if (PAUSE_TIME) this.timeout(0);
 
   // Clear the workspace and load start blocks.
   setup(async function () {

--- a/test/webdriverio/test/test_setup.ts
+++ b/test/webdriverio/test/test_setup.ts
@@ -27,10 +27,22 @@ import {fileURLToPath} from 'url';
 let driver: webdriverio.Browser | null = null;
 
 /**
- * The default amount of time to wait during a test. Increase this to make
- * tests easier to watch; decrease it to make tests run faster.
+ * The default amount of time to wait during a test, in ms.  Increase
+ * this to make tests easier to watch; decrease it to make tests run
+ * faster.
+ *
+ * The _test.js files in this directory are set up to disable timeouts
+ * automatically when PAUSE_TIME is set to a nonzero value via
+ *
+ *     if (PAUSE_TIME) this.timeout(0);
+ *
+ * at the top of each suite.
+ *
+ * Tests should pass reliably even with this set to zero; use one of
+ * the browser.wait* functions if you need your test to wait for
+ * something to happen after sending input.
  */
-export const PAUSE_TIME = 50;
+export const PAUSE_TIME = 0;
 
 /**
  * Start up WebdriverIO and load the test page. This should only be

--- a/test/webdriverio/test/test_setup.ts
+++ b/test/webdriverio/test/test_setup.ts
@@ -455,8 +455,14 @@ export async function tabNavigateToWorkspace(
   hasToolbox = true,
   hasFlyout = true,
 ) {
-  // Navigate past the initial pre-injection focusable div element.
-  await tabNavigateForward(browser);
+  // Move focus to initial pre-injection focusable div element.
+  //
+  // Ideally we'd just rest focus state to the state it is in when the
+  // document initially loads (and then send one tab), but alas
+  // there's no straightforward way to do that; see
+  // https://stackoverflow.com/q/51518855/4969945
+  await browser.execute(() => document.getElementById('focusableDiv')?.focus());
+  // Navigate to workspace.
   if (hasToolbox) await tabNavigateForward(browser);
   if (hasFlyout) await tabNavigateForward(browser);
   await tabNavigateForward(browser); // Tab to the workspace itself.

--- a/test/webdriverio/test/test_setup.ts
+++ b/test/webdriverio/test/test_setup.ts
@@ -11,9 +11,9 @@
  * This file is to be used in the suiteSetup for any automated fuctional test.
  *
  * Note: In this file many functions return browser elements that can
- * be clicked or otherwise interacted with through Selenium WebDriver. These
+ * be clicked or otherwise interacted with through WebdriverIO. These
  * elements are not the raw HTML and SVG elements on the page; they are
- * identifiers that Selenium can use to find those elements.
+ * identifiers that WebdriverIO can use to find those elements.
  */
 
 import * as Blockly from 'blockly';
@@ -33,10 +33,12 @@ let driver: webdriverio.Browser | null = null;
 export const PAUSE_TIME = 50;
 
 /**
- * Start up the test page. This should only be done once, to avoid
- * constantly popping browser windows open and closed.
+ * Start up WebdriverIO and load the test page. This should only be
+ * done once, to avoid constantly popping browser windows open and
+ * closed.
  *
- * @returns A Promise that resolves to a webdriverIO browser that tests can manipulate.
+ * @returns A Promise that resolves to a WebdriverIO browser that
+ *     tests can manipulate.
  */
 export async function driverSetup(): Promise<webdriverio.Browser> {
   const options = {
@@ -68,14 +70,14 @@ export async function driverSetup(): Promise<webdriverio.Browser> {
     // https://github.com/google/blockly/issues/5345 for details.
     options.capabilities['goog:chromeOptions'].args.push('--disable-gpu');
   }
-  // Use Selenium to bring up the page
+  // Use webdriver to bring up the page
   console.log('Starting webdriverio...');
   driver = await webdriverio.remote(options);
   return driver;
 }
 
 /**
- * End the webdriverIO session.
+ * End the WebdriverIO session.
  *
  * @return A Promise that resolves after the actions have been completed.
  */
@@ -90,7 +92,8 @@ export async function driverTeardown() {
  *
  * @param playgroundUrl The URL to open for the test, which should be
  *     a Blockly playground with a workspace.
- * @returns A Promise that resolves to a webdriverIO browser that tests can manipulate.
+ * @returns A Promise that resolves to a WebdriverIO browser that
+ *     tests can manipulate.
  */
 export async function testSetup(
   playgroundUrl: string,
@@ -679,7 +682,7 @@ export async function clickBlock(
     findableId,
   );
 
-  // In the test context, get the Webdriverio Element that we've identified.
+  // In the test context, get the WebdriverIO Element that we've identified.
   const elem = await browser.$(`#${findableId}`);
 
   await elem.click(clickOptions);

--- a/test/webdriverio/test/test_setup.ts
+++ b/test/webdriverio/test/test_setup.ts
@@ -457,8 +457,8 @@ export async function tabNavigateToWorkspace(
 ) {
   // Move focus to initial pre-injection focusable div element.
   //
-  // Ideally we'd just rest focus state to the state it is in when the
-  // document initially loads (and then send one tab), but alas
+  // Ideally we'd just reset focus state to the state it is in when
+  // the document initially loads (and then send one tab), but alas
   // there's no straightforward way to do that; see
   // https://stackoverflow.com/q/51518855/4969945
   await browser.execute(() => document.getElementById('focusableDiv')?.focus());

--- a/test/webdriverio/test/toast_test.ts
+++ b/test/webdriverio/test/toast_test.ts
@@ -9,6 +9,7 @@ import * as Blockly from 'blockly/core';
 import {PAUSE_TIME, testFileLocations, testSetup} from './test_setup.js';
 
 suite('HTML toasts', function () {
+  // Clear the workspace and load start blocks.
   setup(async function () {
     this.browser = await testSetup(testFileLocations.BASE);
     await this.browser.pause(PAUSE_TIME);

--- a/test/webdriverio/test/toast_test.ts
+++ b/test/webdriverio/test/toast_test.ts
@@ -9,6 +9,9 @@ import * as Blockly from 'blockly/core';
 import {PAUSE_TIME, testFileLocations, testSetup} from './test_setup.js';
 
 suite('HTML toasts', function () {
+  // Disable timeouts when non-zero PAUSE_TIME is used to watch tests run.
+  if (PAUSE_TIME) this.timeout(0);
+
   // Clear the workspace and load start blocks.
   setup(async function () {
     this.browser = await testSetup(testFileLocations.BASE);

--- a/test/webdriverio/test/workspace_comment_test.ts
+++ b/test/webdriverio/test/workspace_comment_test.ts
@@ -19,6 +19,7 @@ import {
   keyDown,
   keyUp,
   contextMenuItems,
+  PAUSE_TIME,
 } from './test_setup.js';
 import {Key} from 'webdriverio';
 

--- a/test/webdriverio/test/workspace_comment_test.ts
+++ b/test/webdriverio/test/workspace_comment_test.ts
@@ -23,6 +23,9 @@ import {
 import {Key} from 'webdriverio';
 
 suite('Workspace comment navigation', function () {
+  // Disable timeouts when non-zero PAUSE_TIME is used to watch tests run.
+  if (PAUSE_TIME) this.timeout(0);
+
   // Clear the workspace and load start blocks.
   setup(async function () {
     this.browser = await testSetup(testFileLocations.NAVIGATION_TEST_BLOCKS);

--- a/test/webdriverio/test/workspace_comment_test.ts
+++ b/test/webdriverio/test/workspace_comment_test.ts
@@ -26,7 +26,7 @@ suite('Workspace comment navigation', function () {
   // Setting timeout to unlimited as these tests take a longer time to run than most mocha test
   this.timeout(0);
 
-  // Setup Selenium for all of the tests
+  // Clear the workspace and load start blocks.
   setup(async function () {
     this.browser = await testSetup(testFileLocations.NAVIGATION_TEST_BLOCKS);
     [this.commentId1, this.commentId2] = await this.browser.execute(() => {

--- a/test/webdriverio/test/workspace_comment_test.ts
+++ b/test/webdriverio/test/workspace_comment_test.ts
@@ -23,9 +23,6 @@ import {
 import {Key} from 'webdriverio';
 
 suite('Workspace comment navigation', function () {
-  // Setting timeout to unlimited as these tests take a longer time to run than most mocha test
-  this.timeout(0);
-
   // Clear the workspace and load start blocks.
   setup(async function () {
     this.browser = await testSetup(testFileLocations.NAVIGATION_TEST_BLOCKS);


### PR DESCRIPTION
A bunch of small fixes and refactors of tests:

* fix: Have `scroll_test.ts` restore the original browser window size after it's done.
* docs: Use "WebdriverIO" instead of "Selenium" (since we don't use Selenium!)
* chore: Make `timeout(0)` calls only when `PAUSE_TIME` is nonzero (and make them in every suite).
* fix: Set `PAUSE_TIME` to `0`, making tests run about 50% faster.
* refactor: Use `sendKeyAndWait` almost everywhere (instead of `browser.keys`).
* fix(tests): Make `tabNavigateToWorkspace` idempotent, to avoid relying on a bug #632.
* chore(tests): Remove `tabNavigateToWorkspace` calls that are immediately followed by a `focusOnBlock` call.

This is a rebase, with updates, of the changes from (and supercedes) PR #660, and incorporates changes based on the comments thereto.