### PR TITLE
fix: allow menu shortcut to override existing one

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -19,7 +19,7 @@
         "@types/p5": "^1.7.6",
         "@typescript-eslint/eslint-plugin": "^6.7.2",
         "@typescript-eslint/parser": "^6.7.2",
-        "blockly": "12.3.1",
+        "blockly": "^12.5.1",
         "chai": "^5.2.0",
         "eslint": "^8.49.0",
         "eslint-config-google": "^0.14.0",
@@ -3285,9 +3285,9 @@
       }
     },
     "node_modules/blockly": {
-      "version": "12.3.1",
-      "resolved": "https://registry.npmjs.org/blockly/-/blockly-12.3.1.tgz",
-      "integrity": "sha512-BbWUcpqroY241XgSxTuAiEMHeIZ6u3+oD2zOATf3Fi+0NMWJ/MdMtuSkOcDCSk6Nc7WR3z5n9GHKqz2L+3kQOQ==",
+      "version": "12.5.1",
+      "resolved": "https://registry.npmjs.org/blockly/-/blockly-12.5.1.tgz",
+      "integrity": "sha512-etXLpUtEkcRibHGwIJ4BsvnIzMJJs0C0yPIjE/W0NCtj8ACha/a7Q9n7Ib6+j7N4EzQ0p28YPZMnypi5pNIj1g==",
       "dev": true,
       "license": "Apache-2.0",
       "peer": true,

--- a/package.json
+++ b/package.json
@@ -63,7 +63,7 @@
     "@types/p5": "^1.7.6",
     "@typescript-eslint/eslint-plugin": "^6.7.2",
     "@typescript-eslint/parser": "^6.7.2",
-    "blockly": "12.3.1",
+    "blockly": "^12.5.1",
     "chai": "^5.2.0",
     "eslint": "^8.49.0",
     "eslint-config-google": "^0.14.0",

--- a/src/actions/action_menu.ts
+++ b/src/actions/action_menu.ts
@@ -65,8 +65,9 @@ export class ActionMenu {
         createSerializedKey(KeyCodes.ENTER, [KeyCodes.ALT]),
         createSerializedKey(KeyCodes.ENTER, [KeyCodes.META]),
       ],
+      allowCollision: true,
     };
-    ShortcutRegistry.registry.register(menuShortcut);
+    ShortcutRegistry.registry.register(menuShortcut, true);
   }
 
   /**


### PR DESCRIPTION
Fixes raspberrypifoundation/blockly#9652

Allows the menu shortcut in the plugin to override any in core if present, making the plugin compatible with v12.5+ of blockly

Since the menu shortcut here will return true if the menu is actually opened, this will tell the shortcut system that it has been "handled" and thus the one in core will not fire

Updates the dev version of Blockly to 12.5.1 to test compatibility with latest