### PR TITLE
fix: Improve node ID check robustness & WebdriverIO test CI stability

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -21,7 +21,11 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        os: [ubuntu-latest, macos-latest]
+        include:
+          - os: ubuntu-latest
+            BLOCKLY_WDIO_PAUSE_TIME_MS: donotoverride
+          - os: macos-latest
+            BLOCKLY_WDIO_PAUSE_TIME_MS: 100
 
     steps:
       - name: Checkout experimentation plugin
@@ -64,6 +68,8 @@ jobs:
         run: |
           cd main
           npm run test:ci
+        env:
+          BLOCKLY_WDIO_PAUSE_TIME_MS: ${{ matrix.BLOCKLY_WDIO_PAUSE_TIME_MS }}
 
   webdriverio_tests:
     name: WebdriverIO tests (against pinned v12)

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -63,7 +63,7 @@ jobs:
       - name: Run tests
         run: |
           cd main
-          npm run test
+          npm run test:ci
 
   webdriverio_tests:
     name: WebdriverIO tests (against pinned v12)
@@ -90,4 +90,4 @@ jobs:
         run: npm install
 
       - name: Run tests
-        run: npm run test
+        run: npm run test:ci

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -21,11 +21,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        include:
-          - os: ubuntu-latest
-            BLOCKLY_WDIO_PAUSE_TIME_MS: donotoverride
-          - os: macos-latest
-            BLOCKLY_WDIO_PAUSE_TIME_MS: 100
+        os: [ubuntu-latest, macos-latest]
 
     steps:
       - name: Checkout experimentation plugin
@@ -68,8 +64,6 @@ jobs:
         run: |
           cd main
           npm run test:ci
-        env:
-          BLOCKLY_WDIO_PAUSE_TIME_MS: ${{ matrix.BLOCKLY_WDIO_PAUSE_TIME_MS }}
 
   webdriverio_tests:
     name: WebdriverIO tests (against pinned v12)

--- a/package.json
+++ b/package.json
@@ -23,7 +23,7 @@
     "wdio:build:app": "cd test/webdriverio && webpack",
     "wdio:build:tests": "tsc -p ./test/webdriverio/test/tsconfig.json",
     "wdio:clean": "cd test/webdriverio/test && rm -rf dist",
-    "wdio:run": "npm run wdio:build && cd test/webdriverio/test && npx mocha dist"
+    "wdio:run": "npm run wdio:build && cd test/webdriverio/test && npx mocha dist",
     "wdio:run:ci": "npm run wdio:build && cd test/webdriverio/test && npx mocha --timeout 30000 dist"
   },
   "main": "./dist/index.js",

--- a/package.json
+++ b/package.json
@@ -15,13 +15,16 @@
     "prepublishOnly": "npm login --registry https://wombat-dressing-room.appspot.com",
     "start": "blockly-scripts start",
     "test": "npm run test:mocha && npm run test:wdio",
+    "test:ci": "npm run test:mocha && npm run test:wdio:ci",
     "test:mocha": "blockly-scripts test",
     "test:wdio": "npm run wdio:clean && npm run wdio:run",
+    "test:wdio:ci": "npm run wdio:clean && npm run wdio:run:ci",
     "wdio:build": "npm run wdio:build:app && npm run wdio:build:tests",
     "wdio:build:app": "cd test/webdriverio && webpack",
     "wdio:build:tests": "tsc -p ./test/webdriverio/test/tsconfig.json",
     "wdio:clean": "cd test/webdriverio/test && rm -rf dist",
     "wdio:run": "npm run wdio:build && cd test/webdriverio/test && npx mocha dist"
+    "wdio:run:ci": "npm run wdio:build && cd test/webdriverio/test && npx mocha --timeout 30000 dist"
   },
   "main": "./dist/index.js",
   "module": "./src/index.js",

