### PR TITLE
fix: dont start a new move when pressing m repeatedly

### DIFF
--- a/src/actions/mover.ts
+++ b/src/actions/mover.ts
@@ -179,6 +179,7 @@ export class Mover {
             utils.KeyCodes.DOWN,
             utils.KeyCodes.ENTER,
             utils.KeyCodes.ESC,
+            utils.KeyCodes.M,
           ].includes(
             typeof keyCode === 'number'
               ? keyCode


### PR DESCRIPTION
Fixes #714 

Previous behavior:
1. Press M to start a move
2. Press M again and we'd commit the previous move and start a new one

New behavior:
1. Press M to start a move
2. Press M again and the shortcut precondition that checks if there's already a move in progress fails, so nothing happens