### PR TITLE
refactor(tests): Remove unneeded `tabNavigateToWorkspace` calls

### DIFF
--- a/test/webdriverio/test/duplicate_test.ts
+++ b/test/webdriverio/test/duplicate_test.ts
@@ -29,7 +29,6 @@ suite('Duplicate test', function () {
 
   test('Duplicate block', async function () {
     // Navigate to draw_circle_1.
-    await tabNavigateToWorkspace(this.browser);
     await focusOnBlock(this.browser, 'draw_circle_1');
 
     // Duplicate

--- a/test/webdriverio/test/insert_test.ts
+++ b/test/webdriverio/test/insert_test.ts
@@ -34,7 +34,6 @@ suite('Insert test', function () {
 
   test('Insert and cancel with block selection', async function () {
     // Navigate to draw_circle_1.
-    await tabNavigateToWorkspace(this.browser);
     await focusOnBlock(this.browser, 'draw_circle_1');
     // Insert 'if' block
     await sendKeyAndWait(this.browser, 't');
@@ -70,7 +69,6 @@ suite('Insert test', function () {
 
   test('Insert C-shaped block with statement block selected', async function () {
     // Navigate to draw_circle_1.
-    await tabNavigateToWorkspace(this.browser);
     await focusOnBlock(this.browser, 'draw_circle_1');
 
     await moveToToolboxCategory(this.browser, 'Functions');

--- a/test/webdriverio/test/move_test.ts
+++ b/test/webdriverio/test/move_test.ts
@@ -10,7 +10,6 @@ import {Browser, Key} from 'webdriverio';
 import {
   PAUSE_TIME,
   focusOnBlock,
-  tabNavigateToWorkspace,
   testFileLocations,
   testSetup,
   sendKeyAndWait,
@@ -36,7 +35,6 @@ suite('Move tests', function () {
   test('Start moving statement blocks', async function () {
     for (let i = 1; i < 7; i++) {
       // Navigate to statement_<i>.
-      await tabNavigateToWorkspace(this.browser);
       await focusOnBlock(this.browser, `statement_${i}`);
 
       // Get information about parent connection of selected block,
@@ -96,7 +94,6 @@ suite('Move tests', function () {
   test('Start moving value blocks', async function () {
     for (let i = 1; i < 7; i++) {
       // Navigate to statement_<i>.
-      await tabNavigateToWorkspace(this.browser);
       await focusOnBlock(this.browser, `value_${i}`);
 
       // Get information about parent connection of selected block,
@@ -166,7 +163,6 @@ suite('Move tests', function () {
     });
 
     // Navigate to unconnectable block, get initial coords and start move.
-    await tabNavigateToWorkspace(this.browser);
     await focusOnBlock(this.browser, BLOCK);
     const startCoordinate = await getCoordinate(this.browser, BLOCK);
     await sendKeyAndWait(this.browser, 'm');

--- a/test/webdriverio/test/mutator_test.ts
+++ b/test/webdriverio/test/mutator_test.ts
@@ -14,7 +14,6 @@ import {
   testSetup,
   testFileLocations,
   PAUSE_TIME,
-  tabNavigateToWorkspace,
   sendKeyAndWait,
   keyRight,
   keyDown,
@@ -29,8 +28,6 @@ suite('Mutator navigation', function () {
   setup(async function () {
     this.browser = await testSetup(testFileLocations.NAVIGATION_TEST_BLOCKS);
     this.openMutator = async () => {
-      await tabNavigateToWorkspace(this.browser);
-      await this.browser.pause(PAUSE_TIME);
       await focusOnBlock(this.browser, 'controls_if_1');
       await this.browser.pause(PAUSE_TIME);
       // Navigate to the mutator icon

--- a/test/webdriverio/test/styling_test.ts
+++ b/test/webdriverio/test/styling_test.ts
@@ -81,7 +81,6 @@ suite('Styling test', function () {
   });
 
   test('Workspace has only active tree style when move is in progress', async function () {
-    await tabNavigateToWorkspace(this.browser);
     await focusOnBlock(this.browser, 'set_background_color_1');
     // Moves block to drag layer which requires different selectors.
     await sendKeyAndWait(this.browser, 'm');
@@ -91,7 +90,6 @@ suite('Styling test', function () {
   });
 
   test('Workspace has only active tree style when widget has focus', async function () {
-    await tabNavigateToWorkspace(this.browser);
     await focusOnBlock(this.browser, 'create_canvas_1');
     // Move to field.
     await keyRight(this.browser);
@@ -103,7 +101,6 @@ suite('Styling test', function () {
   });
 
   test('Workspace has only active tree style when dropdown has focus', async function () {
-    await tabNavigateToWorkspace(this.browser);
     await focusOnBlock(this.browser, 'set_background_color_1');
     // Move to color block.
     await keyRight(this.browser);


### PR DESCRIPTION
The `focusOnBlock` function moves focus to the workspace regardless of where it was previously, so there's no need to call `tabNavigateToWorkspace` first.

Completes a refactor started in #692 (commit [06ab50c](https://github.com/google/blockly-keyboard-experimentation/pull/692/commits/06ab50cb4a2d3131b17212c4629b9a7ec30fb986)).