### PR TITLE
chore: add empty workspace test scenario

### DIFF
--- a/test/index.html
+++ b/test/index.html
@@ -118,6 +118,7 @@
                   move value test blocks
                 </option>
                 <option value="comments">comments</option>
+                <option value="emptyWorkspace">empty workspace</option>
               </select>
             </div>
             <div>

--- a/test/loadTestBlocks.js
+++ b/test/loadTestBlocks.js
@@ -1206,6 +1206,12 @@ const comments = {
   },
 };
 
+const emptyWorkspace = {
+  'blocks': {
+    'blocks': [],
+  },
+};
+
 /**
  * Loads saved state from local storage into the given workspace.
  * @param {Blockly.Workspace} workspace Blockly workspace to load into.
@@ -1222,6 +1228,7 @@ export const load = function (workspace, scenarioString) {
     navigationTestBlocks,
     simpleCircle,
     'sun': sunnyDay,
+    emptyWorkspace,
   };
   // Don't emit events during loading.
   Blockly.Events.disable();


### PR DESCRIPTION
Adds a new scenario that contains a completely empty workspace.

All of the other ones have undeletable blocks which makes it difficult to test things like #677 