### PR TITLE
fix: Fix the scenario picker with the advanced playground.

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -10,6 +10,7 @@
       "license": "Apache-2.0",
       "devDependencies": {
         "@blockly/dev-scripts": "^4.0.8",
+        "@blockly/dev-tools": "^9.0.2",
         "@blockly/field-colour": "^6.0.2",
         "@eslint/eslintrc": "^2.1.2",
         "@eslint/js": "^8.49.0",
@@ -321,6 +322,19 @@
       },
       "engines": {
         "node": ">=6.9.0"
+      }
+    },
+    "node_modules/@blockly/block-test": {
+      "version": "7.0.2",
+      "resolved": "https://registry.npmjs.org/@blockly/block-test/-/block-test-7.0.2.tgz",
+      "integrity": "sha512-fwbJnMiH4EoX/CR0ZTGzSKaGfpRBn4nudquoWfvG4ekkhTjaNTldDdHvUSeyexzvwZZcT6M4I1Jtq3IoomTKEg==",
+      "dev": true,
+      "license": "Apache 2.0",
+      "engines": {
+        "node": ">=8.17.0"
+      },
+      "peerDependencies": {
+        "blockly": "^12.0.0"
       }
     },
     "node_modules/@blockly/dev-scripts": {
@@ -761,6 +775,117 @@
         "node": ">=10"
       }
     },
