### PR TITLE
test(`Mover`): Add test for moving statement blocks

### DIFF
--- a/test/index.html
+++ b/test/index.html
@@ -108,7 +108,9 @@
                 <option value="navigationTestBlocks">
                   navigation test blocks
                 </option>
-                <option value="moveTestBlocks">move test blocks</option>
+                <option value="moveStartTestBlocks">
+                  move start test blocks
+                </option>
                 <option value="comments">comments</option>
               </select>
             </div>

--- a/test/index.html
+++ b/test/index.html
@@ -111,6 +111,9 @@
                 <option value="moveStartTestBlocks">
                   move start test blocks
                 </option>
+                <option value="moveStatementTestBlocks">
+                  move statement test blocks
+                </option>
                 <option value="comments">comments</option>
               </select>
             </div>

--- a/test/loadTestBlocks.js
+++ b/test/loadTestBlocks.js
@@ -870,9 +870,9 @@ const moveStartTestBlocks = {
   },
 };
 
-// A bunch of statement blocks.  The draw_emoji block will be
-// (constrained) moved up, down, left and right to verify that it
-// visits the expected positions.
+// A bunch of statement blocks.  The blocks with IDs simple_mover and
+// complex_mover will be (constrained-)moved up, down, left and right
+// to verify that they visit all the expected candidate connections.
 const moveStatementTestBlocks = {
   'blocks': {
     'languageVersion': 0,
@@ -880,7 +880,7 @@ const moveStatementTestBlocks = {
       {
         'type': 'p5_setup',
         'id': 'p5_setup',
-        'x': 0,
+        'x': 75,
         'y': 75,
         'deletable': false,
         'inputs': {
@@ -897,9 +897,18 @@ const moveStatementTestBlocks = {
               'next': {
                 'block': {
                   'type': 'draw_emoji',
-                  'id': 'draw_emoji',
+                  'id': 'simple_mover',
                   'fields': {
-                    'emoji': '✨',
+                    'emoji': '✨'
+                  },
+                  'next': {
+                    'block': {
+                      'type': 'controls_if',
+                      'id': 'complex_mover',
+                      'extraState': {
+                        'hasElse': true,
+                      },
+                    },
                   },
                 },
               },
@@ -910,8 +919,11 @@ const moveStatementTestBlocks = {
       {
         'type': 'text_print',
         'id': 'text_print',
-        'x': 0,
-        'y': 300,
+        "disabledReasons": [
+          "MANUALLY_DISABLED"
+        ],
+        'x': 75,
+        'y': 400,
         'inputs': {
           'TEXT': {
             'shadow': {
@@ -956,8 +968,8 @@ const moveStatementTestBlocks = {
       {
         'type': 'p5_draw',
         'id': 'p5_draw',
-        'x': 0,
-        'y': 753,
+        'x': 75,
+        'y': 950,
         'deletable': false,
       },
     ],

--- a/test/loadTestBlocks.js
+++ b/test/loadTestBlocks.js
@@ -570,7 +570,15 @@ const navigationTestBlocks = {
   },
 };
 
-const moveTestBlocks = {
+// The draw block contains a stack of statement blocks, each of which
+// has a value input to which is connected a value expression block
+// which itself has one or two inputs which have (non-shadow) simple
+// value blocks connected.  Each statement block will be selected in
+// turn and then a move initiated (and then aborted).  This is then
+// repeated with the first level value blocks (those that are attached
+// to the statement blocks).  The second level value blocks are
+// present to verify correct (lack of) heal behaviour.
+const moveStartTestBlocks = {
   'blocks': {
     'languageVersion': 0,
     'blocks': [
@@ -985,17 +993,15 @@ const comments = {
 export const load = function (workspace, scenarioString) {
   const scenarioMap = {
     'blank': blankCanvas,
-    'comments': comments,
-    'moreBlocks': moreBlocks,
-    'moveTestBlocks': moveTestBlocks,
-    'navigationTestBlocks': navigationTestBlocks,
-    'simpleCircle': simpleCircle,
+    comments,
+    moreBlocks,
+    moveStartTestBlocks,
+    navigationTestBlocks,
+    simpleCircle,
     'sun': sunnyDay,
   };
-
-  const data = JSON.stringify(scenarioMap[scenarioString]);
   // Don't emit events during loading.
   Blockly.Events.disable();
-  Blockly.serialization.workspaces.load(JSON.parse(data), workspace, false);
+  Blockly.serialization.workspaces.load(scenarioMap[scenarioString], workspace, false);
   Blockly.Events.enable();
 };

--- a/test/loadTestBlocks.js
+++ b/test/loadTestBlocks.js
@@ -870,6 +870,100 @@ const moveStartTestBlocks = {
   },
 };
 
+// A bunch of statement blocks.  The draw_emoji block will be
+// (constrained) moved up, down, left and right to verify that it
+// visits the expected positions.
+const moveStatementTestBlocks = {
+  'blocks': {
+    'languageVersion': 0,
+    'blocks': [
+      {
+        'type': 'p5_setup',
+        'id': 'p5_setup',
+        'x': 0,
+        'y': 75,
+        'deletable': false,
+        'inputs': {
+          'STATEMENTS': {
+            'block': {
+              'type': 'p5_canvas',
+              'id': 'p5_canvas',
+              'deletable': false,
+              'movable': false,
+              'fields': {
+                'WIDTH': 400,
+                'HEIGHT': 400,
+              },
+              'next': {
+                'block': {
+                  'type': 'draw_emoji',
+                  'id': 'draw_emoji',
+                  'fields': {
+                    'emoji': '✨',
+                  },
+                },
+              },
+            },
+          },
+        },
+      },
+      {
+        'type': 'text_print',
+        'id': 'text_print',
+        'x': 0,
+        'y': 300,
+        'inputs': {
+          'TEXT': {
+            'shadow': {
+              'type': 'text',
+              'id': 'shadow_text',
+              'fields': {
+                'TEXT': 'abc',
+              },
+            },
+          },
+        },
+        'next': {
+          'block': {
+            'type': 'controls_if',
+            'id': 'controls_if',
+            'extraState': {
+              'elseIfCount': 1,
+              'hasElse': true,
+            },
+            'inputs': {
+              'DO0': {
+                'block': {
+                  'type': 'controls_repeat_ext',
+                  'id': 'controls_repeat_ext',
+                  'inputs': {
+                    'TIMES': {
+                      'shadow': {
+                        'type': 'math_number',
+                        'id': 'shadow_math_number',
+                        'fields': {
+                          'NUM': 10,
+                        },
+                      },
+                    },
+                  },
+                },
+              },
+            },
+          },
+        },
+      },
+      {
+        'type': 'p5_draw',
+        'id': 'p5_draw',
+        'x': 0,
+        'y': 753,
+        'deletable': false,
+      },
+    ],
+  },
+};
+
 const comments = {
   'workspaceComments': [
     {
@@ -996,12 +1090,17 @@ export const load = function (workspace, scenarioString) {
     comments,
     moreBlocks,
     moveStartTestBlocks,
+    moveStatementTestBlocks,
     navigationTestBlocks,
     simpleCircle,
     'sun': sunnyDay,
   };
   // Don't emit events during loading.
   Blockly.Events.disable();
-  Blockly.serialization.workspaces.load(scenarioMap[scenarioString], workspace, false);
+  Blockly.serialization.workspaces.load(
+    scenarioMap[scenarioString],
+    workspace,
+    false,
+  );
   Blockly.Events.enable();
 };

--- a/test/webdriverio/test/move_test.ts
+++ b/test/webdriverio/test/move_test.ts
@@ -235,7 +235,7 @@ suite('Statement move tests', function () {
     }),
   );
 
-  /** ID of a statement block with no inputs. */
+  /** ID of a statement block with multiple statement inputs. */
   const BLOCK_COMPLEX = 'complex_mover';
 
   /**

--- a/test/webdriverio/test/move_test.ts
+++ b/test/webdriverio/test/move_test.ts
@@ -158,6 +158,20 @@ suite('Move start tests', function () {
       await sendKeyAndWait(this.browser, Key.Escape);
     }
   });
+});
+
+suite('Statement move tests', function () {
+  // Increase timeout to 10s for this longer test (but disable
+  // timeouts if when non-zero PAUSE_TIME is used to watch tests) run.
+  this.timeout(PAUSE_TIME ? 0 : 10000);
+
+  // Clear the workspace and load start blocks.
+  setup(async function () {
+    this.browser = await testSetup(
+      testFileLocations.MOVE_STATEMENT_TEST_BLOCKS,
+    );
+    await this.browser.pause(PAUSE_TIME);
+  });
 
   // When a top-level block with no previous, next or output
   // connections is subject to a constrained move, it should not move.
@@ -168,7 +182,7 @@ suite('Move start tests', function () {
   // block unexpectedly moving (unless workspace scale was === 1).
   test('Constrained move of unattachable top-level block', async function () {
     // Block ID of an unconnectable block.
-    const BLOCK = 'p5_setup_1';
+    const BLOCK = 'p5_setup';
 
     // Scale workspace.
     await this.browser.execute(() => {

--- a/test/webdriverio/test/move_test.ts
+++ b/test/webdriverio/test/move_test.ts
@@ -235,6 +235,73 @@ suite('Statement move tests', function () {
     }),
   );
 
+  /** ID of a statement block with no inputs. */
+  const BLOCK_COMPLEX = 'complex_mover';
+
+  /**
+   * Expected connection candidates when moving BLOCK_COMPLEX, after
+   * pressing right or down arrow n times.
+   */
+  const EXPECTED_COMPLEX = [
+    // TODO(#702): Due to a bug in KeyboardDragStrategy, certain
+    // connection candidates that can be found using the mouse are not
+    // visited when doing a keyboard drag.  They appear in the list
+    // below, but commented out for now.
+    // is fixed.
+    {id: 'simple_mover', index: 1, ownIndex: 0}, // Next; starting location.
+    // {id: 'text_print', index: 0, ownIndex: 1}, // Previous to own next.
+    {id: 'text_print', index: 0, ownIndex: 4}, // Previous to own else input.
+    // {id: 'text_print', index: 0, ownIndex: 3}, // Previous to own if input.
+    {id: 'text_print', index: 1, ownIndex: 0}, // Next.
+    {id: 'controls_if', index: 3, ownIndex: 0}, // "If" statement input.
+    {id: 'controls_repeat_ext', index: 3, ownIndex: 0}, // Statement input.
+    {id: 'controls_repeat_ext', index: 1, ownIndex: 0}, // Next.
+    {id: 'controls_if', index: 5, ownIndex: 0}, // "Else if" statement input.
+    {id: 'controls_if', index: 6, ownIndex: 0}, // "Else" statement input.
+    {id: 'controls_if', index: 1, ownIndex: 0}, // Next.
+    {id: 'p5_draw', index: 0, ownIndex: 0}, // Statement input.
+    {id: 'p5_canvas', index: 1, ownIndex: 0}, // Next; starting location again.
+    {id: 'simple_mover', index: 1, ownIndex: 0}, // Next; starting location.
+  ];
+  const EXPECTED_COMPLEX_REVERSED = EXPECTED_COMPLEX.slice().reverse();
+
+  test(
+    'Constrained move of complex stack block right',
+    moveTest(BLOCK_COMPLEX, Key.ArrowRight, EXPECTED_COMPLEX,{
+      parentId: null,
+      parentIndex: null,
+      nextId: null, // TODO(#702): Should be 'text_print',
+      valueId: null,
+    }),
+  );
+  test(
+    'Constrained move of complex stack block left',
+    moveTest(BLOCK_COMPLEX, Key.ArrowLeft, EXPECTED_COMPLEX_REVERSED, {
+      parentId: 'p5_canvas',
+      parentIndex: 1,
+      nextId: 'simple_mover',
+      valueId: null,
+    }),
+  );
+  test(
+    'Constrained move of complex stack block down',
+    moveTest(BLOCK_COMPLEX, Key.ArrowDown, EXPECTED_COMPLEX, {
+      parentId: null,
+      parentIndex: null,
+      nextId: null, // TODO(#702): Should be 'text_print',
+      valueId: null,
+    }),
+  );
+  test(
+    'Constrained move of complex stack block up',
+    moveTest(BLOCK_COMPLEX, Key.ArrowUp, EXPECTED_COMPLEX_REVERSED, {
+      parentId: 'p5_canvas',
+      parentIndex: 1,
+      nextId: 'simple_mover',
+      valueId: null,
+    }),
+  );
+
   // When a top-level block with no previous, next or output
   // connections is subject to a constrained move, it should not move.
   //

--- a/test/webdriverio/test/move_test.ts
+++ b/test/webdriverio/test/move_test.ts
@@ -174,7 +174,7 @@ suite('Statement move tests', function () {
   });
 
   /** ID of a statement block with no inputs. */
-  const BLOCK_SIMPLE = 'draw_emoji';
+  const BLOCK_SIMPLE = 'simple_mover';
 
   /**
    * Expected connection candidates when moving BLOCK_SIMPLE, after
@@ -182,6 +182,9 @@ suite('Statement move tests', function () {
    */
   const EXPECTED_SIMPLE = [
     {id: 'p5_canvas', index: 1, ownIndex: 0}, // Next; starting location.
+    {id: 'complex_mover', index: 3, ownIndex: 0}, // "If" statement input.
+    {id: 'complex_mover', index: 4, ownIndex: 0}, // "Else" statement input.
+    {id: 'complex_mover', index: 1, ownIndex: 0}, // Next.
     {id: 'text_print', index: 0, ownIndex: 1}, // Previous.
     {id: 'text_print', index: 1, ownIndex: 0}, // Next.
     {id: 'controls_if', index: 3, ownIndex: 0}, // "If" statement input.
@@ -198,9 +201,9 @@ suite('Statement move tests', function () {
   test(
     'Constrained move of simple stack block right',
     moveTest(BLOCK_SIMPLE, Key.ArrowRight, EXPECTED_SIMPLE, {
-      parentId: null,
-      parentIndex: null,
-      nextId: 'text_print',
+      parentId: 'complex_mover',
+      parentIndex: 3,
+      nextId: null,
       valueId: null,
     }),
   );
@@ -216,9 +219,9 @@ suite('Statement move tests', function () {
   test(
     'Constrained move of simple stack block down',
     moveTest(BLOCK_SIMPLE, Key.ArrowDown, EXPECTED_SIMPLE, {
-      parentId: null,
-      parentIndex: null,
-      nextId: 'text_print',
+      parentId: 'complex_mover',
+      parentIndex: 3,
+      nextId: null,
       valueId: null,
     }),
   );

--- a/test/webdriverio/test/move_test.ts
+++ b/test/webdriverio/test/move_test.ts
@@ -213,6 +213,24 @@ suite('Statement move tests', function () {
       valueId: null,
     }),
   );
+  test(
+    'Constrained move of simple stack block down',
+    moveTest(BLOCK_SIMPLE, Key.ArrowDown, EXPECTED_SIMPLE, {
+      parentId: null,
+      parentIndex: null,
+      nextId: 'text_print',
+      valueId: null,
+    }),
+  );
+  test(
+    'Constrained move of simple stack block up',
+    moveTest(BLOCK_SIMPLE, Key.ArrowUp, EXPECTED_SIMPLE_REVERSED, {
+      parentId: 'p5_draw',
+      parentIndex: 0,
+      nextId: null,
+      valueId: null,
+    }),
+  );
 
   // When a top-level block with no previous, next or output
   // connections is subject to a constrained move, it should not move.

--- a/test/webdriverio/test/move_test.ts
+++ b/test/webdriverio/test/move_test.ts
@@ -17,14 +17,14 @@ import {
   contextMenuItems,
 } from './test_setup.js';
 
-suite('Move tests', function () {
+suite('Move start tests', function () {
   // Increase timeout to 10s for this longer test (but disable
   // timeouts if when non-zero PAUSE_TIME is used to watch tests) run.
   this.timeout(PAUSE_TIME ? 0 : 10000);
 
   // Clear the workspace and load start blocks.
   setup(async function () {
-    this.browser = await testSetup(testFileLocations.MOVE_TEST_BLOCKS);
+    this.browser = await testSetup(testFileLocations.MOVE_START_TEST_BLOCKS);
     await this.browser.pause(PAUSE_TIME);
   });
 

--- a/test/webdriverio/test/move_test.ts
+++ b/test/webdriverio/test/move_test.ts
@@ -330,11 +330,17 @@ function moveTest(
  * child blocks.
  *
  * @param browser The webdriverio browser session.
- * @returns A promise setting to {parentId, parentIndex, nextId,
- *   valueId}, being respectively the parent block ID, index of parent
- *   connection, next block ID, and ID of the block connected to the
- *   zeroth value value input, or null if the given item does not
- *   exist.
+ * @returns A promise setting to
+ *
+ *         {parentId, parentIndex, nextId, valueId}
+ *
+ *     where parentId, parentIndex are the ID of the parent block and
+ *     the index of the connection on that block to which the
+ *     currently-focused block is connected, nextId is the ID of block
+ *     connected to the focused block's next connection, and valueID
+ *     is the ID of a block connected to the zeroth input of the
+ *     focused block (or, in each case, null if there is no such
+ *     block).
  */
 function getFocusedNeighbourInfo(browser: Browser) {
   return browser.execute(() => {

--- a/test/webdriverio/test/test_setup.ts
+++ b/test/webdriverio/test/test_setup.ts
@@ -158,6 +158,10 @@ export const testFileLocations = {
   MOVE_START_TEST_BLOCKS: createTestUrl(
     new URLSearchParams({scenario: 'moveStartTestBlocks'}),
   ),
+  // eslint-disable-next-line @typescript-eslint/naming-convention
+  MOVE_STATEMENT_TEST_BLOCKS: createTestUrl(
+    new URLSearchParams({scenario: 'moveStatementTestBlocks'}),
+  ),
   COMMENTS: createTestUrl(new URLSearchParams({scenario: 'comments'})),
   // eslint-disable-next-line @typescript-eslint/naming-convention
   BASE_RTL: createTestUrl(new URLSearchParams({rtl: 'true'})),

--- a/test/webdriverio/test/test_setup.ts
+++ b/test/webdriverio/test/test_setup.ts
@@ -155,8 +155,8 @@ export const testFileLocations = {
   // eslint-disable-next-line @typescript-eslint/naming-convention
   MORE_BLOCKS: createTestUrl(new URLSearchParams({scenario: 'moreBlocks'})),
   // eslint-disable-next-line @typescript-eslint/naming-convention
-  MOVE_TEST_BLOCKS: createTestUrl(
-    new URLSearchParams({scenario: 'moveTestBlocks'}),
+  MOVE_START_TEST_BLOCKS: createTestUrl(
+    new URLSearchParams({scenario: 'moveStartTestBlocks'}),
   ),
   COMMENTS: createTestUrl(new URLSearchParams({scenario: 'comments'})),
   // eslint-disable-next-line @typescript-eslint/naming-convention


### PR DESCRIPTION
* Remove an unnecessary round trip through `JSON.stringify` + `JSON.parse` when loading tests blocks.
* Rename "move test blocks" to "move _start_ test blocks"
* Create "move statement test blocks" and a new test suite "Statement move tests", for testing movement of statement blocks.
  * Move the existing test for constrained movement following unconstrained movement to the new suite.
* Add tests for constrained movment of a simple stack block left/right/up/down.
* Add tests for constrained movment of a complex stack block (one with statement inputs) left/right/up/down.
  * Note that these tests verify the current behaviour which, due to bug #702, does not conform to the desired behaviour.  There are TODOs to update tests to desired behaviour when bug is fixed.

Part of #696.
