### PR TITLE
chore: remove unused ts expect error

### DIFF
--- a/test/webdriverio/test/move_test.ts
+++ b/test/webdriverio/test/move_test.ts
@@ -692,7 +692,6 @@ function getConnectionCandidate(
     const dragStrategy =
       block.getDragStrategy() as Blockly.dragging.BlockDragStrategy;
     if (!dragStrategy) throw new Error('no drag strategy');
-    // @ts-expect-error connectionCandidate is private.
     const candidate = dragStrategy.connectionCandidate;
     if (!candidate) return null;
     const neighbourBlock = candidate.neighbour.getSourceBlock();


### PR DESCRIPTION
Note: this is against the `add-screen-reader-support-experimental` branch.

Removes a ts-expect-error declaration because in the corresponding branch of blockly, that property is public. The unnecessary expect causes tests to fail to compile.