+    "node_modules/@blockly/dev-tools": {
+      "version": "9.0.2",
+      "resolved": "https://registry.npmjs.org/@blockly/dev-tools/-/dev-tools-9.0.2.tgz",
+      "integrity": "sha512-Ic/+BkqEvLRZxzNQVW/FKXx1cB042xXXPTSmNlTv2qr4oY+hN2fwBtHj3PirBWAzWgMOF8VDTj/EXL36jH1/lg==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@blockly/block-test": "^7.0.2",
+        "@blockly/theme-dark": "^8.0.1",
+        "@blockly/theme-deuteranopia": "^7.0.1",
+        "@blockly/theme-highcontrast": "^7.0.1",
+        "@blockly/theme-tritanopia": "^7.0.1",
+        "chai": "^4.2.0",
+        "dat.gui": "^0.7.7",
+        "lodash.assign": "^4.2.0",
+        "lodash.merge": "^4.6.2",
+        "monaco-editor": "^0.20.0",
+        "sinon": "^9.0.2"
+      },
+      "engines": {
+        "node": ">=8.0.0"
+      },
+      "peerDependencies": {
+        "blockly": "^12.0.0"
+      }
+    },
+    "node_modules/@blockly/dev-tools/node_modules/assertion-error": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/assertion-error/-/assertion-error-1.1.0.tgz",
+      "integrity": "sha512-jgsaNduz+ndvGyFt3uSuWqvy4lCnIJiovtouQN5JZHOKCS2QuhEdbcQHFhVksz2N2U9hXJo8odG7ETyWlEeuDw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": "*"
+      }
+    },
+    "node_modules/@blockly/dev-tools/node_modules/chai": {
+      "version": "4.5.0",
+      "resolved": "https://registry.npmjs.org/chai/-/chai-4.5.0.tgz",
+      "integrity": "sha512-RITGBfijLkBddZvnn8jdqoTypxvqbOLYQkGGxXzeFjVHvudaPw0HNFD9x928/eUwYWd2dPCugVqspGALTZZQKw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "assertion-error": "^1.1.0",
+        "check-error": "^1.0.3",
+        "deep-eql": "^4.1.3",
+        "get-func-name": "^2.0.2",
+        "loupe": "^2.3.6",
+        "pathval": "^1.1.1",
+        "type-detect": "^4.1.0"
+      },
+      "engines": {
+        "node": ">=4"
+      }
+    },
+    "node_modules/@blockly/dev-tools/node_modules/check-error": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/check-error/-/check-error-1.0.3.tgz",
+      "integrity": "sha512-iKEoDYaRmd1mxM90a2OEfWhjsjPpYPuQ+lMYsoxB126+t8fw7ySEO48nmDg5COTjxDI65/Y2OWpeEHk3ZOe8zg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "get-func-name": "^2.0.2"
+      },
+      "engines": {
+        "node": "*"
+      }
+    },
+    "node_modules/@blockly/dev-tools/node_modules/deep-eql": {
+      "version": "4.1.4",
+      "resolved": "https://registry.npmjs.org/deep-eql/-/deep-eql-4.1.4.tgz",
+      "integrity": "sha512-SUwdGfqdKOwxCPeVYjwSyRpJ7Z+fhpwIAtmCUdZIWZ/YP5R9WAsyuSgpLVDi9bjWoN2LXHNss/dk3urXtdQxGg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "type-detect": "^4.0.0"
+      },
+      "engines": {
+        "node": ">=6"
+      }
+    },
+    "node_modules/@blockly/dev-tools/node_modules/loupe": {
+      "version": "2.3.7",
+      "resolved": "https://registry.npmjs.org/loupe/-/loupe-2.3.7.tgz",
+      "integrity": "sha512-zSMINGVYkdpYSOBmLi0D1Uo7JU9nVdQKrHxC8eYlV+9YKK9WePqAlL7lSlorG/U2Fw1w0hTBmaa/jrQ3UbPHtA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "get-func-name": "^2.0.1"
+      }
+    },
+    "node_modules/@blockly/dev-tools/node_modules/pathval": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/pathval/-/pathval-1.1.1.tgz",
+      "integrity": "sha512-Dp6zGqpTdETdR63lehJYPeIOqpiNBNtc7BpWSLrOje7UaIsE5aY92r/AunQA7rsXvet3lrJ3JnZX29UPTKXyKQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": "*"
+      }
+    },
+    "node_modules/@blockly/dev-tools/node_modules/type-detect": {
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/type-detect/-/type-detect-4.1.0.tgz",
+      "integrity": "sha512-Acylog8/luQ8L7il+geoSxhEkazvkslg7PSNKOX59mbB9cOveP5aq9h74Y7YU8yDpJwetzQQrfIwtf4Wp4LKcw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=4"
+      }
+    },
     "node_modules/@blockly/eslint-config": {
       "version": "4.0.1",
       "resolved": "https://registry.npmjs.org/@blockly/eslint-config/-/eslint-config-4.0.1.tgz",
@@ -997,6 +1122,58 @@
       "resolved": "https://registry.npmjs.org/@blockly/field-grid-dropdown/-/field-grid-dropdown-6.0.1.tgz",
       "integrity": "sha512-Y3H5Z4A4cwhbIqP2pWJNTIGoCiKtYUdveZk8U83wGk9goQL2cUgQ4jfpEaxjfZVG+VG4mBwVV4nZHFDc6cJJJQ==",
       "dev": true,
+      "engines": {
+        "node": ">=8.17.0"
+      },
+      "peerDependencies": {
+        "blockly": "^12.0.0"
+      }
+    },
+    "node_modules/@blockly/theme-dark": {
+      "version": "8.0.1",
+      "resolved": "https://registry.npmjs.org/@blockly/theme-dark/-/theme-dark-8.0.1.tgz",
+      "integrity": "sha512-0Di3WIUwCVQw7jK9myUf/J+4oHLADWc8YxeF40KQgGsyulVrVnYipwtBolj+wxq2xjxIkqgvctAN3BdvM4mynA==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "engines": {
+        "node": ">=8.17.0"
+      },
+      "peerDependencies": {
+        "blockly": "^12.0.0"
+      }
+    },
+    "node_modules/@blockly/theme-deuteranopia": {
+      "version": "7.0.1",
+      "resolved": "https://registry.npmjs.org/@blockly/theme-deuteranopia/-/theme-deuteranopia-7.0.1.tgz",
+      "integrity": "sha512-V05Hk2hzQZict47LfzDdSTP+J5HlYiF7de/8LR/bsRQB/ft7UUTraqDLIivYc9gL2alsVtKzq/yFs9wi7FMAqQ==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "engines": {
+        "node": ">=8.17.0"
+      },
+      "peerDependencies": {
+        "blockly": "^12.0.0"
+      }
+    },
+    "node_modules/@blockly/theme-highcontrast": {
+      "version": "7.0.1",
+      "resolved": "https://registry.npmjs.org/@blockly/theme-highcontrast/-/theme-highcontrast-7.0.1.tgz",
+      "integrity": "sha512-dMhysbXf8QtHxuhI1EY5GdZErlfEhjpCogwfzglDKSu8MF2C+5qzOQBxKmqfnEYJl6G9B2HNGw+mEaUo8oel6Q==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "engines": {
+        "node": ">=8.17.0"
+      },
+      "peerDependencies": {
+        "blockly": "^12.0.0"
+      }
+    },
+    "node_modules/@blockly/theme-tritanopia": {
+      "version": "7.0.1",
+      "resolved": "https://registry.npmjs.org/@blockly/theme-tritanopia/-/theme-tritanopia-7.0.1.tgz",
+      "integrity": "sha512-eLqPCmW6xvSYvyTFFE5uz0Bw806LxOmaQrCOzbUywkT41s2ITP06OP1BVQrHdkZSt5whipZYpB1RMGxYxS/Bpw==",
+      "dev": true,
+      "license": "Apache-2.0",
       "engines": {
         "node": ">=8.17.0"
       },
@@ -1529,6 +1706,45 @@
       "engines": {
         "node": ">=18"
       }
+    },
+    "node_modules/@sinonjs/commons": {
+      "version": "1.8.6",
+      "resolved": "https://registry.npmjs.org/@sinonjs/commons/-/commons-1.8.6.tgz",
+      "integrity": "sha512-Ky+XkAkqPZSm3NLBeUng77EBQl3cmeJhITaGHdYH8kjVB+aun3S4XBRti2zt17mtt0mIUDiNxYeoJm6drVvBJQ==",
+      "dev": true,
+      "license": "BSD-3-Clause",
+      "dependencies": {
+        "type-detect": "4.0.8"
+      }
+    },
+    "node_modules/@sinonjs/fake-timers": {
+      "version": "6.0.1",
+      "resolved": "https://registry.npmjs.org/@sinonjs/fake-timers/-/fake-timers-6.0.1.tgz",
+      "integrity": "sha512-MZPUxrmFubI36XS1DI3qmI0YdN1gks62JtFZvxR67ljjSNCeK6U08Zx4msEWOXuofgqUt6zPHSi1H9fbjR/NRA==",
+      "dev": true,
+      "license": "BSD-3-Clause",
+      "dependencies": {
+        "@sinonjs/commons": "^1.7.0"
+      }
+    },
+    "node_modules/@sinonjs/samsam": {
+      "version": "5.3.1",
+      "resolved": "https://registry.npmjs.org/@sinonjs/samsam/-/samsam-5.3.1.tgz",
+      "integrity": "sha512-1Hc0b1TtyfBu8ixF/tpfSHTVWKwCBLY4QJbkgnE7HcwyvT2xArDxb4K7dMgqRm3szI+LJbzmW/s4xxEhv6hwDg==",
+      "dev": true,
+      "license": "BSD-3-Clause",
+      "dependencies": {
+        "@sinonjs/commons": "^1.6.0",
+        "lodash.get": "^4.4.2",
+        "type-detect": "^4.0.8"
+      }
+    },
+    "node_modules/@sinonjs/text-encoding": {
+      "version": "0.7.3",
+      "resolved": "https://registry.npmjs.org/@sinonjs/text-encoding/-/text-encoding-0.7.3.tgz",
+      "integrity": "sha512-DE427ROAphMQzU4ENbliGYrBSYPXF+TtLg9S8vzeA+OF4ZKzoDdzfL8sxuMUGS/lgRhM6j1URSk9ghf7Xo1tyA==",
+      "dev": true,
+      "license": "(Unlicense OR Apache-2.0)"
     },
     "node_modules/@tootallnate/quickjs-emscripten": {
       "version": "0.23.0",
@@ -3996,6 +4212,13 @@
         "node": ">=18"
       }
     },
