### PR TITLE
chore: fix a bug in flaky move test

### DIFF
--- a/src/move_indicator.ts
+++ b/src/move_indicator.ts
@@ -38,6 +38,7 @@ export class MoveIndicatorBubble
       {},
       workspace.getBubbleCanvas(),
     );
+    this.svgRoot.classList.add('blocklyMoveIndicatorBubble');
     const rtl = workspace.RTL;
     Blockly.utils.dom.createSvgElement(
       Blockly.utils.Svg.CIRCLE,

--- a/test/webdriverio/test/move_test.ts
+++ b/test/webdriverio/test/move_test.ts
@@ -98,8 +98,6 @@ suite('Move start tests', function () {
   // When a move of a value block begins, it is expected that block
   // and all blocks connected to its inputs will be moved - i.e., that
   // a stack heal (really: unary operator chain heal) will NOT occur.
-  //
-  // Also tests initiating a move via the context menu.
   test('Start moving value blocks', async function () {
     for (let i = 1; i < 7; i++) {
       // Navigate to statement_<i>.
@@ -122,20 +120,8 @@ suite('Move start tests', function () {
         'selected block should have child value block',
       );
 
-      // Start move using context menu (using keyboard nav).
-      await sendKeyAndWait(this.browser, [Key.Ctrl, Key.Return]);
-
-      // Find how many times to press the down arrow
-      const index = (await contextMenuItems(this.browser)).findIndex(({text}) =>
-        text.includes('Move'),
-      );
-      chai.assert.isAbove(
-        index,
-        -1,
-        'expected Move to appear in context menu items',
-      );
-      await keyDown(this.browser, index);
-      await sendKeyAndWait(this.browser, Key.Return);
+      // Start move
+      await sendKeyAndWait(this.browser, 'm');
 
       // Check that the moving block has nothing connected it its
       // next/previous connections, and same thing connected to value

--- a/test/webdriverio/test/move_test.ts
+++ b/test/webdriverio/test/move_test.ts
@@ -98,6 +98,8 @@ suite('Move start tests', function () {
   // When a move of a value block begins, it is expected that block
   // and all blocks connected to its inputs will be moved - i.e., that
   // a stack heal (really: unary operator chain heal) will NOT occur.
+  //
+  // Also tests initiating a move via the context menu.
   test('Start moving value blocks', async function () {
     for (let i = 1; i < 7; i++) {
       // Navigate to statement_<i>.
@@ -120,8 +122,20 @@ suite('Move start tests', function () {
         'selected block should have child value block',
       );
 
-      // Start move
-      await sendKeyAndWait(this.browser, 'm');
+      // Start move using context menu (using keyboard nav).
+      await sendKeyAndWait(this.browser, [Key.Ctrl, Key.Return]);
+
+      // Find how many times to press the down arrow
+      const index = (await contextMenuItems(this.browser)).findIndex(({text}) =>
+        text.includes('Move'),
+      );
+      chai.assert.isAbove(
+        index,
+        -1,
+        'expected Move to appear in context menu items',
+      );
+      await keyDown(this.browser, index);
+      await sendKeyAndWait(this.browser, Key.Return);
 
       // Check that the moving block has nothing connected it its
       // next/previous connections, and same thing connected to value

--- a/test/webdriverio/test/move_test.ts
+++ b/test/webdriverio/test/move_test.ts
@@ -15,7 +15,6 @@ import {
   testSetup,
   sendKeyAndWait,
   keyDown,
-  contextMenuItems,
 } from './test_setup.js';
 
 suite('Move start tests', function () {

--- a/test/webdriverio/test/move_test.ts
+++ b/test/webdriverio/test/move_test.ts
@@ -138,8 +138,7 @@ suite('Move start tests', function () {
       await sendKeyAndWait(this.browser, Key.Return);
 
       // Wait for the move icon to appear so we know we're in move mode.
-      const bubble = this.browser.$('.blocklyMoveIndicatorBubble');
-      await bubble.waitForExist();
+      await this.browser.$('.blocklyMoveIndicatorBubble').waitForExist();
 
       // Check that the moving block has nothing connected it its
       // next/previous connections, and same thing connected to value

--- a/test/webdriverio/test/move_test.ts
+++ b/test/webdriverio/test/move_test.ts
@@ -15,6 +15,7 @@ import {
   testSetup,
   sendKeyAndWait,
   keyDown,
+  contextMenuItems,
 } from './test_setup.js';
 
 suite('Move start tests', function () {

--- a/test/webdriverio/test/move_test.ts
+++ b/test/webdriverio/test/move_test.ts
@@ -45,12 +45,15 @@ suite('Move start tests', function () {
       // and block connected to selected block's next connection.
       const info = await getFocusedNeighbourInfo(this.browser);
 
-      chai.assert(info.parentId, 'selected block has no parent block');
+      chai.assert.exists(
+        info.parentId,
+        'selected block should have parent block',
+      );
       chai.assert(
         typeof info.parentIndex === 'number',
-        'parent connection index not found',
+        'parent connection index should exist and be a number',
       );
-      chai.assert(info.nextId, 'selected block has no next block');
+      chai.assert.exists(info.nextId, 'selected block should have next block');
 
       // Start move using keyboard shortcut.
       await sendKeyAndWait(this.browser, 'm');
@@ -59,12 +62,12 @@ suite('Move start tests', function () {
       // next/previous connections, and same thing connected to value
       // input.
       const newInfo = await getFocusedNeighbourInfo(this.browser);
-      chai.assert(
-        newInfo.parentId === null,
+      chai.assert.isNull(
+        newInfo.parentId,
         'moving block should have no parent block',
       );
-      chai.assert(
-        newInfo.nextId === null,
+      chai.assert.isNull(
+        newInfo.nextId,
         'moving block should have no next block',
       );
       chai.assert.strictEqual(
@@ -106,16 +109,21 @@ suite('Move start tests', function () {
       // and block connected to selected block's value input.
       const info = await getFocusedNeighbourInfo(this.browser);
 
-      chai.assert(info.parentId, 'selected block has no parent block');
+      chai.assert.exists(
+        info.parentId,
+        'selected block should have parent block',
+      );
       chai.assert(
         typeof info.parentIndex === 'number',
-        'parent connection index not found',
+        'parent connection index should exist and be a number',
       );
-      chai.assert(info.valueId, 'selected block has no child value block');
+      chai.assert.exists(
+        info.valueId,
+        'selected block should have child value block',
+      );
 
       // Start move using context menu (using keyboard nav).
       await sendKeyAndWait(this.browser, [Key.Ctrl, Key.Return]);
-      await sendKeyAndWait(this.browser, 'm');
       await keyDown(
         this.browser,
         (await contextMenuItems(this.browser)).findIndex(({text}) =>
@@ -128,12 +136,12 @@ suite('Move start tests', function () {
       // next/previous connections, and same thing connected to value
       // input.
       const newInfo = await getFocusedNeighbourInfo(this.browser);
-      chai.assert(
-        newInfo.parentId === null,
+      chai.assert.isNull(
+        newInfo.parentId,
         'moving block should have no parent block',
       );
-      chai.assert(
-        newInfo.nextId === null,
+      chai.assert.isNull(
+        newInfo.nextId,
         'moving block should have no next block',
       );
       chai.assert.strictEqual(

--- a/test/webdriverio/test/move_test.ts
+++ b/test/webdriverio/test/move_test.ts
@@ -137,6 +137,10 @@ suite('Move start tests', function () {
       await keyDown(this.browser, index);
       await sendKeyAndWait(this.browser, Key.Return);
 
+      // Wait for the move icon to appear so we know we're in move mode.
+      const bubble = this.browser.$('.blocklyMoveIndicatorBubble');
+      await bubble.waitForExist();
+
       // Check that the moving block has nothing connected it its
       // next/previous connections, and same thing connected to value
       // input.

--- a/test/webdriverio/test/move_test.ts
+++ b/test/webdriverio/test/move_test.ts
@@ -124,12 +124,17 @@ suite('Move start tests', function () {
 
       // Start move using context menu (using keyboard nav).
       await sendKeyAndWait(this.browser, [Key.Ctrl, Key.Return]);
-      await keyDown(
-        this.browser,
-        (await contextMenuItems(this.browser)).findIndex(({text}) =>
-          text.includes('Move'),
-        ),
+
+      // Find how many times to press the down arrow
+      const index = (await contextMenuItems(this.browser)).findIndex(({text}) =>
+        text.includes('Move'),
       );
+      chai.assert.isAbove(
+        index,
+        -1,
+        'expected Move to appear in context menu items',
+      );
+      await keyDown(this.browser, index);
       await sendKeyAndWait(this.browser, Key.Return);
 
       // Check that the moving block has nothing connected it its


### PR DESCRIPTION
Fixes #719 hopefully?

There was a bug in this test, it both opened the context menu and pressed 'm' to start move mode. But that wasn't enough to fix the flaky test.

I changed some of the assertions to be more specific. using `chai.assert.isNull` gives a better error message than `chai.assert` as chai knows more about what you're intending to check. the old error didn't tell you what the value was, which could help with debugging. the new message will say something like "expected null, got 123". That did give better error messages but still didn't fix anything (it wasn't supposed to)

Next I tried adding an assertion to make sure the problem wasn't with the context menu showing up. I added a check to make sure that the "Move" option was found, and that assertion never failed. Yet, the test flaked on.

I tried adding some pause time and still flaky, so removed it again.

I tried triggering the move with the 'm' key instead of the context menu and it was still flaky, so I reverted those commits.

Finally I added a "wait for exist" on the move icon, so that the test doesn't continue until move mode is actually activated. This required adding a class to the actual source code. All other changes are to the test code only.

At this point I don't know if it will solve the flaky test but even if it doesn't I think it's worth merging at this point as it does improve the tests.