--- a/test/webdriverio/test/actions_test.ts
+++ b/test/webdriverio/test/actions_test.ts
@@ -92,12 +92,10 @@ suite('Menus test', function () {
 
   // Clear the workspace and load start blocks.
   setup(async function () {
-    // This is the first test suite, which must wait for Chrome +
-    // chromedriver to start up, which can be slow—perhaps a few
-    // seconds.  Allow 30s just in case.
-    this.timeout(30000);
-
-    this.browser = await testSetup(testFileLocations.MORE_BLOCKS);
+    this.browser = await testSetup(
+      testFileLocations.MORE_BLOCKS,
+      this.timeout(),
+    );
     await this.browser.pause(PAUSE_TIME);
   });
 

--- a/test/webdriverio/test/basic_test.ts
+++ b/test/webdriverio/test/basic_test.ts
@@ -31,7 +31,10 @@ suite('Keyboard navigation on Blocks', function () {
 
   // Clear the workspace and load start blocks.
   suiteSetup(async function () {
-    this.browser = await testSetup(testFileLocations.NAVIGATION_TEST_BLOCKS);
+    this.browser = await testSetup(
+      testFileLocations.NAVIGATION_TEST_BLOCKS,
+      this.timeout(),
+    );
   });
 
   test('Default workspace', async function () {
@@ -226,7 +229,10 @@ suite('Keyboard navigation on Fields', function () {
 
   // Clear the workspace and load start blocks.
   suiteSetup(async function () {
-    this.browser = await testSetup(testFileLocations.NAVIGATION_TEST_BLOCKS);
+    this.browser = await testSetup(
+      testFileLocations.NAVIGATION_TEST_BLOCKS,
+      this.timeout(),
+    );
   });
 
   test('Up from first field selects block', async function () {

--- a/test/webdriverio/test/block_comment_test.ts
+++ b/test/webdriverio/test/block_comment_test.ts
@@ -23,7 +23,10 @@ suite('Block comment navigation', function () {
 
   // Clear the workspace and load start blocks.
   setup(async function () {
-    this.browser = await testSetup(testFileLocations.NAVIGATION_TEST_BLOCKS);
+    this.browser = await testSetup(
+      testFileLocations.NAVIGATION_TEST_BLOCKS,
+      this.timeout(),
+    );
     await this.browser.execute(() => {
       Blockly.getMainWorkspace()
         .getBlockById('p5_canvas_1')

--- a/test/webdriverio/test/block_comment_test.ts
+++ b/test/webdriverio/test/block_comment_test.ts
@@ -37,7 +37,7 @@ suite('Block comment navigation', function () {
     await sendKeyAndWait(this.browser, Key.Enter);
     const focusedNodeId = await getCurrentFocusNodeId(this.browser);
     chai.assert.isDefined(focusedNodeId);
-    chai.assert.match(focusedNodeId, /blockly\-\w+_comment_textarea_/);
+    chai.assert.match(focusedNodeId, /blockly-\w+_comment_textarea_/);
   });
 
   test('Escape from a focused comment focuses its bubble', async function () {

--- a/test/webdriverio/test/block_comment_test.ts
+++ b/test/webdriverio/test/block_comment_test.ts
@@ -36,7 +36,8 @@ suite('Block comment navigation', function () {
     await keyRight(this.browser);
     await sendKeyAndWait(this.browser, Key.Enter);
     const focusedNodeId = await getCurrentFocusNodeId(this.browser);
-    chai.assert.equal(focusedNodeId, 'blockly-2s_comment_textarea_');
+    chai.assert.isDefined(focusedNodeId);
+    chai.assert.match(focusedNodeId, /blockly\-\w+_comment_textarea_/);
   });
 
   test('Escape from a focused comment focuses its bubble', async function () {

--- a/test/webdriverio/test/clipboard_test.ts
+++ b/test/webdriverio/test/clipboard_test.ts
@@ -27,7 +27,7 @@ suite('Clipboard test', function () {
 
   // Clear the workspace and load start blocks.
   setup(async function () {
-    this.browser = await testSetup(testFileLocations.BASE);
+    this.browser = await testSetup(testFileLocations.BASE, this.timeout());
     await this.browser.pause(PAUSE_TIME);
   });
 

--- a/test/webdriverio/test/delete_test.ts
+++ b/test/webdriverio/test/delete_test.ts
@@ -27,7 +27,10 @@ suite('Deleting Blocks', function () {
 
   // Clear the workspace and load start blocks.
   setup(async function () {
-    this.browser = await testSetup(testFileLocations.NAVIGATION_TEST_BLOCKS);
+    this.browser = await testSetup(
+      testFileLocations.NAVIGATION_TEST_BLOCKS,
+      this.timeout(),
+    );
     await this.browser.pause(PAUSE_TIME);
   });
 

--- a/test/webdriverio/test/duplicate_test.ts
+++ b/test/webdriverio/test/duplicate_test.ts
@@ -23,7 +23,7 @@ suite('Duplicate test', function () {
 
   // Clear the workspace and load start blocks.
   setup(async function () {
-    this.browser = await testSetup(testFileLocations.BASE);
+    this.browser = await testSetup(testFileLocations.BASE, this.timeout());
     await this.browser.pause(PAUSE_TIME);
   });
 

--- a/test/webdriverio/test/flyout_test.ts
+++ b/test/webdriverio/test/flyout_test.ts
@@ -28,7 +28,7 @@ suite('Toolbox and flyout test', function () {
 
   // Clear the workspace and load start blocks.
   setup(async function () {
-    this.browser = await testSetup(testFileLocations.BASE);
+    this.browser = await testSetup(testFileLocations.BASE, this.timeout());
     await this.browser.pause(PAUSE_TIME);
   });
 

--- a/test/webdriverio/test/hooks.ts
+++ b/test/webdriverio/test/hooks.ts
@@ -16,7 +16,7 @@ export const mochaHooks: RootHookObject = {
   async beforeAll(this: Mocha.Context) {
     // Set a long timeout for startup.
     this.timeout(60000);
-    return await driverSetup();
+    return await driverSetup(this.timeout());
   },
   async afterAll() {
     return await driverTeardown();

--- a/test/webdriverio/test/insert_test.ts
+++ b/test/webdriverio/test/insert_test.ts
@@ -28,7 +28,7 @@ suite('Insert test', function () {
 
   // Clear the workspace and load start blocks.
   setup(async function () {
-    this.browser = await testSetup(testFileLocations.BASE);
+    this.browser = await testSetup(testFileLocations.BASE, this.timeout());
     await this.browser.pause(PAUSE_TIME);
   });
 

--- a/test/webdriverio/test/keyboard_mode_test.ts
+++ b/test/webdriverio/test/keyboard_mode_test.ts
@@ -32,7 +32,10 @@ suite(
 
     setup(async function () {
       // Reload the page between tests
-      this.browser = await testSetup(testFileLocations.NAVIGATION_TEST_BLOCKS);
+      this.browser = await testSetup(
+        testFileLocations.NAVIGATION_TEST_BLOCKS,
+        this.timeout(),
+      );
 
       await this.browser.pause(PAUSE_TIME);
 

--- a/test/webdriverio/test/move_test.ts
+++ b/test/webdriverio/test/move_test.ts
@@ -25,7 +25,10 @@ suite('Move start tests', function () {
 
   // Clear the workspace and load start blocks.
   setup(async function () {
-    this.browser = await testSetup(testFileLocations.MOVE_START_TEST_BLOCKS);
+    this.browser = await testSetup(
+      testFileLocations.MOVE_START_TEST_BLOCKS,
+      this.timeout(),
+    );
     await this.browser.pause(PAUSE_TIME);
   });
 
@@ -186,6 +189,7 @@ suite('Statement move tests', function () {
   setup(async function () {
     this.browser = await testSetup(
       testFileLocations.MOVE_STATEMENT_TEST_BLOCKS,
+      this.timeout(),
     );
     await this.browser.pause(PAUSE_TIME);
   });
@@ -468,6 +472,7 @@ suite(`Value expression move tests`, function () {
           createTestUrl(
             new URLSearchParams({renderer, scenario: 'moveValueTestBlocks'}),
           ),
+          this.timeout(),
         );
         await this.browser.pause(PAUSE_TIME);
       });

--- a/test/webdriverio/test/mutator_test.ts
+++ b/test/webdriverio/test/mutator_test.ts
@@ -26,7 +26,10 @@ suite('Mutator navigation', function () {
 
   // Clear the workspace and load start blocks.
   setup(async function () {
-    this.browser = await testSetup(testFileLocations.NAVIGATION_TEST_BLOCKS);
+    this.browser = await testSetup(
+      testFileLocations.NAVIGATION_TEST_BLOCKS,
+      this.timeout(),
+    );
     this.openMutator = async () => {
       await focusOnBlock(this.browser, 'controls_if_1');
       await this.browser.pause(PAUSE_TIME);

--- a/test/webdriverio/test/scroll_test.ts
+++ b/test/webdriverio/test/scroll_test.ts
@@ -25,7 +25,7 @@ suite('Scrolling into view', function () {
   //
   // N.B. that this is called only one per suite, not once per test.
   suiteSetup(async function () {
-    this.browser = await testSetup(testFileLocations.BASE);
+    this.browser = await testSetup(testFileLocations.BASE, this.timeout());
     this.windowSize = await this.browser.getWindowSize();
     await this.browser.setWindowSize(800, 600);
     await this.browser.pause(PAUSE_TIME);
@@ -41,7 +41,7 @@ suite('Scrolling into view', function () {
 
   // Clear the workspace and load start blocks.
   setup(async function () {
-    await testSetup(testFileLocations.BASE);
+    await testSetup(testFileLocations.BASE, this.timeout());
   });
 
   test('Insert scrolls new block into view', async function () {

--- a/test/webdriverio/test/stack_navigation.ts
+++ b/test/webdriverio/test/stack_navigation.ts
@@ -18,7 +18,7 @@ import {
 suite('Stack navigation', function () {
   // Clear the workspace and load start blocks.
   setup(async function () {
-    this.browser = await testSetup(testFileLocations.COMMENTS);
+    this.browser = await testSetup(testFileLocations.COMMENTS, this.timeout());
     await this.browser.pause(PAUSE_TIME);
   });
 

--- a/test/webdriverio/test/styling_test.ts
+++ b/test/webdriverio/test/styling_test.ts
@@ -23,7 +23,7 @@ suite('Styling test', function () {
 
   // Clear the workspace and load start blocks.
   setup(async function () {
-    this.browser = await testSetup(testFileLocations.BASE);
+    this.browser = await testSetup(testFileLocations.BASE, this.timeout());
     await this.browser.pause(PAUSE_TIME);
   });
 

--- a/test/webdriverio/test/test_setup.ts
+++ b/test/webdriverio/test/test_setup.ts
@@ -42,7 +42,7 @@ let driver: webdriverio.Browser | null = null;
  * the browser.wait* functions if you need your test to wait for
  * something to happen after sending input.
  */
-export const PAUSE_TIME = 0;
+export const PAUSE_TIME = fetchEnvironmentPauseTime() ?? 0;
 
 /**
  * Start up WebdriverIO and load the test page. This should only be
@@ -91,6 +91,20 @@ export async function driverSetup(
   console.log('Starting webdriverio...');
   driver = await webdriverio.remote(options);
   return driver;
+}
+
+/**
+ * Fetches the environmentally configured pause time for tests.
+ *
+ * @return The paues time, in milliseconds, for tests or null if one isn't
+ *     correctly configured.
+ */
+function fetchEnvironmentPauseTime(): number | null {
+  const envPauseTimeMsStr = process.env.BLOCKLY_WDIO_PAUSE_TIME_MS;
+  if (!envPauseTimeMsStr) return null;
+  const envPauseTimeMs = parseInt(envPauseTimeMsStr);
+  if (isNaN(envPauseTimeMs)) return null;
+  return envPauseTimeMs;
 }
 
 /**

--- a/test/webdriverio/test/test_setup.ts
+++ b/test/webdriverio/test/test_setup.ts
@@ -42,7 +42,7 @@ let driver: webdriverio.Browser | null = null;
  * the browser.wait* functions if you need your test to wait for
  * something to happen after sending input.
  */
-export const PAUSE_TIME = fetchEnvironmentPauseTime() ?? 0;
+export const PAUSE_TIME = 0;
 
 /**
  * Start up WebdriverIO and load the test page. This should only be
@@ -91,20 +91,6 @@ export async function driverSetup(
   console.log('Starting webdriverio...');
   driver = await webdriverio.remote(options);
   return driver;
-}
-
-/**
- * Fetches the environmentally configured pause time for tests.
- *
- * @return The paues time, in milliseconds, for tests or null if one isn't
- *     correctly configured.
- */
-function fetchEnvironmentPauseTime(): number | null {
-  const envPauseTimeMsStr = process.env.BLOCKLY_WDIO_PAUSE_TIME_MS;
-  if (!envPauseTimeMsStr) return null;
-  const envPauseTimeMs = parseInt(envPauseTimeMsStr);
-  if (isNaN(envPauseTimeMs)) return null;
-  return envPauseTimeMs;
 }
 
 /**

--- a/test/webdriverio/test/toast_test.ts
+++ b/test/webdriverio/test/toast_test.ts
@@ -14,7 +14,7 @@ suite('HTML toasts', function () {
 
   // Clear the workspace and load start blocks.
   setup(async function () {
-    this.browser = await testSetup(testFileLocations.BASE);
+    this.browser = await testSetup(testFileLocations.BASE, this.timeout());
     await this.browser.pause(PAUSE_TIME);
   });
 

--- a/test/webdriverio/test/workspace_comment_test.ts
+++ b/test/webdriverio/test/workspace_comment_test.ts
@@ -29,7 +29,10 @@ suite('Workspace comment navigation', function () {
 
   // Clear the workspace and load start blocks.
   setup(async function () {
-    this.browser = await testSetup(testFileLocations.NAVIGATION_TEST_BLOCKS);
+    this.browser = await testSetup(
+      testFileLocations.NAVIGATION_TEST_BLOCKS,
+      this.timeout(),
+    );
     [this.commentId1, this.commentId2] = await this.browser.execute(() => {
       const workspace = Blockly.getMainWorkspace();
       const comment1 = Blockly.serialization.workspaceComments.append(


### PR DESCRIPTION
https://github.com/google/blockly/pull/9384 revealed that one of the Block comment tests was a bit fragile in directly validating a specific node ID. Since node IDs can change if new elements on the page require a generated ID, the test could easily fail with changes to core Blockly.

This PR fixes the issue by using a regex check instead of a direct ID match. The 'comment_textarea' part is _probably_ sufficiently unique for the test to be considered correct (though it is possible for the wrong comment to be focused here, but it seems really unlikely with how simple the test is being set up and, if that actually happened, it's sort of incidentally still correct as there would be _some_ comment that has focus).

This PR also includes a number of attempts to improve test stability (particularly in CI):
- It introduces a CI-specific command that adds a 30 second Mocha test timeout to provide a lot more time for tests to fail (since CI tends to run on less performant machines than used for development).
- It introduces a synchronization between the Mocha timeout and the timeout used for WebdriverIO's `waitFor*` functions. Note that this actually will usually be 60 seconds regardless of the configured Mocha timeout due to the way the hook is set up. However, this is still far better than the 5 second default as at least 1 test seemed to fairly regularly fail against that limit.
- It adds a few missing 'wait' calls for helpers that are performing side effects which ensures better synchronization when using `PAUSE_TIME` (and possibly better stability when running in CI, too, though it's unclear of `pause()` actually does anything when the provided timeout is 0).
- See https://github.com/google/blockly-keyboard-experimentation/pull/745#issuecomment-3336166191 attempts to further stabilize OS X tests only to yield that there are actual test failures.

This will be merged into the screen reader experimental branch to unblock the core Blockly PR as well.

#746 has been filed to track the discovered test failures.