+    "node_modules/dat.gui": {
+      "version": "0.7.9",
+      "resolved": "https://registry.npmjs.org/dat.gui/-/dat.gui-0.7.9.tgz",
+      "integrity": "sha512-sCNc1OHobc+Erc1HqiswYgHdVNpSJUlk/Hz8vzOCsER7rl+oF/4+v8GXFUyCgtXpoCX6+bnmg07DedLvBLwYKQ==",
+      "dev": true,
+      "license": "Apache-2.0"
+    },
     "node_modules/data-uri-to-buffer": {
       "version": "4.0.1",
       "resolved": "https://registry.npmjs.org/data-uri-to-buffer/-/data-uri-to-buffer-4.0.1.tgz",
@@ -5659,6 +5882,16 @@
         "node": "6.* || 8.* || >= 10.*"
       }
     },
+    "node_modules/get-func-name": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/get-func-name/-/get-func-name-2.0.2.tgz",
+      "integrity": "sha512-8vXOvuE167CtIc3OyItco7N/dpRtBbYOsPsXCz7X/PMnlGjYjSGuZJgM1Y7mmew7BKf9BqvLX2tnOVy1BBUsxQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": "*"
+      }
+    },
     "node_modules/get-intrinsic": {
       "version": "1.3.0",
       "resolved": "https://registry.npmjs.org/get-intrinsic/-/get-intrinsic-1.3.0.tgz",
@@ -6813,6 +7046,13 @@
         "safe-buffer": "~5.1.0"
       }
     },
