### PR TITLE
chore: update codeowners to use RPF group

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,1 +1,1 @@
-* @google/blockly-eng
+* @RaspberryPiFoundation/blockly-collaborators


### PR DESCRIPTION
Reason for change: hygiene.