+    "node_modules/just-extend": {
+      "version": "4.2.1",
+      "resolved": "https://registry.npmjs.org/just-extend/-/just-extend-4.2.1.tgz",
+      "integrity": "sha512-g3UB796vUFIY90VIv/WX3L2c8CS2MdWUww3CNrYmqza1Fg0DURc2K/O4YrnklBdQarSJ/y8JnJYDGc+1iumQjg==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/keyv": {
       "version": "4.5.4",
       "resolved": "https://registry.npmjs.org/keyv/-/keyv-4.5.4.tgz",
@@ -6997,11 +7237,26 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/lodash.assign": {
+      "version": "4.2.0",
+      "resolved": "https://registry.npmjs.org/lodash.assign/-/lodash.assign-4.2.0.tgz",
+      "integrity": "sha512-hFuH8TY+Yji7Eja3mGiuAxBqLagejScbG8GbG0j6o9vzn0YL14My+ktnqtZgFTosKymC9/44wP6s7xyuLfnClw==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/lodash.clonedeep": {
       "version": "4.5.0",
       "resolved": "https://registry.npmjs.org/lodash.clonedeep/-/lodash.clonedeep-4.5.0.tgz",
       "integrity": "sha512-H5ZhCF25riFd9uB5UCkVKo61m3S/xZk1x4wA6yp/L3RFP6Z/eHH1ymQcGLo7J3GMPfm0V/7m1tryHuGVxpqEBQ==",
       "dev": true
+    },
+    "node_modules/lodash.get": {
+      "version": "4.4.2",
+      "resolved": "https://registry.npmjs.org/lodash.get/-/lodash.get-4.4.2.tgz",
+      "integrity": "sha512-z+Uw/vLuy6gQe8cfaFWD7p0wVv8fJl3mbzXh33RS+0oW2wvUqiRXiQ69gLWSLpgB5/6sU+r6BlQR0MBILadqTQ==",
+      "deprecated": "This package is deprecated. Use the optional chaining (?.) operator instead.",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/lodash.merge": {
       "version": "4.6.2",
@@ -7353,6 +7608,13 @@
         "url": "https://github.com/chalk/supports-color?sponsor=1"
       }
     },
+    "node_modules/monaco-editor": {
+      "version": "0.20.0",
+      "resolved": "https://registry.npmjs.org/monaco-editor/-/monaco-editor-0.20.0.tgz",
+      "integrity": "sha512-hkvf4EtPJRMQlPC3UbMoRs0vTAFAYdzFQ+gpMb8A+9znae1c43q8Mab9iVsgTcg/4PNiLGGn3SlDIa8uvK1FIQ==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/ms": {
       "version": "2.1.3",
       "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.3.tgz",
@@ -7412,6 +7674,37 @@
       "dev": true,
       "engines": {
         "node": ">= 0.4.0"
+      }
+    },
+    "node_modules/nise": {
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/nise/-/nise-4.1.0.tgz",
+      "integrity": "sha512-eQMEmGN/8arp0xsvGoQ+B1qvSkR73B1nWSCh7nOt5neMCtwcQVYQGdzQMhcNscktTsWB54xnlSQFzOAPJD8nXA==",
+      "dev": true,
+      "license": "BSD-3-Clause",
+      "dependencies": {
+        "@sinonjs/commons": "^1.7.0",
+        "@sinonjs/fake-timers": "^6.0.0",
+        "@sinonjs/text-encoding": "^0.7.1",
+        "just-extend": "^4.0.2",
+        "path-to-regexp": "^1.7.0"
+      }
+    },
+    "node_modules/nise/node_modules/isarray": {
+      "version": "0.0.1",
+      "resolved": "https://registry.npmjs.org/isarray/-/isarray-0.0.1.tgz",
+      "integrity": "sha512-D2S+3GLxWH+uhrNEcoh/fnmYeP8E8/zHl644d/jdA0g2uyXvy3sb0qxotE+ne0LtccHknQzWwZEzhak7oJ0COQ==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/nise/node_modules/path-to-regexp": {
+      "version": "1.9.0",
+      "resolved": "https://registry.npmjs.org/path-to-regexp/-/path-to-regexp-1.9.0.tgz",
+      "integrity": "sha512-xIp7/apCFJuUHdDLWe8O1HIkb0kQrOMb/0u6FXQjemHn/ii5LrIzU6bdECnsiTF/GjZkMEKg1xdiZwNqDYlZ6g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "isarray": "0.0.1"
       }
     },
     "node_modules/no-case": {
@@ -9018,6 +9311,36 @@
         "url": "https://github.com/sponsors/ljharb"
       }
     },
+    "node_modules/sinon": {
+      "version": "9.2.4",
+      "resolved": "https://registry.npmjs.org/sinon/-/sinon-9.2.4.tgz",
+      "integrity": "sha512-zljcULZQsJxVra28qIAL6ow1Z9tpattkCTEJR4RBP3TGc00FcttsP5pK284Nas5WjMZU5Yzy3kAIp3B3KRf5Yg==",
+      "deprecated": "16.1.1",
+      "dev": true,
+      "license": "BSD-3-Clause",
+      "dependencies": {
+        "@sinonjs/commons": "^1.8.1",
+        "@sinonjs/fake-timers": "^6.0.1",
+        "@sinonjs/samsam": "^5.3.1",
+        "diff": "^4.0.2",
+        "nise": "^4.0.4",
+        "supports-color": "^7.1.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/sinon"
+      }
+    },
+    "node_modules/sinon/node_modules/diff": {
+      "version": "4.0.2",
+      "resolved": "https://registry.npmjs.org/diff/-/diff-4.0.2.tgz",
+      "integrity": "sha512-58lmxKSA4BNyLz+HHMUzlOEpg09FV+ev6ZMe3vJihgdxzgcwZ8VoEEPmALCZG9LmqfVoNMMKpttIYTVG6uDY7A==",
+      "dev": true,
+      "license": "BSD-3-Clause",
+      "engines": {
+        "node": ">=0.3.1"
+      }
+    },
     "node_modules/slash": {
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/slash/-/slash-3.0.0.tgz",
@@ -9812,6 +10135,16 @@
       },
       "engines": {
         "node": ">= 0.8.0"
+      }
+    },
+    "node_modules/type-detect": {
+      "version": "4.0.8",
+      "resolved": "https://registry.npmjs.org/type-detect/-/type-detect-4.0.8.tgz",
+      "integrity": "sha512-0fr/mIH1dlO+x7TlcMy+bIDqKPsw/70tVyeHW787goQjhmqaZe10uwLujubK9q9Lg6Fiho1KUKDYz0Z7k7g5/g==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=4"
       }
     },
     "node_modules/type-fest": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -10,7 +10,7 @@
       "license": "Apache-2.0",
       "devDependencies": {
         "@blockly/dev-scripts": "^4.0.8",
-        "@blockly/dev-tools": "^9.0.2",
+        "@blockly/dev-tools": "^9.0.3",
         "@blockly/field-colour": "^6.0.2",
         "@eslint/eslintrc": "^2.1.2",
         "@eslint/js": "^8.49.0",
@@ -776,9 +776,9 @@
       }
     },
     "node_modules/@blockly/dev-tools": {
-      "version": "9.0.2",
-      "resolved": "https://registry.npmjs.org/@blockly/dev-tools/-/dev-tools-9.0.2.tgz",
-      "integrity": "sha512-Ic/+BkqEvLRZxzNQVW/FKXx1cB042xXXPTSmNlTv2qr4oY+hN2fwBtHj3PirBWAzWgMOF8VDTj/EXL36jH1/lg==",
+      "version": "9.0.3",
+      "resolved": "https://registry.npmjs.org/@blockly/dev-tools/-/dev-tools-9.0.3.tgz",
+      "integrity": "sha512-iJ0QZtupYqQ1VTqUDvy8yB4vZJto6cNaV73K7ExnkFm2WYA5NEmq+1Stbvts8j66EX1Qj4EyTucf4tPIqBHXYw==",
       "dev": true,
       "license": "Apache-2.0",
       "dependencies": {

--- a/package.json
+++ b/package.json
@@ -54,6 +54,7 @@
   ],
   "devDependencies": {
     "@blockly/dev-scripts": "^4.0.8",
+    "@blockly/dev-tools": "^9.0.2",
     "@blockly/field-colour": "^6.0.2",
     "@eslint/eslintrc": "^2.1.2",
     "@eslint/js": "^8.49.0",

--- a/package.json
+++ b/package.json
@@ -54,7 +54,7 @@
   ],
   "devDependencies": {
     "@blockly/dev-scripts": "^4.0.8",
-    "@blockly/dev-tools": "^9.0.2",
+    "@blockly/dev-tools": "^9.0.3",
     "@blockly/field-colour": "^6.0.2",
     "@eslint/eslintrc": "^2.1.2",
     "@eslint/js": "^8.49.0",

--- a/test/index.html
+++ b/test/index.html
@@ -101,6 +101,7 @@
                 name="scenario"
                 id="scenario"
                 onchange="document.forms.options.submit()">
+                <option value="custom">custom</option>
                 <option value="simpleCircle">simple circle</option>
                 <option value="sun">sun</option>
                 <option value="blank">blank canvas</option>
@@ -119,27 +120,6 @@
                 </option>
                 <option value="comments">comments</option>
                 <option value="emptyWorkspace">empty workspace</option>
-              </select>
-            </div>
-            <div>
-              <label for="toolbox">Toolbox:</label>
-              <select
-                name="toolbox"
-                id="toolbox"
-                onchange="document.forms.options.submit()">
-                <option value="toolbox">toolbox</option>
-                <option value="flyout">flyout</option>
-              </select>
-            </div>
-            <div>
-              <label for="renderer">Renderer:</label>
-              <select
-                name="renderer"
-                id="renderer"
-                onchange="document.forms.options.submit()">
-                <option value="geras">Geras</option>
-                <option value="thrasos">Thrasos</option>
-                <option value="zelos">Zelos</option>
               </select>
             </div>
           </form>

--- a/test/index.ts
+++ b/test/index.ts
@@ -24,54 +24,35 @@ import {javascriptGenerator} from 'blockly/javascript';
 // @ts-expect-error No types in js file
 import {load} from './loadTestBlocks';
 import {runCode, registerRunCodeShortcut} from './runCode';
+import {createPlayground} from '@blockly/dev-tools';
 
 (window as unknown as {Blockly: typeof Blockly}).Blockly = Blockly;
 
 /**
- * Parse query params for inject and navigation options and update
- * the fields on the options form to match.
- *
- * @returns An options object with keys for each supported option.
+ * Parse query params for a predefined block scenario and applies it to the
+ * workspace.
  */
-function getOptions() {
+function applyScenario() {
   const params = new URLSearchParams(window.location.search);
 
   const scenarioParam = params.get('scenario');
-  const scenario = scenarioParam ?? 'simpleCircle';
-
-  const rendererParam = params.get('renderer');
-  let renderer = 'zelos';
-  // For backwards compatibility with previous behaviour, support
-  // (e.g.) ?geras as well as ?renderer=geras:
-  if (rendererParam) {
-    renderer = rendererParam;
-  } else if (params.get('geras')) {
-    renderer = 'geras';
-  } else if (params.get('thrasos')) {
-    renderer = 'thrasos';
-  }
-
-  const toolboxParam = params.get('toolbox');
-  const toolbox = toolboxParam ?? 'toolbox';
-  const toolboxObject =
-    toolbox === 'flyout' ? toolboxFlyout : toolboxCategories;
+  const scenario = scenarioParam ?? 'custom';
 
   // Update form inputs to match params, but only after the page is
   // fully loaded as Chrome (at least) tries to restore previous form
   // values and does so _after_ DOMContentLoaded has fired, which can
   // result in the form inputs being out-of-sync with the actual
-  // options when doing browswer page navigation.
+  // options when doing browser page navigation.
   window.addEventListener('load', () => {
-    (document.getElementById('toolbox') as HTMLSelectElement).value = toolbox;
-    (document.getElementById('renderer') as HTMLSelectElement).value = renderer;
     (document.getElementById('scenario') as HTMLSelectElement).value = scenario;
   });
 
-  return {
-    scenario,
-    renderer,
-    toolbox: toolboxObject,
-  };
+  if (scenario !== 'custom') {
+    load(Blockly.getMainWorkspace(), scenario);
+    const url = new URL(window.location.href);
+    url.searchParams.delete('scenario');
+    window.history.replaceState({}, document.title, url.toString());
+  }
 }
 
 /**
@@ -80,13 +61,8 @@ function getOptions() {
  *
  * @returns The created workspace.
  */
-function createWorkspace(): Blockly.WorkspaceSvg {
-  const {scenario, renderer, toolbox} = getOptions();
-
-  const injectOptions = {
-    toolbox,
-    renderer,
-  };
+async function createWorkspace(): Promise<Blockly.WorkspaceSvg> {
+  const injectOptions = {toolbox: toolboxCategories};
   const blocklyDiv = document.getElementById('blocklyDiv');
   if (!blocklyDiv) {
     throw new Error('Missing blocklyDiv');
@@ -96,16 +72,30 @@ function createWorkspace(): Blockly.WorkspaceSvg {
   KeyboardNavigation.registerKeyboardNavigationStyles();
   registerFlyoutCursor();
   registerNavigationDeferringToolbox();
-  const workspace = Blockly.inject(blocklyDiv, injectOptions);
-
-  Blockly.ContextMenuItems.registerCommentOptions();
-  new KeyboardNavigation(workspace);
   registerRunCodeShortcut();
+  Blockly.ContextMenuItems.registerCommentOptions();
 
-  // Disable blocks that aren't inside the setup or draw loops.
-  workspace.addChangeListener(Blockly.Events.disableOrphans);
+  let navigation: KeyboardNavigation | null = null;
+  const workspace = (
+    await createPlayground(
+      blocklyDiv,
+      (blocklyDiv, options) => {
+        if (navigation) {
+          navigation.dispose();
+        }
+        const ws = Blockly.inject(blocklyDiv, options);
+        navigation = new KeyboardNavigation(ws);
 
-  load(workspace, scenario);
+        // Disable blocks that aren't inside the setup or draw loops.
+        ws.addChangeListener(Blockly.Events.disableOrphans);
+
+        return ws;
+      },
+      injectOptions,
+    )
+  ).getWorkspace();
+
+  applyScenario();
   runCode();
 
   return workspace;
@@ -124,9 +114,9 @@ function addP5() {
   javascriptGenerator.addReservedWords('sketch');
 }
 
-document.addEventListener('DOMContentLoaded', () => {
+document.addEventListener('DOMContentLoaded', async () => {
   addP5();
-  createWorkspace();
+  await createWorkspace();
   document.getElementById('run')?.addEventListener('click', runCode);
   // Add Blockly to the global scope so that test code can access it to
   // verify state after keypresses.

--- a/test/index.ts
+++ b/test/index.ts
@@ -16,8 +16,6 @@ import {forBlock} from './blocks/p5_generators';
 // @ts-expect-error No types in js file
 import {blocks} from './blocks/p5_blocks';
 // @ts-expect-error No types in js file
-import {toolbox as toolboxFlyout} from './blocks/toolbox.js';
-// @ts-expect-error No types in js file
 import toolboxCategories from './toolboxCategories.js';
 
 import {javascriptGenerator} from 'blockly/javascript';


### PR DESCRIPTION
This PR rolls forward the change that enabled the advanced playground on the demo page, and fixes the scenario picker. Now, when a scenario is chosen, the contents of the workspace are replaced with the blocks from that scenario. Reloading the page persists the workspace's configuration. The renderer and toolbox options have been removed from below the scenario picker in favor of configuring those options in the advanced playground.